### PR TITLE
Add transaction tagging and categorizing tools

### DIFF
--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -436,6 +436,132 @@ def update_transaction(
 
 
 @mcp.tool()
+def get_transaction_categories() -> str:
+    """Get all available transaction categories from Monarch Money."""
+    try:
+
+        async def _get() -> Any:
+            client = await get_monarch_client()
+            return await client.get_transaction_categories()
+
+        data = run_async(_get())
+
+        categories = []
+        for cat in data.get("categories", []):
+            group = cat.get("group") or {}
+            categories.append(
+                {
+                    "id": cat.get("id"),
+                    "name": cat.get("name"),
+                    "icon": cat.get("icon"),
+                    "group": group.get("name") if isinstance(group, dict) else None,
+                    "group_id": group.get("id") if isinstance(group, dict) else None,
+                }
+            )
+        return json.dumps(categories, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Failed to get transaction categories: {e}")
+        return f"Error getting transaction categories: {str(e)}"
+
+
+@mcp.tool()
+def get_transaction_tags() -> str:
+    """Get all available transaction tags from Monarch Money."""
+    try:
+
+        async def _get() -> Any:
+            client = await get_monarch_client()
+            return await client.get_transaction_tags()
+
+        data = run_async(_get())
+
+        # The library returns tags under "householdTransactionTags"
+        raw_tags = data.get("householdTransactionTags") or data.get("tags") or []
+        tags = [
+            {
+                "id": t.get("id"),
+                "name": t.get("name"),
+                "color": t.get("color"),
+            }
+            for t in raw_tags
+        ]
+        return json.dumps(tags, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Failed to get transaction tags: {e}")
+        return f"Error getting transaction tags: {str(e)}"
+
+
+@mcp.tool()
+def set_transaction_tags(transaction_id: str, tag_ids: list[str]) -> str:
+    """
+    Set the tags on a transaction (replaces existing tags).
+
+    Args:
+        transaction_id: The ID of the transaction to tag
+        tag_ids: List of tag IDs to assign. Pass [] to clear all tags.
+    """
+    try:
+
+        async def _set() -> Any:
+            client = await get_monarch_client()
+            return await client.set_transaction_tags(
+                transaction_id=transaction_id, tag_ids=tag_ids
+            )
+
+        result = run_async(_set())
+        return json.dumps(result, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Failed to set transaction tags: {e}")
+        return f"Error setting transaction tags: {str(e)}"
+
+
+@mcp.tool()
+def create_transaction_tag(name: str, color: str) -> str:
+    """
+    Create a new transaction tag.
+
+    Args:
+        name: Name of the new tag
+        color: Hex color code for the tag (e.g. "#ff0000")
+    """
+    try:
+
+        async def _create() -> Any:
+            client = await get_monarch_client()
+            return await client.create_transaction_tag(name=name, color=color)
+
+        result = run_async(_create())
+        return json.dumps(result, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Failed to create transaction tag: {e}")
+        return f"Error creating transaction tag: {str(e)}"
+
+
+@mcp.tool()
+def categorize_transaction(transaction_id: str, category_id: str) -> str:
+    """
+    Assign a category to a transaction.
+
+    Args:
+        transaction_id: The ID of the transaction to categorize
+        category_id: The category ID to assign
+    """
+    try:
+
+        async def _categorize() -> Any:
+            client = await get_monarch_client()
+            return await client.update_transaction(
+                transaction_id=transaction_id, category_id=category_id
+            )
+
+        result = run_async(_categorize())
+        return json.dumps(result, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Failed to categorize transaction: {e}")
+        return f"Error categorizing transaction: {str(e)}"
+
+
+@mcp.tool()
 def refresh_accounts() -> str:
     """Request account data refresh from financial institutions."""
     try:

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -465,6 +465,67 @@ def get_transaction_categories() -> str:
 
 
 @mcp.tool()
+def get_transaction_category_groups() -> str:
+    """Get all transaction category groups (parent groupings for categories)."""
+    try:
+
+        async def _get() -> Any:
+            client = await get_monarch_client()
+            return await client.get_transaction_category_groups()
+
+        data = run_async(_get())
+        groups = [
+            {"id": g.get("id"), "name": g.get("name"), "type": g.get("type")}
+            for g in data.get("categoryGroups", [])
+        ]
+        return json.dumps(groups, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Failed to get transaction category groups: {e}")
+        return f"Error getting transaction category groups: {str(e)}"
+
+
+@mcp.tool()
+def create_transaction_category(
+    group_id: str,
+    transaction_category_name: str,
+    icon: Optional[str] = None,
+    rollover_enabled: Optional[bool] = None,
+    rollover_type: Optional[str] = None,
+) -> str:
+    """
+    Create a new transaction category.
+
+    Args:
+        group_id: The category group ID this category belongs to
+        transaction_category_name: Name of the new category
+        icon: Optional emoji icon for the category
+        rollover_enabled: Optional, whether budget rollover is enabled
+        rollover_type: Optional rollover type (e.g. "monthly")
+    """
+    try:
+
+        async def _create() -> Any:
+            client = await get_monarch_client()
+            kwargs: Dict[str, Any] = {
+                "group_id": group_id,
+                "transaction_category_name": transaction_category_name,
+            }
+            if icon is not None:
+                kwargs["icon"] = icon
+            if rollover_enabled is not None:
+                kwargs["rollover_enabled"] = rollover_enabled
+            if rollover_type is not None:
+                kwargs["rollover_type"] = rollover_type
+            return await client.create_transaction_category(**kwargs)
+
+        result = run_async(_create())
+        return json.dumps(result, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Failed to create transaction category: {e}")
+        return f"Error creating transaction category: {str(e)}"
+
+
+@mcp.tool()
 def get_transaction_tags() -> str:
     """Get all available transaction tags from Monarch Money."""
     try:

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -577,6 +577,35 @@ def set_transaction_tags(transaction_id: str, tag_ids: list[str]) -> str:
 
 
 @mcp.tool()
+def add_transaction_tag(transaction_id: str, tag_id: str) -> str:
+    """
+    Add a tag to a transaction, preserving any tags already on it.
+
+    Args:
+        transaction_id: The ID of the transaction
+        tag_id: The tag ID to add
+    """
+    try:
+
+        async def _add() -> Any:
+            client = await get_monarch_client()
+            details = await client.get_transaction_details(transaction_id)
+            txn = details.get("getTransaction") or {}
+            existing = [t.get("id") for t in (txn.get("tags") or []) if t.get("id")]
+            if tag_id not in existing:
+                existing.append(tag_id)
+            return await client.set_transaction_tags(
+                transaction_id=transaction_id, tag_ids=existing
+            )
+
+        result = run_async(_add())
+        return json.dumps(result, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Failed to add transaction tag: {e}")
+        return f"Error adding transaction tag: {str(e)}"
+
+
+@mcp.tool()
 def create_transaction_tag(name: str, color: str) -> str:
     """
     Create a new transaction tag.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,38 @@ def mock_monarch_client():
         "requestAccountsRefresh": {"success": True}
     }
 
+    client.get_transaction_categories.return_value = {
+        "categories": [
+            {
+                "id": "cat-1",
+                "name": "Groceries",
+                "icon": "🛒",
+                "group": {"id": "grp-1", "name": "Food"},
+            },
+            {
+                "id": "cat-2",
+                "name": "Dining Out",
+                "icon": "🍽️",
+                "group": {"id": "grp-1", "name": "Food"},
+            },
+        ]
+    }
+
+    client.get_transaction_tags.return_value = {
+        "householdTransactionTags": [
+            {"id": "tag-1", "name": "business", "color": "#ff0000"},
+            {"id": "tag-2", "name": "vacation", "color": "#00ff00"},
+        ]
+    }
+
+    client.set_transaction_tags.return_value = {
+        "setTransactionTags": {"transaction": {"id": "txn-1"}}
+    }
+
+    client.create_transaction_tag.return_value = {
+        "createTransactionTag": {"tag": {"id": "tag-new", "name": "new", "color": "#0000ff"}}
+    }
+
     return client
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,17 @@ def mock_monarch_client():
         "setTransactionTags": {"transaction": {"id": "txn-1"}}
     }
 
+    client.get_transaction_category_groups.return_value = {
+        "categoryGroups": [
+            {"id": "grp-1", "name": "Food", "type": "expense"},
+            {"id": "grp-2", "name": "Income", "type": "income"},
+        ]
+    }
+
+    client.create_transaction_category.return_value = {
+        "createCategory": {"category": {"id": "cat-new", "name": "Coffee"}}
+    }
+
     client.create_transaction_tag.return_value = {
         "createTransactionTag": {"tag": {"id": "tag-new", "name": "new", "color": "#0000ff"}}
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,6 +145,13 @@ def mock_monarch_client():
         ]
     }
 
+    client.get_transaction_details.return_value = {
+        "getTransaction": {
+            "id": "txn-1",
+            "tags": [{"id": "tag-1", "name": "business"}],
+        }
+    }
+
     client.set_transaction_tags.return_value = {
         "setTransactionTags": {"transaction": {"id": "txn-1"}}
     }

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,6 +13,11 @@ from monarch_mcp_server.server import (
     update_transaction,
     refresh_accounts,
     check_auth_status,
+    get_transaction_categories,
+    get_transaction_tags,
+    set_transaction_tags,
+    create_transaction_tag,
+    categorize_transaction,
 )
 
 
@@ -280,6 +285,82 @@ class TestUpdateTransaction:
         mock_monarch_client.update_transaction.side_effect = Exception("Not found")
         result = update_transaction("bad-id")
         assert "Error updating transaction" in result
+
+
+class TestGetTransactionCategories:
+    def test_returns_categories(self):
+        result = json.loads(get_transaction_categories())
+        assert len(result) == 2
+        assert result[0]["id"] == "cat-1"
+        assert result[0]["name"] == "Groceries"
+        assert result[0]["group"] == "Food"
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.get_transaction_categories.side_effect = Exception("boom")
+        result = get_transaction_categories()
+        assert "Error getting transaction categories" in result
+
+
+class TestGetTransactionTags:
+    def test_returns_tags(self):
+        result = json.loads(get_transaction_tags())
+        assert len(result) == 2
+        assert result[0]["id"] == "tag-1"
+        assert result[0]["name"] == "business"
+        assert result[0]["color"] == "#ff0000"
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.get_transaction_tags.side_effect = Exception("boom")
+        result = get_transaction_tags()
+        assert "Error getting transaction tags" in result
+
+
+class TestSetTransactionTags:
+    def test_sets_tags(self):
+        result = json.loads(set_transaction_tags("txn-1", ["tag-1", "tag-2"]))
+        assert "setTransactionTags" in result
+
+    def test_passes_args(self, mock_monarch_client):
+        set_transaction_tags("txn-1", ["tag-1"])
+        mock_monarch_client.set_transaction_tags.assert_called_once_with(
+            transaction_id="txn-1", tag_ids=["tag-1"]
+        )
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.set_transaction_tags.side_effect = Exception("boom")
+        result = set_transaction_tags("txn-1", [])
+        assert "Error setting transaction tags" in result
+
+
+class TestCreateTransactionTag:
+    def test_creates_tag(self):
+        result = json.loads(create_transaction_tag("new", "#0000ff"))
+        assert "createTransactionTag" in result
+
+    def test_passes_args(self, mock_monarch_client):
+        create_transaction_tag("vacation", "#00ff00")
+        mock_monarch_client.create_transaction_tag.assert_called_once_with(
+            name="vacation", color="#00ff00"
+        )
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.create_transaction_tag.side_effect = Exception("boom")
+        result = create_transaction_tag("x", "#fff")
+        assert "Error creating transaction tag" in result
+
+
+class TestCategorizeTransaction:
+    def test_categorizes(self, mock_monarch_client):
+        result = json.loads(categorize_transaction("txn-1", "cat-2"))
+        assert "updateTransaction" in result
+        mock_monarch_client.update_transaction.assert_called_once_with(
+            transaction_id="txn-1", category_id="cat-2"
+        )
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.update_transaction.side_effect = Exception("boom")
+        result = categorize_transaction("txn-1", "cat-2")
+        assert "Error categorizing transaction" in result
 
 
 class TestRefreshAccounts:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -20,6 +20,7 @@ from monarch_mcp_server.server import (
     categorize_transaction,
     get_transaction_category_groups,
     create_transaction_category,
+    add_transaction_tag,
 )
 
 
@@ -406,6 +407,35 @@ class TestCreateTransactionCategory:
         mock_monarch_client.create_transaction_category.side_effect = Exception("boom")
         result = create_transaction_category("grp-1", "Coffee")
         assert "Error creating transaction category" in result
+
+
+class TestAddTransactionTag:
+    def test_appends_to_existing_tags(self, mock_monarch_client):
+        result = json.loads(add_transaction_tag("txn-1", "tag-2"))
+        assert "setTransactionTags" in result
+        mock_monarch_client.set_transaction_tags.assert_called_once_with(
+            transaction_id="txn-1", tag_ids=["tag-1", "tag-2"]
+        )
+
+    def test_no_duplicate_when_already_present(self, mock_monarch_client):
+        add_transaction_tag("txn-1", "tag-1")
+        mock_monarch_client.set_transaction_tags.assert_called_once_with(
+            transaction_id="txn-1", tag_ids=["tag-1"]
+        )
+
+    def test_handles_no_existing_tags(self, mock_monarch_client):
+        mock_monarch_client.get_transaction_details.return_value = {
+            "getTransaction": {"id": "txn-1", "tags": []}
+        }
+        add_transaction_tag("txn-1", "tag-2")
+        mock_monarch_client.set_transaction_tags.assert_called_once_with(
+            transaction_id="txn-1", tag_ids=["tag-2"]
+        )
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.get_transaction_details.side_effect = Exception("boom")
+        result = add_transaction_tag("txn-1", "tag-2")
+        assert "Error adding transaction tag" in result
 
 
 class TestRefreshAccounts:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -18,6 +18,8 @@ from monarch_mcp_server.server import (
     set_transaction_tags,
     create_transaction_tag,
     categorize_transaction,
+    get_transaction_category_groups,
+    create_transaction_category,
 )
 
 
@@ -361,6 +363,49 @@ class TestCategorizeTransaction:
         mock_monarch_client.update_transaction.side_effect = Exception("boom")
         result = categorize_transaction("txn-1", "cat-2")
         assert "Error categorizing transaction" in result
+
+
+class TestGetTransactionCategoryGroups:
+    def test_returns_groups(self):
+        result = json.loads(get_transaction_category_groups())
+        assert len(result) == 2
+        assert result[0]["id"] == "grp-1"
+        assert result[0]["name"] == "Food"
+        assert result[0]["type"] == "expense"
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.get_transaction_category_groups.side_effect = Exception("boom")
+        result = get_transaction_category_groups()
+        assert "Error getting transaction category groups" in result
+
+
+class TestCreateTransactionCategory:
+    def test_creates_category(self):
+        result = json.loads(create_transaction_category("grp-1", "Coffee"))
+        assert "createCategory" in result
+
+    def test_passes_required_args(self, mock_monarch_client):
+        create_transaction_category("grp-1", "Coffee")
+        mock_monarch_client.create_transaction_category.assert_called_once_with(
+            group_id="grp-1", transaction_category_name="Coffee"
+        )
+
+    def test_passes_optional_args(self, mock_monarch_client):
+        create_transaction_category(
+            "grp-1", "Coffee", icon="☕", rollover_enabled=True, rollover_type="monthly"
+        )
+        mock_monarch_client.create_transaction_category.assert_called_once_with(
+            group_id="grp-1",
+            transaction_category_name="Coffee",
+            icon="☕",
+            rollover_enabled=True,
+            rollover_type="monthly",
+        )
+
+    def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.create_transaction_category.side_effect = Exception("boom")
+        result = create_transaction_category("grp-1", "Coffee")
+        assert "Error creating transaction category" in result
 
 
 class TestRefreshAccounts:


### PR DESCRIPTION
## Summary
- Adds 8 new MCP tools for tagging, categorizing, and managing categories/tags:
  - `get_transaction_categories` — list all categories
  - `get_transaction_category_groups` — list category groups (parents)
  - `create_transaction_category` — create a new category under a group
  - `get_transaction_tags` — list all tags
  - `create_transaction_tag` — create a new tag
  - `set_transaction_tags` — set tags on a transaction (replaces existing)
  - `add_transaction_tag` — add a tag to a transaction, preserving existing tags
  - `categorize_transaction` — assign a category to a transaction
- Developed via TDD; 22 new tests added (53 total, all passing)

## Test plan
- [x] `uv run -m pytest tests/test_tools.py` — 53 passed
- [ ] Manual smoke test against a real Monarch account: list categories/tags, create one of each, tag and categorize a single transaction, verify in the Monarch web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)