### PR TITLE
Add elicitation-based login tools

### DIFF
--- a/src/monarch_mcp_server/auth.py
+++ b/src/monarch_mcp_server/auth.py
@@ -1,0 +1,81 @@
+"""Interactive authentication for the Monarch Money MCP server.
+
+Uses MCP elicitation so credentials flow client-UI → server directly over
+the protocol — they never appear in tool arguments or the model's context.
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import Context
+from monarchmoney import MonarchMoney, RequireMFAException
+from pydantic import BaseModel, Field
+
+from monarch_mcp_server.secure_session import secure_session
+
+
+class LoginForm(BaseModel):
+    email: str = Field(description="Monarch Money email address")
+    password: str = Field(description="Monarch Money password")
+
+
+class MFAForm(BaseModel):
+    mfa_code: str = Field(description="Monarch Money MFA code")
+
+
+class TokenForm(BaseModel):
+    token: str = Field(
+        description=(
+            "Monarch Money session token. Grab it from browser DevTools → "
+            "Application → Local Storage for app.monarchmoney.com, key 'token'."
+        ),
+    )
+
+
+async def login_interactive(ctx: Context) -> str:
+    form_result = await ctx.elicit(message="Sign in to Monarch Money.", schema=LoginForm)
+    if form_result.action != "accept":
+        return "Login cancelled."
+    form = form_result.data
+
+    mm = MonarchMoney()
+    try:
+        await mm.login(
+            form.email,
+            form.password,
+            use_saved_session=False,
+            save_session=False,
+        )
+    except RequireMFAException:
+        mfa_result = await ctx.elicit(
+            message="Enter your Monarch Money MFA code.", schema=MFAForm
+        )
+        if mfa_result.action != "accept":
+            return "Login cancelled."
+        await mm.multi_factor_authenticate(
+            form.email, form.password, mfa_result.data.mfa_code
+        )
+
+    secure_session.save_authenticated_session(mm)
+    return "Logged in. Session saved to system keyring."
+
+
+async def login_with_token_interactive(ctx: Context) -> str:
+    form_result = await ctx.elicit(
+        message="Paste your Monarch Money session token.", schema=TokenForm
+    )
+    if form_result.action != "accept":
+        return "Login cancelled."
+
+    token = form_result.data.token.strip()
+    if not token:
+        return "Empty token — aborting."
+
+    mm = MonarchMoney(token=token)
+    await mm.get_subscription_details()
+    secure_session.save_token(token)
+    return "Session token saved to system keyring."
+
+
+async def logout() -> str:
+    secure_session.delete_token()
+    return "Cleared stored Monarch session."

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -8,10 +8,11 @@ import json
 from concurrent.futures import ThreadPoolExecutor
 
 from dotenv import load_dotenv
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
 import mcp.types as types
 from monarchmoney import MonarchMoney, RequireMFAException  # type: ignore
 from pydantic import BaseModel, Field
+from monarch_mcp_server import auth
 from monarch_mcp_server.secure_session import secure_session
 
 # Configure logging
@@ -146,6 +147,33 @@ def debug_session_loading() -> str:
 
         error_details = traceback.format_exc()
         return f"❌ Keyring access failed:\nError: {str(e)}\nType: {type(e)}\nTraceback:\n{error_details}"
+
+
+@mcp.tool()
+async def monarch_login(ctx: Context) -> str:
+    """Sign in to Monarch Money.
+
+    Opens a secure form in the client UI to collect email, password, and
+    (if required) an MFA code. Credentials never pass through the model —
+    they flow client-UI → server directly via the MCP protocol.
+    """
+    return await auth.login_interactive(ctx)
+
+
+@mcp.tool()
+async def monarch_login_with_token(ctx: Context) -> str:
+    """Sign in to Monarch Money using a browser-copied session token.
+
+    Useful for SSO users who can't use password login. Grab the token from
+    browser DevTools → Application → Local Storage → app.monarchmoney.com.
+    """
+    return await auth.login_with_token_interactive(ctx)
+
+
+@mcp.tool()
+async def monarch_logout() -> str:
+    """Clear the stored Monarch Money session from the system keyring."""
+    return await auth.logout()
 
 
 @mcp.tool()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,110 @@
+"""Tests for elicitation-based auth tools."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from monarchmoney import RequireMFAException
+
+from monarch_mcp_server import auth
+
+
+def make_ctx(*elicit_results):
+    """Build a mock Context whose elicit() returns the given results in order."""
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(side_effect=list(elicit_results))
+    return ctx
+
+
+def accept(**fields):
+    return SimpleNamespace(action="accept", data=SimpleNamespace(**fields))
+
+
+def cancel():
+    return SimpleNamespace(action="cancel", data=None)
+
+
+@pytest.fixture(autouse=True)
+def no_session_save():
+    """Prevent real keyring writes during auth tests."""
+    with patch("monarch_mcp_server.auth.secure_session") as mock:
+        yield mock
+
+
+class TestLoginInteractive:
+    def test_happy_path_no_mfa(self, no_session_save):
+        mm = AsyncMock()
+        with patch("monarch_mcp_server.auth.MonarchMoney", return_value=mm):
+            ctx = make_ctx(accept(email="a@b.com", password="pw"))
+            result = asyncio.run(auth.login_interactive(ctx))
+        assert "Logged in" in result
+        mm.login.assert_awaited_once()
+        no_session_save.save_authenticated_session.assert_called_once_with(mm)
+
+    def test_mfa_required(self, no_session_save):
+        mm = AsyncMock()
+        mm.login.side_effect = RequireMFAException("mfa")
+        with patch("monarch_mcp_server.auth.MonarchMoney", return_value=mm):
+            ctx = make_ctx(
+                accept(email="a@b.com", password="pw"),
+                accept(mfa_code="123456"),
+            )
+            result = asyncio.run(auth.login_interactive(ctx))
+        assert "Logged in" in result
+        mm.multi_factor_authenticate.assert_awaited_once_with(
+            "a@b.com", "pw", "123456"
+        )
+        no_session_save.save_authenticated_session.assert_called_once_with(mm)
+
+    def test_user_cancels_initial_form(self, no_session_save):
+        ctx = make_ctx(cancel())
+        result = asyncio.run(auth.login_interactive(ctx))
+        assert result == "Login cancelled."
+        no_session_save.save_authenticated_session.assert_not_called()
+
+    def test_user_cancels_mfa(self, no_session_save):
+        mm = AsyncMock()
+        mm.login.side_effect = RequireMFAException("mfa")
+        with patch("monarch_mcp_server.auth.MonarchMoney", return_value=mm):
+            ctx = make_ctx(accept(email="a@b.com", password="pw"), cancel())
+            result = asyncio.run(auth.login_interactive(ctx))
+        assert result == "Login cancelled."
+        no_session_save.save_authenticated_session.assert_not_called()
+
+
+class TestLoginWithTokenInteractive:
+    def test_happy_path(self, no_session_save):
+        mm = AsyncMock()
+        with patch("monarch_mcp_server.auth.MonarchMoney", return_value=mm):
+            ctx = make_ctx(accept(token="raw-token"))
+            result = asyncio.run(auth.login_with_token_interactive(ctx))
+        assert "saved" in result.lower()
+        mm.get_subscription_details.assert_awaited_once()
+        no_session_save.save_token.assert_called_once_with("raw-token")
+
+    def test_strips_whitespace(self, no_session_save):
+        mm = AsyncMock()
+        with patch("monarch_mcp_server.auth.MonarchMoney", return_value=mm):
+            ctx = make_ctx(accept(token="  token-with-spaces  "))
+            asyncio.run(auth.login_with_token_interactive(ctx))
+        no_session_save.save_token.assert_called_once_with("token-with-spaces")
+
+    def test_empty_token_rejected(self, no_session_save):
+        ctx = make_ctx(accept(token="   "))
+        result = asyncio.run(auth.login_with_token_interactive(ctx))
+        assert "Empty" in result
+        no_session_save.save_token.assert_not_called()
+
+    def test_user_cancels(self, no_session_save):
+        ctx = make_ctx(cancel())
+        result = asyncio.run(auth.login_with_token_interactive(ctx))
+        assert result == "Login cancelled."
+        no_session_save.save_token.assert_not_called()
+
+
+class TestLogout:
+    def test_clears_session(self, no_session_save):
+        result = asyncio.run(auth.logout())
+        assert "Cleared" in result
+        no_session_save.delete_token.assert_called_once()


### PR DESCRIPTION
Thanks @darrenhaas for the suggestion in #44 — credit to him for the design and the original implementation sketch.

## Summary
- Adds three new tools that use MCP elicitation to collect credentials directly from the client UI, so they never pass through the model's context as tool arguments:
  - \`monarch_login\` — email + password, with MFA re-prompt when required
  - \`monarch_login_with_token\` — paste a browser-copied session token (SSO users)
  - \`monarch_logout\` — clear the stored session from the keyring
- Existing auth paths (env vars, \`login_setup.py\`, keyring session loading) are preserved unchanged — this PR is purely additive.
- 9 new tests in \`tests/test_auth.py\` covering happy paths, MFA flow, user-cancellation at each elicitation step, token whitespace stripping, and empty-token rejection.

Closes #44

## Test plan
- [x] \`uv run --extra dev pytest tests/\` — all 68 tests pass (59 existing + 9 new)
- [ ] Manual: invoke \`monarch_login\` from Claude Code, complete the form, confirm session is saved to keyring
- [ ] Manual: invoke \`monarch_login_with_token\` with a real token, confirm it authenticates
- [ ] Manual: invoke \`monarch_logout\`, confirm \`check_auth_status\` then reports no session