### PR TITLE
Add transaction split support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Once authenticated, use these tools directly in Claude Desktop:
 - **Delete Transaction**: Remove a transaction
 - **Get Recurring Transactions**: View upcoming recurring transactions
 
+### 🤖 Transaction Rules (Auto-Categorization)
+- **Get Transaction Rules**: List all auto-categorization rules
+- **Create Transaction Rule**: Create rules with merchant/amount conditions to auto-categorize
+- **Update Transaction Rule**: Modify existing rules
+- **Delete Transaction Rule**: Remove a rule
+
 ### 📈 Financial Analysis
 - **Get Budgets**: Access budget information including spent amounts and remaining balances
 - **Get Cashflow**: Analyze financial cashflow over specified date ranges with income/expense breakdowns
@@ -156,6 +162,10 @@ Once authenticated, use these tools directly in Claude Desktop:
 | `get_transaction_details` | Get details of a transaction | `transaction_id` |
 | `delete_transaction` | Delete a transaction | `transaction_id` |
 | `get_recurring_transactions` | Get recurring transactions | None |
+| `get_transaction_rules` | List auto-categorization rules | None |
+| `create_transaction_rule` | Create an auto-categorization rule | `merchant_criteria_operator`, `merchant_criteria_value`, `set_category_id`, `add_tag_ids`, `amount_operator`, `amount_value` |
+| `update_transaction_rule` | Update an existing rule | `rule_id`, `merchant_criteria_operator`, `merchant_criteria_value`, `set_category_id` |
+| `delete_transaction_rule` | Delete a rule | `rule_id` |
 
 ## 📝 Usage Examples
 
@@ -207,6 +217,11 @@ Find all Amazon transactions over $50 from the last month using search_transacti
 ### View Recurring Bills
 ```
 Show me my upcoming recurring transactions using get_recurring_transactions
+```
+
+### Create Auto-Categorization Rule
+```
+Create a rule to automatically categorize Amazon transactions as "Shopping" using create_transaction_rule
 ```
 
 ## 📅 Date Formats

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Once authenticated, use these tools directly in Claude Desktop:
 - **Update Transaction Notes**: Add or update notes on transactions (great for receipt links)
 - **Mark Transaction Reviewed**: Clear the needs_review flag on transactions
 
+### 📦 Bulk Operations
+- **Bulk Categorize Transactions**: Apply a category to multiple transactions at once
+
 ### 📈 Financial Analysis
 - **Get Budgets**: Access budget information including spent amounts and remaining balances
 - **Get Cashflow**: Analyze financial cashflow over specified date ranges with income/expense breakdowns
@@ -134,6 +137,7 @@ Once authenticated, use these tools directly in Claude Desktop:
 | `set_transaction_category` | Set category on a transaction | `transaction_id`, `category_id`, `mark_reviewed` |
 | `update_transaction_notes` | Update notes on a transaction | `transaction_id`, `notes` |
 | `mark_transaction_reviewed` | Mark transaction as reviewed | `transaction_id` |
+| `bulk_categorize_transactions` | Categorize multiple transactions | `transaction_ids`, `category_id` |
 
 ## 📝 Usage Examples
 
@@ -165,6 +169,11 @@ Show me all available categories using get_categories
 ### Review Uncategorized Transactions
 ```
 Show me transactions from the last 7 days that need review using get_transactions_needing_review
+```
+
+### Bulk Categorize Transactions
+```
+Categorize these three transactions as "Groceries" using bulk_categorize_transactions
 ```
 
 ## 📅 Date Formats

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ Once authenticated, use these tools directly in Claude Desktop:
 - **Update Transaction Rule**: Modify existing rules
 - **Delete Transaction Rule**: Remove a rule
 
+### ✂️ Transaction Splits
+- **Get Transaction Splits**: View how a transaction has been split into parts
+- **Split Transaction**: Divide a single transaction into multiple parts with different categories or merchants
+
 ### 📈 Financial Analysis
 - **Get Budgets**: Access budget information including spent amounts and remaining balances
 - **Get Cashflow**: Analyze financial cashflow over specified date ranges with income/expense breakdowns
@@ -179,6 +183,8 @@ Once authenticated, use these tools directly in Claude Desktop:
 | `create_transaction_rule` | Create an auto-categorization rule | `merchant_criteria_operator`, `merchant_criteria_value`, `set_category_id`, `add_tag_ids`, `amount_operator`, `amount_value` |
 | `update_transaction_rule` | Update an existing rule | `rule_id`, `merchant_criteria_operator`, `merchant_criteria_value`, `set_category_id` |
 | `delete_transaction_rule` | Delete a rule | `rule_id` |
+| `get_transaction_splits` | Get splits for a transaction | `transaction_id` |
+| `split_transaction` | Split a transaction into parts | `transaction_id`, `splits` (JSON array) |
 
 ## 📝 Usage Examples
 
@@ -235,6 +241,11 @@ Show me my upcoming recurring transactions using get_recurring_transactions
 ### Create Auto-Categorization Rule
 ```
 Create a rule to automatically categorize Amazon transactions as "Shopping" using create_transaction_rule
+```
+
+### Split a Transaction
+```
+Split this $100 Costco transaction into $60 for Groceries and $40 for Household using split_transaction
 ```
 
 ## 📅 Date Formats

--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ Once authenticated, use these tools directly in Claude Desktop:
 - **Get Categories**: List all transaction categories with groups, icons, and metadata
 - **Get Category Groups**: View category groups with their associated categories
 
+### 📋 Transaction Review
+- **Get Transactions Needing Review**: Find transactions that need attention (uncategorized, no notes, flagged)
+- **Set Transaction Category**: Assign a category to a transaction
+- **Update Transaction Notes**: Add or update notes on transactions (great for receipt links)
+- **Mark Transaction Reviewed**: Clear the needs_review flag on transactions
+
 ### 📈 Financial Analysis
 - **Get Budgets**: Access budget information including spent amounts and remaining balances
 - **Get Cashflow**: Analyze financial cashflow over specified date ranges with income/expense breakdowns
@@ -124,6 +130,10 @@ Once authenticated, use these tools directly in Claude Desktop:
 | `refresh_accounts` | Request account data refresh | None |
 | `get_categories` | List all transaction categories | None |
 | `get_category_groups` | List category groups with categories | None |
+| `get_transactions_needing_review` | Get transactions needing review | `needs_review`, `days`, `uncategorized`, `no_notes` |
+| `set_transaction_category` | Set category on a transaction | `transaction_id`, `category_id`, `mark_reviewed` |
+| `update_transaction_notes` | Update notes on a transaction | `transaction_id`, `notes` |
+| `mark_transaction_reviewed` | Mark transaction as reviewed | `transaction_id` |
 
 ## 📝 Usage Examples
 
@@ -150,6 +160,11 @@ Get my cashflow for the last 3 months using get_cashflow
 ### List Available Categories
 ```
 Show me all available categories using get_categories
+```
+
+### Review Uncategorized Transactions
+```
+Show me transactions from the last 7 days that need review using get_transactions_needing_review
 ```
 
 ## 📅 Date Formats

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ Once authenticated, use these tools directly in Claude Desktop:
 - **Create Transaction**: Add new transactions to accounts
 - **Update Transaction**: Modify existing transactions (amount, description, category, date)
 
+### 🏷️ Category Management
+- **Get Categories**: List all transaction categories with groups, icons, and metadata
+- **Get Category Groups**: View category groups with their associated categories
+
 ### 📈 Financial Analysis
 - **Get Budgets**: Access budget information including spent amounts and remaining balances
 - **Get Cashflow**: Analyze financial cashflow over specified date ranges with income/expense breakdowns
@@ -118,6 +122,8 @@ Once authenticated, use these tools directly in Claude Desktop:
 | `create_transaction` | Create new transaction | `account_id`, `amount`, `description`, `date`, `category_id`, `merchant_name` |
 | `update_transaction` | Update existing transaction | `transaction_id`, `amount`, `description`, `category_id`, `date` |
 | `refresh_accounts` | Request account data refresh | None |
+| `get_categories` | List all transaction categories | None |
+| `get_category_groups` | List category groups with categories | None |
 
 ## 📝 Usage Examples
 
@@ -139,6 +145,11 @@ Use get_budgets to show my current budget status
 ### Analyze Cash Flow
 ```
 Get my cashflow for the last 3 months using get_cashflow
+```
+
+### List Available Categories
+```
+Show me all available categories using get_categories
 ```
 
 ## 📅 Date Formats

--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ Once authenticated, use these tools directly in Claude Desktop:
 - **Set Transaction Tags**: Apply tags to a transaction
 - **Create Tag**: Create a new tag with custom name and color
 
+### 🔍 Advanced Search
+- **Search Transactions**: Comprehensive search with filters for merchant, category, account, tags, date ranges, and amounts
+- **Get Transaction Details**: Retrieve complete details for a single transaction
+- **Delete Transaction**: Remove a transaction
+- **Get Recurring Transactions**: View upcoming recurring transactions
+
 ### 📈 Financial Analysis
 - **Get Budgets**: Access budget information including spent amounts and remaining balances
 - **Get Cashflow**: Analyze financial cashflow over specified date ranges with income/expense breakdowns
@@ -146,6 +152,10 @@ Once authenticated, use these tools directly in Claude Desktop:
 | `get_tags` | List all tags | None |
 | `set_transaction_tags` | Set tags on a transaction | `transaction_id`, `tag_ids` |
 | `create_tag` | Create a new tag | `name`, `color` |
+| `search_transactions` | Search transactions with filters | `search`, `category_ids`, `account_ids`, `tag_ids`, `start_date`, `end_date`, `min_amount`, `max_amount` |
+| `get_transaction_details` | Get details of a transaction | `transaction_id` |
+| `delete_transaction` | Delete a transaction | `transaction_id` |
+| `get_recurring_transactions` | Get recurring transactions | None |
 
 ## 📝 Usage Examples
 
@@ -187,6 +197,16 @@ Categorize these three transactions as "Groceries" using bulk_categorize_transac
 ### Tag a Transaction
 ```
 Add the "Tax Deductible" tag to this transaction using set_transaction_tags
+```
+
+### Search for Transactions
+```
+Find all Amazon transactions over $50 from the last month using search_transactions
+```
+
+### View Recurring Bills
+```
+Show me my upcoming recurring transactions using get_recurring_transactions
 ```
 
 ## 📅 Date Formats

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ Once authenticated, use these tools directly in Claude Desktop:
 ### 📦 Bulk Operations
 - **Bulk Categorize Transactions**: Apply a category to multiple transactions at once
 
+### 🔖 Tag Management
+- **Get Tags**: List all available tags with colors and usage counts
+- **Set Transaction Tags**: Apply tags to a transaction
+- **Create Tag**: Create a new tag with custom name and color
+
 ### 📈 Financial Analysis
 - **Get Budgets**: Access budget information including spent amounts and remaining balances
 - **Get Cashflow**: Analyze financial cashflow over specified date ranges with income/expense breakdowns
@@ -138,6 +143,9 @@ Once authenticated, use these tools directly in Claude Desktop:
 | `update_transaction_notes` | Update notes on a transaction | `transaction_id`, `notes` |
 | `mark_transaction_reviewed` | Mark transaction as reviewed | `transaction_id` |
 | `bulk_categorize_transactions` | Categorize multiple transactions | `transaction_ids`, `category_id` |
+| `get_tags` | List all tags | None |
+| `set_transaction_tags` | Set tags on a transaction | `transaction_id`, `tag_ids` |
+| `create_tag` | Create a new tag | `name`, `color` |
 
 ## 📝 Usage Examples
 
@@ -174,6 +182,11 @@ Show me transactions from the last 7 days that need review using get_transaction
 ### Bulk Categorize Transactions
 ```
 Categorize these three transactions as "Groceries" using bulk_categorize_transactions
+```
+
+### Tag a Transaction
+```
+Add the "Tax Deductible" tag to this transaction using set_transaction_tags
 ```
 
 ## 📅 Date Formats

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ My MonarchMoney referral: https://www.monarchmoney.com/referral/ufmn0r83yf?r_sou
 
 **Important**: For security and MFA support, authentication is done outside of Claude Desktop.
 
-Open Terminal and run:
+#### Option A: Email/Password Login
 ```bash
 cd /path/to/your/monarch-mcp-server
 python login_setup.py
@@ -73,6 +73,17 @@ Follow the prompts:
 - Enter your Monarch Money email and password
 - Provide 2FA code if you have MFA enabled
 - Session will be saved automatically
+
+#### Option B: Google OAuth Login
+If you sign in to Monarch with Google:
+```bash
+cd /path/to/your/monarch-mcp-server
+python google_login.py
+```
+
+This opens a browser window where you can sign in with Google. The token is captured automatically.
+
+You can also trigger authentication from within Claude using the `authenticate_with_google` tool.
 
 ### 3. Start Using in Claude Desktop
 
@@ -131,6 +142,7 @@ Once authenticated, use these tools directly in Claude Desktop:
 ### 🔐 Secure Authentication
 - **One-Time Setup**: Authenticate once, use for weeks/months
 - **MFA Support**: Full support for two-factor authentication
+- **Google OAuth**: Sign in with Google account (no password needed)
 - **Session Persistence**: No need to re-authenticate frequently
 - **Secure**: Credentials never pass through Claude Desktop
 
@@ -139,6 +151,7 @@ Once authenticated, use these tools directly in Claude Desktop:
 | Tool | Description | Parameters |
 |------|-------------|------------|
 | `setup_authentication` | Get setup instructions | None |
+| `authenticate_with_google` | Open browser for Google OAuth login | None |
 | `check_auth_status` | Check authentication status | None |
 | `get_accounts` | Get all financial accounts | None |
 | `get_transactions` | Get transactions with filtering | `limit`, `offset`, `start_date`, `end_date`, `account_id` |
@@ -233,7 +246,7 @@ Create a rule to automatically categorize Amazon transactions as "Shopping" usin
 
 ### Authentication Issues
 If you see "Authentication needed" errors:
-1. Run the setup command: `cd /path/to/your/monarch-mcp-server && python login_setup.py`
+1. Run the setup command: `python login_setup.py` (or `python google_login.py` for Google OAuth)
 2. Restart Claude Desktop
 3. Try using a tool like `get_accounts`
 
@@ -256,7 +269,8 @@ monarch-mcp-server/
 ├── src/monarch_mcp_server/
 │   ├── __init__.py
 │   └── server.py          # Main server implementation
-├── login_setup.py         # Authentication setup script
+├── login_setup.py         # Email/password authentication script
+├── google_login.py        # Google OAuth authentication script
 ├── pyproject.toml         # Project configuration
 ├── requirements.txt       # Dependencies
 └── README.md             # This documentation

--- a/google_login.py
+++ b/google_login.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Google OAuth Login for Monarch Money MCP Server
+
+This script opens a browser window where you can sign in to Monarch Money
+using your Google account. After successful login, it automatically
+captures and saves the auth token.
+
+Usage:
+    python google_login.py
+"""
+
+import asyncio
+import sys
+import keyring
+from playwright.async_api import async_playwright
+
+# Keyring settings (same as secure_session.py)
+KEYRING_SERVICE = "com.mcp.monarch-mcp-server"
+KEYRING_USERNAME = "monarch-token"
+
+# Monarch URLs
+MONARCH_LOGIN_URL = "https://app.monarch.com/login"
+MONARCH_APP_URL = "https://app.monarch.com"
+
+
+async def capture_auth_token():
+    """Open browser for Google login and capture the auth token."""
+
+    print("🔐 Monarch Money - Google OAuth Login")
+    print("=" * 50)
+    print()
+    print("A browser window will open. Please:")
+    print("1. Click 'Sign in with Google'")
+    print("2. Complete the Google authentication")
+    print("3. Wait for the app to load")
+    print()
+    print("The token will be captured automatically.")
+    print("=" * 50)
+    print()
+
+    captured_token = None
+
+    async with async_playwright() as p:
+        # Launch browser in non-headless mode so user can interact
+        browser = await p.chromium.launch(
+            headless=False,
+            args=['--disable-blink-features=AutomationControlled']
+        )
+
+        context = await browser.new_context(
+            viewport={'width': 1280, 'height': 800},
+            user_agent='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+        )
+
+        page = await context.new_page()
+
+        # Set up request interception to capture auth token
+        async def handle_request(request):
+            nonlocal captured_token
+            auth_header = request.headers.get('authorization', '')
+            if auth_header.startswith('Token ') and not captured_token:
+                captured_token = auth_header.replace('Token ', '')
+                print(f"✅ Auth token captured!")
+
+        page.on('request', handle_request)
+
+        # Navigate to Monarch login
+        print("Opening Monarch login page...")
+        await page.goto(MONARCH_LOGIN_URL)
+
+        # Wait for user to complete login
+        print("Waiting for login... (complete the Google OAuth in the browser)")
+        print()
+
+        try:
+            # Wait for navigation to the main app (indicates successful login)
+            # or wait for a GraphQL request with auth token
+            max_wait = 300  # 5 minutes max
+            wait_interval = 1
+            waited = 0
+
+            while not captured_token and waited < max_wait:
+                await asyncio.sleep(wait_interval)
+                waited += wait_interval
+
+                # Check if we're on the main app page
+                current_url = page.url
+                if 'login' not in current_url and captured_token:
+                    break
+
+                # Show progress every 10 seconds
+                if waited % 10 == 0 and waited > 0:
+                    print(f"  Still waiting... ({waited}s)")
+
+            if captured_token:
+                print()
+                print("=" * 50)
+                print("✅ Login successful!")
+                print(f"   Token: {captured_token[:20]}...{captured_token[-10:]}")
+                print()
+
+                # Save to keyring
+                keyring.set_password(KEYRING_SERVICE, KEYRING_USERNAME, captured_token)
+                print("✅ Token saved to secure keyring storage")
+                print()
+                print("You can now close this browser window.")
+                print("The MCP server will use this token automatically.")
+                print("=" * 50)
+
+                # Keep browser open briefly so user can see success
+                await asyncio.sleep(3)
+            else:
+                print()
+                print("❌ Timeout: No auth token captured")
+                print("   Please try again or check your login.")
+
+        except Exception as e:
+            print(f"❌ Error during login: {e}")
+
+        finally:
+            await browser.close()
+
+    return captured_token
+
+
+def main():
+    """Main entry point."""
+    try:
+        token = asyncio.run(capture_auth_token())
+        if token:
+            print()
+            print("🎉 Setup complete! You can now use the Monarch MCP server.")
+            sys.exit(0)
+        else:
+            print()
+            print("❌ Setup failed. Please try again.")
+            sys.exit(1)
+    except KeyboardInterrupt:
+        print("\n\nCancelled by user.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",
     "asyncio>=3.4.3",
+    "playwright>=1.40.0",
 ]
 
 [project.optional-dependencies]

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -14,8 +14,12 @@ from mcp.server.auth.provider import AccessTokenT
 from mcp.server.fastmcp import FastMCP
 import mcp.types as types
 from monarchmoney import MonarchMoney, RequireMFAException
+from monarchmoney.monarchmoney import MonarchMoneyEndpoints
 from pydantic import BaseModel, Field
 from monarch_mcp_server.secure_session import secure_session
+
+# Patch MonarchMoney to use new API domain (monarch.com instead of monarchmoney.com)
+MonarchMoneyEndpoints.BASE_URL = "https://api.monarch.com"
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -927,6 +927,459 @@ def get_recurring_transactions(
         return f"Error getting recurring transactions: {str(e)}"
 
 
+# =============================================================================
+# Transaction Rules API (reverse-engineered from Monarch web app)
+# =============================================================================
+
+# GraphQL query for getting transaction rules
+GET_TRANSACTION_RULES_QUERY = """
+query GetTransactionRules {
+  transactionRules {
+    id
+    order
+    merchantCriteriaUseOriginalStatement
+    merchantCriteria {
+      operator
+      value
+      __typename
+    }
+    originalStatementCriteria {
+      operator
+      value
+      __typename
+    }
+    merchantNameCriteria {
+      operator
+      value
+      __typename
+    }
+    amountCriteria {
+      operator
+      isExpense
+      value
+      valueRange {
+        lower
+        upper
+        __typename
+      }
+      __typename
+    }
+    categoryIds
+    accountIds
+    categories {
+      id
+      name
+      icon
+      __typename
+    }
+    accounts {
+      id
+      displayName
+      __typename
+    }
+    setMerchantAction {
+      id
+      name
+      __typename
+    }
+    setCategoryAction {
+      id
+      name
+      icon
+      __typename
+    }
+    addTagsAction {
+      id
+      name
+      color
+      __typename
+    }
+    linkGoalAction {
+      id
+      name
+      __typename
+    }
+    setHideFromReportsAction
+    reviewStatusAction
+    recentApplicationCount
+    lastAppliedAt
+    __typename
+  }
+}
+"""
+
+CREATE_TRANSACTION_RULE_MUTATION = """
+mutation Common_CreateTransactionRuleMutationV2($input: CreateTransactionRuleInput!) {
+  createTransactionRuleV2(input: $input) {
+    errors {
+      fieldErrors {
+        field
+        messages
+        __typename
+      }
+      message
+      code
+      __typename
+    }
+    __typename
+  }
+}
+"""
+
+UPDATE_TRANSACTION_RULE_MUTATION = """
+mutation Common_UpdateTransactionRuleMutationV2($input: UpdateTransactionRuleInput!) {
+  updateTransactionRuleV2(input: $input) {
+    errors {
+      fieldErrors {
+        field
+        messages
+        __typename
+      }
+      message
+      code
+      __typename
+    }
+    __typename
+  }
+}
+"""
+
+DELETE_TRANSACTION_RULE_MUTATION = """
+mutation Common_DeleteTransactionRule($id: ID!) {
+  deleteTransactionRule(id: $id) {
+    deleted
+    errors {
+      fieldErrors {
+        field
+        messages
+        __typename
+      }
+      message
+      code
+      __typename
+    }
+    __typename
+  }
+}
+"""
+
+
+@mcp.tool()
+def get_transaction_rules() -> str:
+    """
+    Get all transaction auto-categorization rules from Monarch Money.
+
+    Returns a list of rules with their conditions and actions.
+    Rules automatically categorize transactions based on merchant, amount, etc.
+    """
+    try:
+        from gql import gql
+
+        async def _get_rules():
+            client = await get_monarch_client()
+            query = gql(GET_TRANSACTION_RULES_QUERY)
+            return await client.gql_call(
+                operation="GetTransactionRules",
+                graphql_query=query,
+                variables={},
+            )
+
+        result = run_async(_get_rules())
+
+        # Format rules for display
+        rules_list = []
+        for rule in result.get("transactionRules", []):
+            rule_info = {
+                "id": rule.get("id"),
+                "order": rule.get("order"),
+                # Criteria (conditions)
+                "merchant_criteria": rule.get("merchantCriteria"),
+                "merchant_name_criteria": rule.get("merchantNameCriteria"),
+                "original_statement_criteria": rule.get("originalStatementCriteria"),
+                "amount_criteria": rule.get("amountCriteria"),
+                "category_ids": rule.get("categoryIds"),
+                "account_ids": rule.get("accountIds"),
+                "use_original_statement": rule.get("merchantCriteriaUseOriginalStatement"),
+                # Actions
+                "set_category_action": {
+                    "id": rule.get("setCategoryAction", {}).get("id"),
+                    "name": rule.get("setCategoryAction", {}).get("name"),
+                } if rule.get("setCategoryAction") else None,
+                "set_merchant_action": {
+                    "id": rule.get("setMerchantAction", {}).get("id"),
+                    "name": rule.get("setMerchantAction", {}).get("name"),
+                } if rule.get("setMerchantAction") else None,
+                "add_tags_action": [
+                    {"id": tag.get("id"), "name": tag.get("name")}
+                    for tag in rule.get("addTagsAction", [])
+                ] if rule.get("addTagsAction") else None,
+                "link_goal_action": rule.get("linkGoalAction"),
+                "hide_from_reports_action": rule.get("setHideFromReportsAction"),
+                "review_status_action": rule.get("reviewStatusAction"),
+                # Stats
+                "recent_application_count": rule.get("recentApplicationCount"),
+                "last_applied_at": rule.get("lastAppliedAt"),
+            }
+            rules_list.append(rule_info)
+
+        return json.dumps(rules_list, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Failed to get transaction rules: {e}")
+        return f"Error getting transaction rules: {str(e)}"
+
+
+@mcp.tool()
+def create_transaction_rule(
+    merchant_criteria_operator: Optional[str] = None,
+    merchant_criteria_value: Optional[str] = None,
+    amount_operator: Optional[str] = None,
+    amount_value: Optional[float] = None,
+    amount_is_expense: bool = True,
+    set_category_id: Optional[str] = None,
+    set_merchant_name: Optional[str] = None,
+    add_tag_ids: Optional[List[str]] = None,
+    hide_from_reports: Optional[bool] = None,
+    review_status: Optional[str] = None,
+    account_ids: Optional[List[str]] = None,
+    apply_to_existing: bool = False,
+) -> str:
+    """
+    Create a new transaction auto-categorization rule.
+
+    Rules automatically categorize future transactions based on conditions.
+
+    Args:
+        merchant_criteria_operator: How to match merchant ("eq", "contains")
+        merchant_criteria_value: Merchant name/pattern to match
+        amount_operator: Amount comparison ("gt", "lt", "eq", "between")
+        amount_value: Amount threshold value
+        amount_is_expense: Whether amount is expense (negative) or income
+        set_category_id: Category ID to assign (use get_categories for IDs)
+        set_merchant_name: Merchant name to set on matching transactions
+        add_tag_ids: List of tag IDs to add (use get_tags for IDs)
+        hide_from_reports: Whether to hide matching transactions from reports
+        review_status: Review status to set ("needs_review" or null)
+        account_ids: Limit rule to specific account IDs
+        apply_to_existing: Whether to apply rule to existing transactions
+
+    Returns:
+        Result of rule creation.
+
+    Example:
+        Create rule: "Amazon purchases → Shopping category"
+        create_transaction_rule(
+            merchant_criteria_operator="contains",
+            merchant_criteria_value="amazon",
+            set_category_id="cat_123"
+        )
+    """
+    try:
+        from gql import gql
+
+        async def _create_rule():
+            client = await get_monarch_client()
+
+            # Build input
+            rule_input: Dict[str, Any] = {
+                "applyToExistingTransactions": apply_to_existing,
+            }
+
+            # Merchant criteria
+            if merchant_criteria_operator and merchant_criteria_value:
+                rule_input["merchantNameCriteria"] = [{
+                    "operator": merchant_criteria_operator,
+                    "value": merchant_criteria_value,
+                }]
+
+            # Amount criteria
+            if amount_operator and amount_value is not None:
+                rule_input["amountCriteria"] = {
+                    "operator": amount_operator,
+                    "isExpense": amount_is_expense,
+                    "value": amount_value,
+                    "valueRange": None,
+                }
+
+            # Account filter
+            if account_ids:
+                rule_input["accountIds"] = account_ids
+
+            # Actions
+            if set_category_id:
+                rule_input["setCategoryAction"] = set_category_id
+            if set_merchant_name:
+                rule_input["setMerchantAction"] = set_merchant_name
+            if add_tag_ids:
+                rule_input["addTagsAction"] = add_tag_ids
+            if hide_from_reports is not None:
+                rule_input["setHideFromReportsAction"] = hide_from_reports
+            if review_status:
+                rule_input["reviewStatusAction"] = review_status
+
+            query = gql(CREATE_TRANSACTION_RULE_MUTATION)
+            return await client.gql_call(
+                operation="Common_CreateTransactionRuleMutationV2",
+                graphql_query=query,
+                variables={"input": rule_input},
+            )
+
+        result = run_async(_create_rule())
+
+        # Check for errors
+        errors = result.get("createTransactionRuleV2", {}).get("errors")
+        if errors:
+            return json.dumps({"success": False, "errors": errors}, indent=2)
+
+        return json.dumps({"success": True, "message": "Rule created successfully"}, indent=2)
+    except Exception as e:
+        logger.error(f"Failed to create transaction rule: {e}")
+        return f"Error creating transaction rule: {str(e)}"
+
+
+@mcp.tool()
+def update_transaction_rule(
+    rule_id: str,
+    merchant_criteria_operator: Optional[str] = None,
+    merchant_criteria_value: Optional[str] = None,
+    amount_operator: Optional[str] = None,
+    amount_value: Optional[float] = None,
+    amount_is_expense: bool = True,
+    set_category_id: Optional[str] = None,
+    set_merchant_name: Optional[str] = None,
+    add_tag_ids: Optional[List[str]] = None,
+    hide_from_reports: Optional[bool] = None,
+    review_status: Optional[str] = None,
+    account_ids: Optional[List[str]] = None,
+    apply_to_existing: bool = False,
+) -> str:
+    """
+    Update an existing transaction rule.
+
+    Args:
+        rule_id: The ID of the rule to update (use get_transaction_rules to find IDs)
+        merchant_criteria_operator: How to match merchant ("eq", "contains")
+        merchant_criteria_value: Merchant name/pattern to match
+        amount_operator: Amount comparison ("gt", "lt", "eq", "between")
+        amount_value: Amount threshold value
+        amount_is_expense: Whether amount is expense (negative) or income
+        set_category_id: Category ID to assign
+        set_merchant_name: Merchant name to set
+        add_tag_ids: List of tag IDs to add
+        hide_from_reports: Whether to hide from reports
+        review_status: Review status to set
+        account_ids: Limit rule to specific accounts
+        apply_to_existing: Apply changes to existing transactions
+
+    Returns:
+        Result of rule update.
+    """
+    try:
+        from gql import gql
+
+        async def _update_rule():
+            client = await get_monarch_client()
+
+            # Build input
+            rule_input: Dict[str, Any] = {
+                "id": rule_id,
+                "applyToExistingTransactions": apply_to_existing,
+            }
+
+            # Merchant criteria
+            if merchant_criteria_operator and merchant_criteria_value:
+                rule_input["merchantNameCriteria"] = [{
+                    "operator": merchant_criteria_operator,
+                    "value": merchant_criteria_value,
+                }]
+
+            # Amount criteria
+            if amount_operator and amount_value is not None:
+                rule_input["amountCriteria"] = {
+                    "operator": amount_operator,
+                    "isExpense": amount_is_expense,
+                    "value": amount_value,
+                    "valueRange": None,
+                }
+
+            # Account filter
+            if account_ids:
+                rule_input["accountIds"] = account_ids
+
+            # Actions
+            if set_category_id:
+                rule_input["setCategoryAction"] = set_category_id
+            if set_merchant_name:
+                rule_input["setMerchantAction"] = set_merchant_name
+            if add_tag_ids:
+                rule_input["addTagsAction"] = add_tag_ids
+            if hide_from_reports is not None:
+                rule_input["setHideFromReportsAction"] = hide_from_reports
+            if review_status:
+                rule_input["reviewStatusAction"] = review_status
+
+            query = gql(UPDATE_TRANSACTION_RULE_MUTATION)
+            return await client.gql_call(
+                operation="Common_UpdateTransactionRuleMutationV2",
+                graphql_query=query,
+                variables={"input": rule_input},
+            )
+
+        result = run_async(_update_rule())
+
+        # Check for errors
+        errors = result.get("updateTransactionRuleV2", {}).get("errors")
+        if errors:
+            return json.dumps({"success": False, "errors": errors}, indent=2)
+
+        return json.dumps({"success": True, "message": "Rule updated successfully"}, indent=2)
+    except Exception as e:
+        logger.error(f"Failed to update transaction rule: {e}")
+        return f"Error updating transaction rule: {str(e)}"
+
+
+@mcp.tool()
+def delete_transaction_rule(
+    rule_id: str,
+) -> str:
+    """
+    Delete a transaction rule.
+
+    Args:
+        rule_id: The ID of the rule to delete (use get_transaction_rules to find IDs)
+
+    Returns:
+        Confirmation of deletion.
+    """
+    try:
+        from gql import gql
+
+        async def _delete_rule():
+            client = await get_monarch_client()
+
+            query = gql(DELETE_TRANSACTION_RULE_MUTATION)
+            return await client.gql_call(
+                operation="Common_DeleteTransactionRule",
+                graphql_query=query,
+                variables={"id": rule_id},
+            )
+
+        result = run_async(_delete_rule())
+
+        # Check result
+        delete_result = result.get("deleteTransactionRule", {})
+        if delete_result.get("deleted"):
+            return json.dumps({"success": True, "message": "Rule deleted successfully"}, indent=2)
+
+        errors = delete_result.get("errors")
+        if errors:
+            return json.dumps({"success": False, "errors": errors}, indent=2)
+
+        return json.dumps({"success": False, "message": "Unknown error"}, indent=2)
+    except Exception as e:
+        logger.error(f"Failed to delete transaction rule: {e}")
+        return f"Error deleting transaction rule: {str(e)}"
+
+
 @mcp.tool()
 def refresh_accounts() -> str:
     """Request account data refresh from financial institutions."""

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -437,6 +437,83 @@ def refresh_accounts() -> str:
         return f"Error refreshing accounts: {str(e)}"
 
 
+@mcp.tool()
+def get_categories() -> str:
+    """
+    Get all transaction categories from Monarch Money.
+
+    Returns a list of categories with their groups, icons, and metadata.
+    Useful for selecting a category when categorizing transactions.
+    """
+    try:
+
+        async def _get_categories():
+            client = await get_monarch_client()
+            return await client.get_transaction_categories()
+
+        categories_data = run_async(_get_categories())
+
+        # Format categories for display
+        category_list = []
+        for cat in categories_data.get("categories", []):
+            category_info = {
+                "id": cat.get("id"),
+                "name": cat.get("name"),
+                "icon": cat.get("icon"),
+                "group": cat.get("group", {}).get("name") if cat.get("group") else None,
+                "group_id": cat.get("group", {}).get("id") if cat.get("group") else None,
+                "is_system_category": cat.get("isSystemCategory", False),
+                "is_disabled": cat.get("isDisabled", False),
+            }
+            category_list.append(category_info)
+
+        return json.dumps(category_list, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Failed to get categories: {e}")
+        return f"Error getting categories: {str(e)}"
+
+
+@mcp.tool()
+def get_category_groups() -> str:
+    """
+    Get all transaction category groups from Monarch Money.
+
+    Returns groups like Income, Expenses, etc. with their associated categories.
+    """
+    try:
+
+        async def _get_category_groups():
+            client = await get_monarch_client()
+            return await client.get_transaction_category_groups()
+
+        groups_data = run_async(_get_category_groups())
+
+        # Format category groups for display
+        group_list = []
+        for group in groups_data.get("categoryGroups", []):
+            group_info = {
+                "id": group.get("id"),
+                "name": group.get("name"),
+                "type": group.get("type"),
+                "budget_variability": group.get("budgetVariability"),
+                "group_level_budgeting_enabled": group.get("groupLevelBudgetingEnabled", False),
+                "categories": [
+                    {
+                        "id": cat.get("id"),
+                        "name": cat.get("name"),
+                        "icon": cat.get("icon"),
+                    }
+                    for cat in group.get("categories", [])
+                ],
+            }
+            group_list.append(group_info)
+
+        return json.dumps(group_list, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Failed to get category groups: {e}")
+        return f"Error getting category groups: {str(e)}"
+
+
 def main():
     """Main entry point for the server."""
     logger.info("Starting Monarch Money MCP Server...")

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -601,6 +601,109 @@ def bulk_categorize_transactions(
 
 
 @mcp.tool()
+def get_tags() -> str:
+    """
+    Get all transaction tags from Monarch Money.
+
+    Returns a list of tags with their colors and transaction counts.
+    Use this to see available tags before applying them to transactions.
+    """
+    try:
+
+        async def _get_tags():
+            client = await get_monarch_client()
+            return await client.get_transaction_tags()
+
+        tags_data = run_async(_get_tags())
+
+        # Format tags for display
+        tag_list = []
+        for tag in tags_data.get("householdTransactionTags", []):
+            tag_info = {
+                "id": tag.get("id"),
+                "name": tag.get("name"),
+                "color": tag.get("color"),
+                "order": tag.get("order"),
+                "transaction_count": tag.get("transactionCount", 0),
+            }
+            tag_list.append(tag_info)
+
+        return json.dumps(tag_list, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Failed to get tags: {e}")
+        return f"Error getting tags: {str(e)}"
+
+
+@mcp.tool()
+def set_transaction_tags(
+    transaction_id: str,
+    tag_ids: List[str],
+) -> str:
+    """
+    Set tags on a transaction.
+
+    Note: This REPLACES all existing tags on the transaction.
+    To add a tag, include both existing and new tag IDs.
+    To remove all tags, pass an empty list.
+
+    Args:
+        transaction_id: The ID of the transaction to tag
+        tag_ids: List of tag IDs to apply (use get_tags to find IDs)
+
+    Returns:
+        Updated transaction details.
+    """
+    try:
+
+        async def _set_tags():
+            client = await get_monarch_client()
+            return await client.set_transaction_tags(
+                transaction_id=transaction_id,
+                tag_ids=tag_ids,
+            )
+
+        result = run_async(_set_tags())
+
+        return json.dumps(result, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Failed to set transaction tags: {e}")
+        return f"Error setting tags: {str(e)}"
+
+
+@mcp.tool()
+def create_tag(
+    name: str,
+    color: str = "#19D2A5",
+) -> str:
+    """
+    Create a new transaction tag.
+
+    Args:
+        name: Name for the new tag
+        color: Hex color code for the tag (default: "#19D2A5" - teal)
+               Examples: "#FF5733" (red-orange), "#3498DB" (blue), "#9B59B6" (purple)
+
+    Returns:
+        The created tag details including its ID.
+    """
+    try:
+
+        async def _create_tag():
+            client = await get_monarch_client()
+            return await client.create_transaction_tag(
+                name=name,
+                color=color,
+            )
+
+        result = run_async(_create_tag())
+
+        return json.dumps(result, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Failed to create tag: {e}")
+        return f"Error creating tag: {str(e)}"
+
+
+@mcp.tool()
 def refresh_accounts() -> str:
     """Request account data refresh from financial institutions."""
     try:

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,143 @@
+"""Tests for category-related MCP tools."""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+# Mock the monarchmoney module before importing server
+import sys
+sys.modules['monarchmoney'] = MagicMock()
+sys.modules['monarchmoney'].MonarchMoney = MagicMock
+sys.modules['monarchmoney'].RequireMFAException = Exception
+
+from monarch_mcp_server.server import get_categories, get_category_groups
+
+
+class TestGetCategories:
+    """Tests for get_categories tool."""
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_categories_success(self, mock_get_client):
+        """Test successful retrieval of categories."""
+        # Setup mock
+        mock_client = AsyncMock()
+        mock_client.get_transaction_categories.return_value = {
+            "categories": [
+                {
+                    "id": "cat_123",
+                    "name": "Groceries",
+                    "icon": "🛒",
+                    "group": {"id": "grp_1", "name": "Food & Dining"},
+                    "isSystemCategory": False,
+                    "isDisabled": False,
+                },
+                {
+                    "id": "cat_456",
+                    "name": "Salary",
+                    "icon": "💰",
+                    "group": {"id": "grp_2", "name": "Income"},
+                    "isSystemCategory": True,
+                    "isDisabled": False,
+                },
+            ]
+        }
+        mock_get_client.return_value = mock_client
+
+        # Execute
+        result = get_categories()
+
+        # Verify
+        categories = json.loads(result)
+        assert len(categories) == 2
+        assert categories[0]["id"] == "cat_123"
+        assert categories[0]["name"] == "Groceries"
+        assert categories[0]["group"] == "Food & Dining"
+        assert categories[1]["is_system_category"] is True
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_categories_empty(self, mock_get_client):
+        """Test retrieval when no categories exist."""
+        mock_client = AsyncMock()
+        mock_client.get_transaction_categories.return_value = {"categories": []}
+        mock_get_client.return_value = mock_client
+
+        result = get_categories()
+
+        categories = json.loads(result)
+        assert len(categories) == 0
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_categories_error(self, mock_get_client):
+        """Test error handling when API fails."""
+        mock_get_client.side_effect = RuntimeError("Auth needed")
+
+        result = get_categories()
+
+        assert "Error getting categories" in result
+        assert "Auth needed" in result
+
+
+class TestGetCategoryGroups:
+    """Tests for get_category_groups tool."""
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_category_groups_success(self, mock_get_client):
+        """Test successful retrieval of category groups."""
+        mock_client = AsyncMock()
+        mock_client.get_transaction_category_groups.return_value = {
+            "categoryGroups": [
+                {
+                    "id": "grp_1",
+                    "name": "Income",
+                    "type": "income",
+                    "budgetVariability": "fixed",
+                    "groupLevelBudgetingEnabled": False,
+                    "categories": [
+                        {"id": "cat_1", "name": "Salary", "icon": "💰"},
+                        {"id": "cat_2", "name": "Bonus", "icon": "🎁"},
+                    ],
+                },
+                {
+                    "id": "grp_2",
+                    "name": "Food & Dining",
+                    "type": "expense",
+                    "budgetVariability": "variable",
+                    "groupLevelBudgetingEnabled": True,
+                    "categories": [
+                        {"id": "cat_3", "name": "Groceries", "icon": "🛒"},
+                    ],
+                },
+            ]
+        }
+        mock_get_client.return_value = mock_client
+
+        result = get_category_groups()
+
+        groups = json.loads(result)
+        assert len(groups) == 2
+        assert groups[0]["name"] == "Income"
+        assert groups[0]["type"] == "income"
+        assert len(groups[0]["categories"]) == 2
+        assert groups[1]["group_level_budgeting_enabled"] is True
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_category_groups_empty(self, mock_get_client):
+        """Test retrieval when no category groups exist."""
+        mock_client = AsyncMock()
+        mock_client.get_transaction_category_groups.return_value = {"categoryGroups": []}
+        mock_get_client.return_value = mock_client
+
+        result = get_category_groups()
+
+        groups = json.loads(result)
+        assert len(groups) == 0
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_category_groups_error(self, mock_get_client):
+        """Test error handling when API fails."""
+        mock_get_client.side_effect = RuntimeError("Connection failed")
+
+        result = get_category_groups()
+
+        assert "Error getting category groups" in result
+        assert "Connection failed" in result

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,285 @@
+"""Tests for transaction rules MCP tools."""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+# Mock the monarchmoney module before importing server
+import sys
+sys.modules['monarchmoney'] = MagicMock()
+sys.modules['monarchmoney'].MonarchMoney = MagicMock
+sys.modules['monarchmoney'].RequireMFAException = Exception
+
+from monarch_mcp_server.server import (
+    get_transaction_rules,
+    create_transaction_rule,
+    update_transaction_rule,
+    delete_transaction_rule,
+)
+
+
+class TestGetTransactionRules:
+    """Tests for get_transaction_rules tool."""
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_rules_success(self, mock_get_client):
+        """Test successful retrieval of transaction rules."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "transactionRules": [
+                {
+                    "id": "rule_1",
+                    "order": 0,
+                    "merchantCriteriaUseOriginalStatement": False,
+                    "merchantCriteria": [
+                        {"operator": "contains", "value": "amazon"}
+                    ],
+                    "merchantNameCriteria": None,
+                    "originalStatementCriteria": None,
+                    "amountCriteria": None,
+                    "categoryIds": None,
+                    "accountIds": None,
+                    "setCategoryAction": {
+                        "id": "cat_123",
+                        "name": "Shopping",
+                    },
+                    "setMerchantAction": None,
+                    "addTagsAction": [
+                        {"id": "tag_1", "name": "Online", "color": "#FF0000"}
+                    ],
+                    "linkGoalAction": None,
+                    "setHideFromReportsAction": False,
+                    "reviewStatusAction": None,
+                    "recentApplicationCount": 5,
+                    "lastAppliedAt": "2024-01-15T10:00:00Z",
+                },
+            ]
+        }
+        mock_get_client.return_value = mock_client
+
+        result = get_transaction_rules()
+
+        rules = json.loads(result)
+        assert len(rules) == 1
+        assert rules[0]["id"] == "rule_1"
+        assert rules[0]["merchant_criteria"][0]["value"] == "amazon"
+        assert rules[0]["set_category_action"]["name"] == "Shopping"
+        assert rules[0]["add_tags_action"][0]["name"] == "Online"
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_rules_empty(self, mock_get_client):
+        """Test when no rules exist."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {"transactionRules": []}
+        mock_get_client.return_value = mock_client
+
+        result = get_transaction_rules()
+
+        rules = json.loads(result)
+        assert len(rules) == 0
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_rules_error(self, mock_get_client):
+        """Test error handling."""
+        mock_get_client.side_effect = RuntimeError("Auth needed")
+
+        result = get_transaction_rules()
+
+        assert "Error getting transaction rules" in result
+
+
+class TestCreateTransactionRule:
+    """Tests for create_transaction_rule tool."""
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_create_rule_simple(self, mock_get_client):
+        """Test creating a simple merchant-to-category rule."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "createTransactionRuleV2": {"errors": None}
+        }
+        mock_get_client.return_value = mock_client
+
+        result = create_transaction_rule(
+            merchant_criteria_operator="contains",
+            merchant_criteria_value="amazon",
+            set_category_id="cat_123"
+        )
+
+        data = json.loads(result)
+        assert data["success"] is True
+
+        # Verify the call
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert variables["input"]["merchantNameCriteria"][0]["operator"] == "contains"
+        assert variables["input"]["merchantNameCriteria"][0]["value"] == "amazon"
+        assert variables["input"]["setCategoryAction"] == "cat_123"
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_create_rule_with_amount(self, mock_get_client):
+        """Test creating a rule with amount criteria."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "createTransactionRuleV2": {"errors": None}
+        }
+        mock_get_client.return_value = mock_client
+
+        result = create_transaction_rule(
+            merchant_criteria_operator="contains",
+            merchant_criteria_value="uber",
+            amount_operator="lt",
+            amount_value=50.0,
+            amount_is_expense=True,
+            set_category_id="cat_transport"
+        )
+
+        data = json.loads(result)
+        assert data["success"] is True
+
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert variables["input"]["amountCriteria"]["operator"] == "lt"
+        assert variables["input"]["amountCriteria"]["value"] == 50.0
+        assert variables["input"]["amountCriteria"]["isExpense"] is True
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_create_rule_with_tags(self, mock_get_client):
+        """Test creating a rule that adds tags."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "createTransactionRuleV2": {"errors": None}
+        }
+        mock_get_client.return_value = mock_client
+
+        result = create_transaction_rule(
+            merchant_criteria_operator="eq",
+            merchant_criteria_value="netflix",
+            add_tag_ids=["tag_1", "tag_2"]
+        )
+
+        data = json.loads(result)
+        assert data["success"] is True
+
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert variables["input"]["addTagsAction"] == ["tag_1", "tag_2"]
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_create_rule_error(self, mock_get_client):
+        """Test error handling when creation fails."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "createTransactionRuleV2": {
+                "errors": {
+                    "message": "Invalid category ID",
+                    "code": "INVALID_INPUT"
+                }
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = create_transaction_rule(
+            merchant_criteria_operator="contains",
+            merchant_criteria_value="test",
+            set_category_id="invalid_cat"
+        )
+
+        data = json.loads(result)
+        assert data["success"] is False
+        assert data["errors"] is not None
+
+
+class TestUpdateTransactionRule:
+    """Tests for update_transaction_rule tool."""
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_update_rule_success(self, mock_get_client):
+        """Test successful rule update."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateTransactionRuleV2": {"errors": None}
+        }
+        mock_get_client.return_value = mock_client
+
+        result = update_transaction_rule(
+            rule_id="rule_123",
+            merchant_criteria_operator="contains",
+            merchant_criteria_value="amazon prime",
+            set_category_id="cat_456"
+        )
+
+        data = json.loads(result)
+        assert data["success"] is True
+
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert variables["input"]["id"] == "rule_123"
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_update_rule_error(self, mock_get_client):
+        """Test error handling when update fails."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateTransactionRuleV2": {
+                "errors": {"message": "Rule not found"}
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = update_transaction_rule(
+            rule_id="invalid_rule",
+            merchant_criteria_operator="eq",
+            merchant_criteria_value="test"
+        )
+
+        data = json.loads(result)
+        assert data["success"] is False
+
+
+class TestDeleteTransactionRule:
+    """Tests for delete_transaction_rule tool."""
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_delete_rule_success(self, mock_get_client):
+        """Test successful rule deletion."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "deleteTransactionRule": {
+                "deleted": True,
+                "errors": None
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = delete_transaction_rule(rule_id="rule_123")
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert "deleted" in data["message"].lower()
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_delete_rule_not_found(self, mock_get_client):
+        """Test deletion when rule doesn't exist."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "deleteTransactionRule": {
+                "deleted": False,
+                "errors": {"message": "Rule not found"}
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = delete_transaction_rule(rule_id="invalid_rule")
+
+        data = json.loads(result)
+        assert data["success"] is False
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_delete_rule_error(self, mock_get_client):
+        """Test error handling."""
+        mock_get_client.side_effect = RuntimeError("API error")
+
+        result = delete_transaction_rule(rule_id="rule_123")
+
+        assert "Error deleting transaction rule" in result

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,194 @@
+"""Tests for tag-related MCP tools."""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+# Mock the monarchmoney module before importing server
+import sys
+sys.modules['monarchmoney'] = MagicMock()
+sys.modules['monarchmoney'].MonarchMoney = MagicMock
+sys.modules['monarchmoney'].RequireMFAException = Exception
+
+from monarch_mcp_server.server import get_tags, set_transaction_tags, create_tag
+
+
+class TestGetTags:
+    """Tests for get_tags tool."""
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_tags_success(self, mock_get_client):
+        """Test successful retrieval of tags."""
+        mock_client = AsyncMock()
+        mock_client.get_transaction_tags.return_value = {
+            "householdTransactionTags": [
+                {
+                    "id": "tag_1",
+                    "name": "Tax Deductible",
+                    "color": "#FF5733",
+                    "order": 1,
+                    "transactionCount": 42,
+                },
+                {
+                    "id": "tag_2",
+                    "name": "Reimbursable",
+                    "color": "#3498DB",
+                    "order": 2,
+                    "transactionCount": 15,
+                },
+            ]
+        }
+        mock_get_client.return_value = mock_client
+
+        result = get_tags()
+
+        tags = json.loads(result)
+        assert len(tags) == 2
+        assert tags[0]["id"] == "tag_1"
+        assert tags[0]["name"] == "Tax Deductible"
+        assert tags[0]["color"] == "#FF5733"
+        assert tags[0]["transaction_count"] == 42
+        assert tags[1]["name"] == "Reimbursable"
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_tags_empty(self, mock_get_client):
+        """Test retrieval when no tags exist."""
+        mock_client = AsyncMock()
+        mock_client.get_transaction_tags.return_value = {
+            "householdTransactionTags": []
+        }
+        mock_get_client.return_value = mock_client
+
+        result = get_tags()
+
+        tags = json.loads(result)
+        assert len(tags) == 0
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_tags_error(self, mock_get_client):
+        """Test error handling."""
+        mock_get_client.side_effect = RuntimeError("Auth needed")
+
+        result = get_tags()
+
+        assert "Error getting tags" in result
+
+
+class TestSetTransactionTags:
+    """Tests for set_transaction_tags tool."""
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_set_tags_success(self, mock_get_client):
+        """Test setting tags on a transaction."""
+        mock_client = AsyncMock()
+        mock_client.set_transaction_tags.return_value = {
+            "setTransactionTags": {
+                "transaction": {
+                    "id": "txn_123",
+                    "tags": [
+                        {"id": "tag_1", "name": "Tax Deductible"},
+                        {"id": "tag_2", "name": "Reimbursable"},
+                    ]
+                }
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = set_transaction_tags(
+            transaction_id="txn_123",
+            tag_ids=["tag_1", "tag_2"]
+        )
+
+        # Verify API called correctly
+        mock_client.set_transaction_tags.assert_called_once_with(
+            transaction_id="txn_123",
+            tag_ids=["tag_1", "tag_2"]
+        )
+
+        data = json.loads(result)
+        assert "setTransactionTags" in data
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_set_tags_empty_list(self, mock_get_client):
+        """Test removing all tags by passing empty list."""
+        mock_client = AsyncMock()
+        mock_client.set_transaction_tags.return_value = {
+            "setTransactionTags": {
+                "transaction": {"id": "txn_123", "tags": []}
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = set_transaction_tags(
+            transaction_id="txn_123",
+            tag_ids=[]
+        )
+
+        mock_client.set_transaction_tags.assert_called_once_with(
+            transaction_id="txn_123",
+            tag_ids=[]
+        )
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_set_tags_error(self, mock_get_client):
+        """Test error handling."""
+        mock_get_client.side_effect = RuntimeError("API error")
+
+        result = set_transaction_tags("txn_123", ["tag_1"])
+
+        assert "Error setting tags" in result
+
+
+class TestCreateTag:
+    """Tests for create_tag tool."""
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_create_tag_success(self, mock_get_client):
+        """Test successful tag creation."""
+        mock_client = AsyncMock()
+        mock_client.create_transaction_tag.return_value = {
+            "createTransactionTag": {
+                "tag": {
+                    "id": "tag_new",
+                    "name": "Business Expense",
+                    "color": "#9B59B6",
+                }
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = create_tag(
+            name="Business Expense",
+            color="#9B59B6"
+        )
+
+        mock_client.create_transaction_tag.assert_called_once_with(
+            name="Business Expense",
+            color="#9B59B6"
+        )
+
+        data = json.loads(result)
+        assert "createTransactionTag" in data
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_create_tag_default_color(self, mock_get_client):
+        """Test tag creation with default color."""
+        mock_client = AsyncMock()
+        mock_client.create_transaction_tag.return_value = {"createTransactionTag": {}}
+        mock_get_client.return_value = mock_client
+
+        create_tag(name="My Tag")
+
+        mock_client.create_transaction_tag.assert_called_once_with(
+            name="My Tag",
+            color="#19D2A5"
+        )
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_create_tag_error(self, mock_get_client):
+        """Test error handling."""
+        mock_get_client.side_effect = RuntimeError("API error")
+
+        result = create_tag("Test Tag")
+
+        assert "Error creating tag" in result

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,0 +1,186 @@
+"""Tests for transaction-related MCP tools."""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+# Mock the monarchmoney module before importing server
+import sys
+sys.modules['monarchmoney'] = MagicMock()
+sys.modules['monarchmoney'].MonarchMoney = MagicMock
+sys.modules['monarchmoney'].RequireMFAException = Exception
+
+from monarch_mcp_server.server import get_transactions_needing_review
+
+
+class TestGetTransactionsNeedingReview:
+    """Tests for get_transactions_needing_review tool."""
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_transactions_needs_review_filter(self, mock_get_client):
+        """Test filtering by needs_review flag."""
+        mock_client = AsyncMock()
+        mock_client.get_transactions.return_value = {
+            "allTransactions": {
+                "results": [
+                    {
+                        "id": "txn_1",
+                        "date": "2024-01-15",
+                        "amount": -50.00,
+                        "merchant": {"name": "Amazon"},
+                        "category": {"id": "cat_1", "name": "Shopping"},
+                        "account": {"id": "acc_1", "displayName": "Checking"},
+                        "needsReview": True,
+                        "notes": None,
+                        "tags": [],
+                    },
+                    {
+                        "id": "txn_2",
+                        "date": "2024-01-14",
+                        "amount": -25.00,
+                        "merchant": {"name": "Starbucks"},
+                        "category": {"id": "cat_2", "name": "Coffee"},
+                        "account": {"id": "acc_1", "displayName": "Checking"},
+                        "needsReview": False,
+                        "notes": "Morning coffee",
+                        "tags": [],
+                    },
+                ]
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = get_transactions_needing_review(needs_review=True)
+
+        transactions = json.loads(result)
+        assert len(transactions) == 1
+        assert transactions[0]["id"] == "txn_1"
+        assert transactions[0]["needs_review"] is True
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_transactions_uncategorized_filter(self, mock_get_client):
+        """Test filtering for uncategorized transactions."""
+        mock_client = AsyncMock()
+        mock_client.get_transactions.return_value = {
+            "allTransactions": {
+                "results": [
+                    {
+                        "id": "txn_1",
+                        "date": "2024-01-15",
+                        "amount": -50.00,
+                        "merchant": {"name": "Unknown Store"},
+                        "category": None,
+                        "account": {"id": "acc_1", "displayName": "Checking"},
+                        "needsReview": True,
+                        "notes": None,
+                        "tags": [],
+                    },
+                    {
+                        "id": "txn_2",
+                        "date": "2024-01-14",
+                        "amount": -25.00,
+                        "merchant": {"name": "Grocery Store"},
+                        "category": {"id": "cat_1", "name": "Groceries"},
+                        "account": {"id": "acc_1", "displayName": "Checking"},
+                        "needsReview": True,
+                        "notes": None,
+                        "tags": [],
+                    },
+                ]
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = get_transactions_needing_review(
+            needs_review=True,
+            uncategorized_only=True
+        )
+
+        transactions = json.loads(result)
+        assert len(transactions) == 1
+        assert transactions[0]["id"] == "txn_1"
+        assert transactions[0]["category"] is None
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_transactions_with_days_filter(self, mock_get_client):
+        """Test filtering by days parameter."""
+        mock_client = AsyncMock()
+        mock_client.get_transactions.return_value = {
+            "allTransactions": {"results": []}
+        }
+        mock_get_client.return_value = mock_client
+
+        result = get_transactions_needing_review(days=7, needs_review=False)
+
+        # Verify the API was called with date filters
+        call_kwargs = mock_client.get_transactions.call_args.kwargs
+        assert "start_date" in call_kwargs
+        assert "end_date" in call_kwargs
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_transactions_full_details(self, mock_get_client):
+        """Test that full transaction details are returned."""
+        mock_client = AsyncMock()
+        mock_client.get_transactions.return_value = {
+            "allTransactions": {
+                "results": [
+                    {
+                        "id": "txn_1",
+                        "date": "2024-01-15",
+                        "amount": -50.00,
+                        "merchant": {"name": "Amazon"},
+                        "plaidName": "AMAZON.COM*1234",
+                        "category": {"id": "cat_1", "name": "Shopping"},
+                        "account": {"id": "acc_1", "displayName": "Checking"},
+                        "needsReview": True,
+                        "pending": False,
+                        "hideFromReports": False,
+                        "notes": "Test note",
+                        "tags": [{"id": "tag_1", "name": "Online"}],
+                    },
+                ]
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = get_transactions_needing_review(needs_review=True)
+
+        transactions = json.loads(result)
+        assert len(transactions) == 1
+        txn = transactions[0]
+        assert txn["id"] == "txn_1"
+        assert txn["merchant"] == "Amazon"
+        assert txn["original_name"] == "AMAZON.COM*1234"
+        assert txn["category"] == "Shopping"
+        assert txn["category_id"] == "cat_1"
+        assert txn["account"] == "Checking"
+        assert txn["account_id"] == "acc_1"
+        assert txn["notes"] == "Test note"
+        assert txn["is_pending"] is False
+        assert txn["hide_from_reports"] is False
+        assert len(txn["tags"]) == 1
+        assert txn["tags"][0]["name"] == "Online"
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_transactions_error(self, mock_get_client):
+        """Test error handling."""
+        mock_get_client.side_effect = RuntimeError("Auth needed")
+
+        result = get_transactions_needing_review()
+
+        assert "Error getting transactions" in result
+        assert "Auth needed" in result
+
+    @patch('monarch_mcp_server.server.get_monarch_client')
+    def test_get_transactions_empty(self, mock_get_client):
+        """Test when no transactions match criteria."""
+        mock_client = AsyncMock()
+        mock_client.get_transactions.return_value = {
+            "allTransactions": {"results": []}
+        }
+        mock_get_client.return_value = mock_client
+
+        result = get_transactions_needing_review()
+
+        transactions = json.loads(result)
+        assert len(transactions) == 0


### PR DESCRIPTION
This adds support for splitting transactions into multiple parts with different categories or merchants.

## Changes

Added two new tools:

- `get_transaction_splits` - View how a transaction has been divided into parts
- `split_transaction` - Split a single transaction into multiple parts with different categories or merchants

## Use Case

Split transactions are useful when a single purchase contains items from multiple budget categories. For example, splitting a Costco trip into groceries and household items, or separating a mixed Amazon order into different expense categories.

## Implementation

Uses the existing `get_transaction_splits` and `update_transaction_splits` methods from the monarchmoney library. The split amounts must sum to the original transaction amount.