### PR TITLE
Fix `NoneType` error in `get_accounts` for manual loan accounts

### DIFF
--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -160,13 +160,20 @@ def get_accounts() -> str:
         # Format accounts for display
         account_list = []
         for account in accounts.get("accounts", []):
+            type_info = account.get("type", {})
+            type_name = type_info.get("name") if isinstance(type_info, dict) else None
+
+            institution_info = account.get("institution", {})
+            institution_name = institution_info.get("name") if isinstance(institution_info, dict) else None
+
             account_info = {
                 "id": account.get("id"),
                 "name": account.get("displayName", account.get("name")),
-                "type": account.get("type", {}).get("name"),
+                "type": type_name,
                 "balance": account.get("currentBalance"),
-                "institution": account.get("institution", {}).get("name"),
-                "is_active": account.get("isActive", True)
+                "institution": institution_name,
+                "is_active": not account.get("deactivatedAt"),
+                "is_hidden": account.get("isHidden", False)
             }
             account_list.append(account_info)
         


### PR DESCRIPTION
## Problem

The `get_accounts` function throws an `AttributeError` when processing accounts that have `null` or missing `type` or `institution` fields, which in my experience, was the case for my manual loan accounts. (see #8).

```
Error getting accounts: 'NoneType' object has no attribute 'get'
```

This occurs at lines 166-169 in `server.py` where the code assumes these fields always return dictionaries.

## Root Cause

The code directly calls `.get("name")` on the result of `account.get("type")` and `account.get("institution")` without checking if these fields are `None`:

```python
"type": account.get("type", {}).get("name"),  # Fails if type is None
"institution": account.get("institution", {}).get("name"),  # Fails if institution is None
```

## Solution

This PR adds defensive checks to safely handle null fields:

1. Check if `type` and `institution` are dictionaries before accessing nested properties
2. Return `None` for the name fields when parent objects are missing
3. Use `deactivatedAt` field to properly determine account active status
4. Add `is_hidden` field for better account visibility control

## Testing

Tested with a Monarch Money account containing 32 accounts, successfully retrieving all accounts without errors.

## Changes

- Add safe type checking for nested field access
- Handle null/missing type and institution fields gracefully
- Fix account active status detection
- Add is_hidden field to account info

This ensures the MCP server is more robust when handling accounts from various financial institutions that may not populate all fields.

Fixes #8