### PR TITLE
Fix get_budgets returning empty results

### DIFF
--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -247,31 +247,25 @@ def get_transactions(
 
 
 @mcp.tool()
-def get_budgets() -> str:
-    """Get budget information from Monarch Money."""
+def get_budgets(
+    start_date: Optional[str] = None, end_date: Optional[str] = None
+) -> str:
+    """Get budget information from Monarch Money.
+
+    Args:
+        start_date: Optional start date in YYYY-MM-DD format.
+        end_date: Optional end date in YYYY-MM-DD format.
+    """
     try:
 
         async def _get_budgets() -> Any:
             client = await get_monarch_client()
-            return await client.get_budgets()
+            return await client.get_budgets(
+                start_date=start_date, end_date=end_date
+            )
 
         budgets = run_async(_get_budgets())
-
-        # Format budgets for display
-        budget_list = []
-        for budget in budgets.get("budgets", []):
-            budget_info = {
-                "id": budget.get("id"),
-                "name": budget.get("name"),
-                "amount": budget.get("amount"),
-                "spent": budget.get("spent"),
-                "remaining": budget.get("remaining"),
-                "category": budget.get("category", {}).get("name"),
-                "period": budget.get("period"),
-            }
-            budget_list.append(budget_info)
-
-        return json.dumps(budget_list, indent=2, default=str)
+        return json.dumps(budgets, indent=2, default=str)
     except Exception as e:
         logger.error(f"Failed to get budgets: {e}")
         return f"Error getting budgets: {str(e)}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,135 @@
+"""Shared test fixtures for Monarch MCP Server tests."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_monarch_client():
+    """Create a mock MonarchMoney client with default responses."""
+    client = AsyncMock()
+
+    client.get_accounts.return_value = {
+        "accounts": [
+            {
+                "id": "acc-1",
+                "displayName": "Checking Account",
+                "name": "Checking",
+                "type": {"name": "checking"},
+                "currentBalance": 1500.00,
+                "institution": {"name": "Test Bank"},
+                "deactivatedAt": None,
+                "isHidden": False,
+            },
+            {
+                "id": "acc-2",
+                "displayName": "Savings Account",
+                "name": "Savings",
+                "type": {"name": "savings"},
+                "currentBalance": 10000.00,
+                "institution": {"name": "Test Bank"},
+                "deactivatedAt": None,
+                "isHidden": True,
+            },
+        ]
+    }
+
+    client.get_transactions.return_value = {
+        "allTransactions": {
+            "results": [
+                {
+                    "id": "txn-1",
+                    "date": "2026-03-01",
+                    "amount": -42.50,
+                    "description": "Grocery Store",
+                    "category": {"name": "Groceries"},
+                    "account": {"displayName": "Checking Account"},
+                    "merchant": {"name": "Whole Foods"},
+                    "isPending": False,
+                },
+                {
+                    "id": "txn-2",
+                    "date": "2026-03-02",
+                    "amount": 3000.00,
+                    "description": "Paycheck",
+                    "category": {"name": "Income"},
+                    "account": {"displayName": "Checking Account"},
+                    "merchant": None,
+                    "isPending": False,
+                },
+            ]
+        }
+    }
+
+    client.get_budgets.return_value = {
+        "budgetData": {
+            "monthlyAmountsByCategory": [
+                {
+                    "category": {"id": "cat-1", "name": "Groceries"},
+                    "monthlyAmounts": [
+                        {
+                            "month": "2026-03-01",
+                            "plannedCashFlowAmount": 500.00,
+                            "actualCashFlowAmount": 320.00,
+                        }
+                    ],
+                },
+                {
+                    "category": {"id": "cat-2", "name": "Dining Out"},
+                    "monthlyAmounts": [
+                        {
+                            "month": "2026-03-01",
+                            "plannedCashFlowAmount": 200.00,
+                            "actualCashFlowAmount": 185.00,
+                        }
+                    ],
+                },
+            ]
+        }
+    }
+
+    client.get_cashflow.return_value = {
+        "cashflow": {
+            "income": 5000.00,
+            "expenses": -3200.00,
+            "savings": 1800.00,
+        }
+    }
+
+    client.get_account_holdings.return_value = {
+        "holdings": [
+            {
+                "id": "hold-1",
+                "name": "VTI",
+                "quantity": 100,
+                "value": 25000.00,
+            }
+        ]
+    }
+
+    client.create_transaction.return_value = {
+        "createTransaction": {"transaction": {"id": "txn-new"}}
+    }
+
+    client.update_transaction.return_value = {
+        "updateTransaction": {"transaction": {"id": "txn-1"}}
+    }
+
+    client.request_accounts_refresh.return_value = {
+        "requestAccountsRefresh": {"success": True}
+    }
+
+    return client
+
+
+@pytest.fixture(autouse=True)
+def patch_monarch_client(mock_monarch_client):
+    """Automatically patch get_monarch_client for all tests."""
+    with patch(
+        "monarch_mcp_server.server.get_monarch_client",
+        new_callable=AsyncMock,
+        return_value=mock_monarch_client,
+    ):
+        yield mock_monarch_client

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,293 @@
+"""Tests for Monarch MCP Server tools."""
+
+import json
+from unittest.mock import AsyncMock
+
+from monarch_mcp_server.server import (
+    get_accounts,
+    get_transactions,
+    get_budgets,
+    get_cashflow,
+    get_account_holdings,
+    create_transaction,
+    update_transaction,
+    refresh_accounts,
+    check_auth_status,
+)
+
+
+class TestGetAccounts:
+    def test_returns_formatted_account_list(self):
+        result = json.loads(get_accounts())
+        assert len(result) == 2
+        assert result[0]["id"] == "acc-1"
+        assert result[0]["name"] == "Checking Account"
+        assert result[0]["type"] == "checking"
+        assert result[0]["balance"] == 1500.00
+        assert result[0]["institution"] == "Test Bank"
+        assert result[0]["is_active"] is True
+        assert result[0]["is_hidden"] is False
+
+    def test_hidden_account_flagged(self):
+        result = json.loads(get_accounts())
+        assert result[1]["is_hidden"] is True
+
+    def test_handles_null_type(self, mock_monarch_client):
+        mock_monarch_client.get_accounts.return_value = {
+            "accounts": [
+                {
+                    "id": "acc-3",
+                    "displayName": "Unknown",
+                    "type": None,
+                    "currentBalance": 0,
+                    "institution": None,
+                    "deactivatedAt": None,
+                    "isHidden": False,
+                }
+            ]
+        }
+        result = json.loads(get_accounts())
+        assert result[0]["type"] is None
+        assert result[0]["institution"] is None
+
+    def test_handles_empty_accounts(self, mock_monarch_client):
+        mock_monarch_client.get_accounts.return_value = {"accounts": []}
+        result = json.loads(get_accounts())
+        assert result == []
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.get_accounts.side_effect = Exception("API timeout")
+        result = get_accounts()
+        assert "Error getting accounts" in result
+        assert "API timeout" in result
+
+
+class TestGetTransactions:
+    def test_returns_formatted_transactions(self):
+        result = json.loads(get_transactions())
+        assert len(result) == 2
+        assert result[0]["id"] == "txn-1"
+        assert result[0]["amount"] == -42.50
+        assert result[0]["category"] == "Groceries"
+        assert result[0]["merchant"] == "Whole Foods"
+
+    def test_handles_null_merchant(self):
+        result = json.loads(get_transactions())
+        assert result[1]["merchant"] is None
+
+    def test_handles_null_category(self, mock_monarch_client):
+        mock_monarch_client.get_transactions.return_value = {
+            "allTransactions": {
+                "results": [
+                    {
+                        "id": "txn-3",
+                        "date": "2026-03-03",
+                        "amount": -10.00,
+                        "description": "ATM",
+                        "category": None,
+                        "account": {"displayName": "Checking"},
+                        "merchant": None,
+                        "isPending": True,
+                    }
+                ]
+            }
+        }
+        result = json.loads(get_transactions())
+        assert result[0]["category"] is None
+        assert result[0]["is_pending"] is True
+
+    def test_passes_filters_to_client(self, mock_monarch_client):
+        get_transactions(
+            limit=10, offset=5, start_date="2026-03-01", account_id="acc-1"
+        )
+        mock_monarch_client.get_transactions.assert_called_once_with(
+            limit=10,
+            offset=5,
+            start_date="2026-03-01",
+            account_id="acc-1",
+        )
+
+    def test_handles_empty_transactions(self, mock_monarch_client):
+        mock_monarch_client.get_transactions.return_value = {
+            "allTransactions": {"results": []}
+        }
+        result = json.loads(get_transactions())
+        assert result == []
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.get_transactions.side_effect = Exception("Auth expired")
+        result = get_transactions()
+        assert "Error getting transactions" in result
+
+
+class TestGetBudgets:
+    def test_returns_raw_budget_data(self):
+        result = json.loads(get_budgets())
+        assert "budgetData" in result
+        categories = result["budgetData"]["monthlyAmountsByCategory"]
+        assert len(categories) == 2
+        assert categories[0]["category"]["name"] == "Groceries"
+
+    def test_passes_date_params(self, mock_monarch_client):
+        get_budgets(start_date="2026-03-01", end_date="2026-03-31")
+        mock_monarch_client.get_budgets.assert_called_once_with(
+            start_date="2026-03-01", end_date="2026-03-31"
+        )
+
+    def test_passes_none_dates_by_default(self, mock_monarch_client):
+        get_budgets()
+        mock_monarch_client.get_budgets.assert_called_once_with(
+            start_date=None, end_date=None
+        )
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.get_budgets.side_effect = Exception("Budget error")
+        result = get_budgets()
+        assert "Error getting budgets" in result
+
+
+class TestGetCashflow:
+    def test_returns_cashflow_data(self):
+        result = json.loads(get_cashflow())
+        assert result["cashflow"]["income"] == 5000.00
+        assert result["cashflow"]["expenses"] == -3200.00
+
+    def test_passes_date_params(self, mock_monarch_client):
+        get_cashflow(start_date="2026-01-01", end_date="2026-01-31")
+        mock_monarch_client.get_cashflow.assert_called_once_with(
+            start_date="2026-01-01", end_date="2026-01-31"
+        )
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.get_cashflow.side_effect = Exception("Cashflow error")
+        result = get_cashflow()
+        assert "Error getting cashflow" in result
+
+
+class TestGetAccountHoldings:
+    def test_returns_holdings(self):
+        result = json.loads(get_account_holdings("acc-1"))
+        assert result["holdings"][0]["name"] == "VTI"
+        assert result["holdings"][0]["value"] == 25000.00
+
+    def test_passes_account_id(self, mock_monarch_client):
+        get_account_holdings("acc-99")
+        mock_monarch_client.get_account_holdings.assert_called_once_with("acc-99")
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.get_account_holdings.side_effect = Exception("Not found")
+        result = get_account_holdings("bad-id")
+        assert "Error getting account holdings" in result
+
+
+class TestCreateTransaction:
+    def test_creates_transaction(self):
+        result = json.loads(
+            create_transaction(
+                date="2026-03-15",
+                account_id="acc-1",
+                amount=-25.00,
+                merchant_name="Coffee Shop",
+                category_id="cat-1",
+            )
+        )
+        assert "createTransaction" in result
+
+    def test_passes_all_params(self, mock_monarch_client):
+        create_transaction(
+            date="2026-03-15",
+            account_id="acc-1",
+            amount=-25.00,
+            merchant_name="Coffee Shop",
+            category_id="cat-1",
+            notes="Morning coffee",
+            update_balance=True,
+        )
+        mock_monarch_client.create_transaction.assert_called_once_with(
+            date="2026-03-15",
+            account_id="acc-1",
+            amount=-25.00,
+            merchant_name="Coffee Shop",
+            category_id="cat-1",
+            notes="Morning coffee",
+            update_balance=True,
+        )
+
+    def test_omits_optional_params_when_not_set(self, mock_monarch_client):
+        create_transaction(
+            date="2026-03-15",
+            account_id="acc-1",
+            amount=-25.00,
+            merchant_name="Store",
+            category_id="cat-1",
+        )
+        mock_monarch_client.create_transaction.assert_called_once_with(
+            date="2026-03-15",
+            account_id="acc-1",
+            amount=-25.00,
+            merchant_name="Store",
+            category_id="cat-1",
+        )
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.create_transaction.side_effect = Exception("Bad request")
+        result = create_transaction(
+            date="2026-03-15",
+            account_id="acc-1",
+            amount=-25.00,
+            merchant_name="Store",
+            category_id="cat-1",
+        )
+        assert "Error creating transaction" in result
+
+
+class TestUpdateTransaction:
+    def test_updates_transaction(self):
+        result = json.loads(update_transaction("txn-1", category_id="cat-2"))
+        assert "updateTransaction" in result
+
+    def test_passes_only_provided_fields(self, mock_monarch_client):
+        update_transaction("txn-1", amount=99.99, notes="Updated")
+        mock_monarch_client.update_transaction.assert_called_once_with(
+            transaction_id="txn-1", amount=99.99, notes="Updated"
+        )
+
+    def test_passes_all_fields(self, mock_monarch_client):
+        update_transaction(
+            "txn-1",
+            category_id="cat-2",
+            merchant_name="New Merchant",
+            goal_id="goal-1",
+            amount=50.00,
+            date="2026-04-01",
+            hide_from_reports=True,
+            needs_review=False,
+            notes="All fields",
+        )
+        mock_monarch_client.update_transaction.assert_called_once_with(
+            transaction_id="txn-1",
+            category_id="cat-2",
+            merchant_name="New Merchant",
+            goal_id="goal-1",
+            amount=50.00,
+            date="2026-04-01",
+            hide_from_reports=True,
+            needs_review=False,
+            notes="All fields",
+        )
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.update_transaction.side_effect = Exception("Not found")
+        result = update_transaction("bad-id")
+        assert "Error updating transaction" in result
+
+
+class TestRefreshAccounts:
+    def test_refreshes_accounts(self):
+        result = json.loads(refresh_accounts())
+        assert result["requestAccountsRefresh"]["success"] is True
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.request_accounts_refresh.side_effect = Exception("Timeout")
+        result = refresh_accounts()
+        assert "Error refreshing accounts" in result


### PR DESCRIPTION
## Summary
- The `get_budgets` tool always returned an empty list because it parsed the API response using `.get("budgets", [])`, but the Monarch API returns data under `budgetData.monthlyAmountsByCategory`
- Fixed by returning the raw API response directly, which is more robust against future API changes
- Added `start_date` and `end_date` parameters to match the SDK's capabilities

Fixes #15