### PR TITLE
Add file-based token fallback for WSL/headless environments

### DIFF
--- a/src/monarch_mcp_server/secure_session.py
+++ b/src/monarch_mcp_server/secure_session.py
@@ -1,10 +1,14 @@
 """
-Secure session management for Monarch Money MCP Server using keyring.
+Secure session management for Monarch Money MCP Server.
+
+Uses the system keyring when available, with an automatic file-based
+fallback for environments without a keyring backend (e.g. WSL, headless Linux).
 """
 
-import keyring
 import logging
 import os
+import stat
+from pathlib import Path
 from typing import Optional
 from monarchmoney import MonarchMoney
 
@@ -14,50 +18,132 @@ logger = logging.getLogger(__name__)
 KEYRING_SERVICE = "com.mcp.monarch-mcp-server"
 KEYRING_USERNAME = "monarch-token"
 
+# File-based fallback location
+_TOKEN_DIR = Path.home() / ".monarch-mcp-server"
+_TOKEN_FILE = _TOKEN_DIR / "token"
+
+
+def _keyring_available() -> bool:
+    """Check whether a usable keyring backend is available."""
+    try:
+        import keyring
+        backend = keyring.get_keyring()
+        # The fail backend means no real backend was found
+        from keyrings.alt import file as _  # noqa: F401 – probe import
+        # If we get here, keyrings.alt is installed but may be the only option.
+        # Fall through and check the backend name.
+    except ImportError:
+        pass
+
+    try:
+        import keyring
+        backend = keyring.get_keyring()
+        backend_name = type(backend).__name__
+        # These backends indicate no real keyring is available
+        if backend_name in ("Keyring", "NullKeyring", "FailKeyring", "ChainerBackend"):
+            # ChainerBackend may wrap a real backend — try a round-trip test
+            if backend_name == "ChainerBackend":
+                try:
+                    keyring.set_password(KEYRING_SERVICE, "__probe__", "1")
+                    keyring.delete_password(KEYRING_SERVICE, "__probe__")
+                    return True
+                except Exception:
+                    return False
+            return False
+        return True
+    except Exception:
+        return False
+
 
 class SecureMonarchSession:
-    """Manages Monarch Money sessions securely using the system keyring."""
+    """Manages Monarch Money sessions securely using the system keyring,
+    falling back to a file-based store when no keyring backend is available."""
+
+    def __init__(self) -> None:
+        self._use_keyring = _keyring_available()
+        if self._use_keyring:
+            logger.info("🔐 Using system keyring for token storage")
+        else:
+            logger.info("🔐 Keyring unavailable — using file-based token storage")
+
+    # -- file-based helpers --------------------------------------------------
+
+    def _save_token_file(self, token: str) -> None:
+        _TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+        # Write with owner-only permissions
+        _TOKEN_FILE.write_text(token)
+        _TOKEN_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 600
+        _TOKEN_DIR.chmod(stat.S_IRWXU)  # 700
+        logger.info(f"✅ Token saved to {_TOKEN_FILE}")
+
+    def _load_token_file(self) -> Optional[str]:
+        if _TOKEN_FILE.is_file():
+            token = _TOKEN_FILE.read_text().strip()
+            if token:
+                logger.info(f"✅ Token loaded from {_TOKEN_FILE}")
+                return token
+        return None
+
+    def _delete_token_file(self) -> None:
+        if _TOKEN_FILE.is_file():
+            _TOKEN_FILE.unlink()
+            logger.info(f"🗑️ Token file deleted: {_TOKEN_FILE}")
+        # Remove directory if empty
+        if _TOKEN_DIR.is_dir() and not list(_TOKEN_DIR.iterdir()):
+            _TOKEN_DIR.rmdir()
+
+    # -- public API ----------------------------------------------------------
 
     def save_token(self, token: str) -> None:
-        """Save the authentication token to the system keyring."""
-        try:
-            keyring.set_password(KEYRING_SERVICE, KEYRING_USERNAME, token)
-            logger.info("✅ Token saved securely to keyring")
+        """Save the authentication token to the system keyring or file fallback."""
+        if self._use_keyring:
+            try:
+                import keyring
+                keyring.set_password(KEYRING_SERVICE, KEYRING_USERNAME, token)
+                logger.info("✅ Token saved securely to keyring")
+                self._cleanup_old_session_files()
+                return
+            except Exception as e:
+                logger.warning(f"⚠️  Keyring save failed, falling back to file: {e}")
 
-            # Clean up any old insecure files
-            self._cleanup_old_session_files()
-
-        except Exception as e:
-            logger.error(f"❌ Failed to save token to keyring: {e}")
-            raise
+        self._save_token_file(token)
+        self._cleanup_old_session_files()
 
     def load_token(self) -> Optional[str]:
-        """Load the authentication token from the system keyring."""
-        try:
-            token = keyring.get_password(KEYRING_SERVICE, KEYRING_USERNAME)
-            if token:
-                logger.info("✅ Token loaded from keyring")
-                return token
-            else:
-                logger.info("🔍 No token found in keyring")
-                return None
-        except Exception as e:
-            logger.error(f"❌ Failed to load token from keyring: {e}")
-            return None
+        """Load the authentication token from the system keyring or file fallback."""
+        if self._use_keyring:
+            try:
+                import keyring
+                token = keyring.get_password(KEYRING_SERVICE, KEYRING_USERNAME)
+                if token:
+                    logger.info("✅ Token loaded from keyring")
+                    return token
+                else:
+                    logger.info("🔍 No token found in keyring")
+                    return None
+            except Exception as e:
+                logger.warning(f"⚠️  Keyring load failed, trying file fallback: {e}")
+
+        token = self._load_token_file()
+        if token:
+            return token
+        logger.info("🔍 No token found")
+        return None
 
     def delete_token(self) -> None:
-        """Delete the authentication token from the system keyring."""
-        try:
-            keyring.delete_password(KEYRING_SERVICE, KEYRING_USERNAME)
-            logger.info("🗑️ Token deleted from keyring")
+        """Delete the authentication token from all storage backends."""
+        # Try keyring
+        if self._use_keyring:
+            try:
+                import keyring
+                keyring.delete_password(KEYRING_SERVICE, KEYRING_USERNAME)
+                logger.info("🗑️ Token deleted from keyring")
+            except Exception:
+                pass
 
-            # Also clean up any old insecure files
-            self._cleanup_old_session_files()
-
-        except keyring.errors.PasswordDeleteError:
-            logger.info("🔍 No token found in keyring to delete")
-        except Exception as e:
-            logger.error(f"❌ Failed to delete token from keyring: {e}")
+        # Always try file cleanup too
+        self._delete_token_file()
+        self._cleanup_old_session_files()
 
     def get_authenticated_client(self) -> Optional[MonarchMoney]:
         """Get an authenticated MonarchMoney client."""


### PR DESCRIPTION
## Summary
- Adds automatic detection of whether a usable keyring backend is available at startup
- Falls back to file-based token storage (`~/.monarch-mcp-server/token` with `chmod 600`) when no keyring backend is found (e.g. WSL, headless Linux, containers)
- Existing keyring behavior on macOS and desktop Linux is completely unchanged

## Context
On WSL and headless Linux, `login_setup.py` succeeds at authentication but fails when saving the session because no keyring backend is installed. This makes the MCP server unusable in those environments without manual workarounds.

## Test plan
- [x] All 31 existing tests pass
- [x] Verified `_keyring_available()` returns `False` on WSL
- [x] Verified `login_setup.py` saves session successfully via file fallback on WSL
- [x] MCP server loads the saved token and connects in Claude Desktop (via `wsl.exe`)