### PR TITLE
Remove unnecessary BASE_URL monkey-patch

### DIFF
--- a/login_setup.py
+++ b/login_setup.py
@@ -18,10 +18,6 @@ src_path = Path(__file__).parent / "src"
 sys.path.insert(0, str(src_path))
 
 from monarchmoney import MonarchMoney, RequireMFAException
-from monarchmoney.monarchmoney import MonarchMoneyEndpoints
-
-# The monarchmoney library hardcodes the old API domain. Patch it to the current one.
-MonarchMoneyEndpoints.BASE_URL = "https://api.monarch.com"
 from dotenv import load_dotenv
 from monarch_mcp_server.secure_session import secure_session
 

--- a/src/monarch_mcp_server/__init__.py
+++ b/src/monarch_mcp_server/__init__.py
@@ -1,7 +1,3 @@
 """Monarch Money MCP Server."""
 
 __version__ = "0.1.0"
-
-# The monarchmoney library hardcodes the old API domain. Patch it to the current one.
-from monarchmoney.monarchmoney import MonarchMoneyEndpoints
-MonarchMoneyEndpoints.BASE_URL = "https://api.monarch.com"


### PR DESCRIPTION
## Summary
- Removes the `MonarchMoneyEndpoints.BASE_URL` monkey-patch from `__init__.py` and `login_setup.py`
- This was added in #36 to fix the old API domain, but is no longer needed since #37 switched to `monarchmoneycommunity` which already uses the correct `api.monarch.com` domain

## Test plan
- [ ] Verify `login_setup.py` still authenticates successfully
- [ ] Verify MCP server connects to Monarch API correctly