### PR TITLE
Fix get_account_balance_history and add upload tool

### DIFF
--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -24,6 +24,7 @@ from monarch_mcp_server.tools.accounts import (  # noqa: F401
     refresh_accounts,
     get_account_holdings,
     get_account_balance_history,
+    upload_account_balance_history,
 )
 from monarch_mcp_server.tools.transactions import (  # noqa: F401
     get_transactions,

--- a/src/monarch_mcp_server/tools/accounts.py
+++ b/src/monarch_mcp_server/tools/accounts.py
@@ -1,6 +1,8 @@
 """Account management tools."""
 
+import json
 import logging
+from datetime import datetime
 from typing import Optional
 
 from monarch_mcp_server.app import mcp
@@ -83,9 +85,7 @@ async def get_account_balance_history(account_id: str) -> str:
     """
     try:
         client = await get_monarch_client()
-        result = await client.get_account_history(account_id=int(account_id))
-
-        snapshots = result.get("accountSnapshotHistory", {}).get("snapshots", [])
+        snapshots = await client.get_account_history(account_id=int(account_id))
 
         formatted = {
             "account_id": account_id,
@@ -111,3 +111,58 @@ async def get_account_balance_history(account_id: str) -> str:
         return json_success(formatted)
     except Exception as e:
         return json_error("get_account_balance_history", e)
+
+
+@mcp.tool()
+async def upload_account_balance_history(account_id: str, corrections: str) -> str:
+    """
+    Upload corrected balance snapshots for an account.
+
+    Fetches the full existing balance history, applies the corrections,
+    and re-uploads the complete history.
+
+    Args:
+        account_id: The ID of the account to correct
+        corrections: JSON object mapping dates to corrected balances,
+                     e.g. '{"2026-04-23": 24846.45, "2026-04-24": 24846.45}'
+    """
+    try:
+        from monarchmoney.monarchmoney import BalanceHistoryRow
+
+        date_to_balance = json.loads(corrections)
+
+        client = await get_monarch_client()
+        snapshots = await client.get_account_history(account_id=int(account_id))
+
+        applied = []
+        rows = []
+        for snapshot in snapshots:
+            date_str = snapshot.get("date")
+            balance = snapshot.get("signedBalance", 0)
+            account_name = snapshot.get("accountName", "")
+
+            if date_str in date_to_balance:
+                balance = date_to_balance[date_str]
+                applied.append(date_str)
+
+            rows.append(BalanceHistoryRow(
+                date=datetime.strptime(date_str, "%Y-%m-%d"),
+                amount=balance,
+                account_name=account_name,
+            ))
+
+        if not applied:
+            return json_success({"updated": False, "message": "No matching dates found in history"})
+
+        result = await client.upload_account_balance_history(
+            account_id=account_id,
+            csv_content=rows,
+        )
+
+        return json_success({
+            "updated": result,
+            "dates_corrected": applied,
+            "total_snapshots": len(rows),
+        })
+    except Exception as e:
+        return json_error("upload_account_balance_history", e)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,6 +193,14 @@ def mock_monarch_client():
         "createTransactionTag": {"tag": {"id": "tag-new", "name": "new", "color": "#0000ff"}}
     }
 
+    client.get_account_history.return_value = [
+        {"date": "2026-04-20", "signedBalance": 1000.0, "accountId": "acc-1", "accountName": "Checking Account"},
+        {"date": "2026-04-21", "signedBalance": 1200.0, "accountId": "acc-1", "accountName": "Checking Account"},
+        {"date": "2026-04-22", "signedBalance": 1100.0, "accountId": "acc-1", "accountName": "Checking Account"},
+    ]
+
+    client.upload_account_balance_history.return_value = True
+
     return client
 
 

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -6,6 +6,8 @@ from monarch_mcp_server.tools.accounts import (
     get_accounts,
     get_account_holdings,
     refresh_accounts,
+    get_account_balance_history,
+    upload_account_balance_history,
 )
 
 
@@ -80,3 +82,50 @@ class TestRefreshAccounts:
         mock_monarch_client.request_accounts_refresh.side_effect = Exception("Timeout")
         result = await refresh_accounts()
         assert "refresh_accounts" in result
+
+
+class TestGetAccountBalanceHistory:
+    async def test_returns_formatted_snapshots(self):
+        result = json.loads(await get_account_balance_history("12345"))
+        assert result["account_id"] == "12345"
+        assert result["snapshot_count"] == 3
+        assert result["current_balance"] == 1100.0
+        assert result["earliest_balance"] == 1000.0
+        assert result["highest"] == 1200.0
+        assert result["lowest"] == 1000.0
+        assert result["snapshots"][0] == {"date": "2026-04-20", "balance": 1000.0}
+
+    async def test_handles_empty_history(self, mock_monarch_client):
+        mock_monarch_client.get_account_history.return_value = []
+        result = json.loads(await get_account_balance_history("12345"))
+        assert result["snapshot_count"] == 0
+        assert result["snapshots"] == []
+
+    async def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.get_account_history.side_effect = Exception("Not found")
+        result = await get_account_balance_history("12345")
+        assert "get_account_balance_history" in result
+
+
+class TestUploadAccountBalanceHistory:
+    async def test_applies_corrections(self, mock_monarch_client):
+        corrections = json.dumps({"2026-04-21": 900.0})
+        result = json.loads(await upload_account_balance_history("12345", corrections))
+        assert result["updated"] is True
+        assert result["dates_corrected"] == ["2026-04-21"]
+        assert result["total_snapshots"] == 3
+
+        call_args = mock_monarch_client.upload_account_balance_history.call_args
+        assert call_args.kwargs["account_id"] == "12345"
+        assert len(call_args.kwargs["csv_content"]) == 3
+
+    async def test_no_matching_dates(self, mock_monarch_client):
+        corrections = json.dumps({"2026-01-01": 500.0})
+        result = json.loads(await upload_account_balance_history("12345", corrections))
+        assert result["updated"] is False
+        mock_monarch_client.upload_account_balance_history.assert_not_called()
+
+    async def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.get_account_history.side_effect = Exception("Timeout")
+        result = await upload_account_balance_history("12345", '{"2026-04-21": 0}')
+        assert "upload_account_balance_history" in result


### PR DESCRIPTION
## Summary
- **Bug fix**: `get_account_balance_history` crashed with `'list' object has no attribute 'get'` because the monarchmoney library returns a list of snapshots, not a dict
- **New tool**: `upload_account_balance_history` lets you correct historical balance snapshots by passing a JSON dict of `{date: balance}` corrections — useful for fixing net worth chart blips from institution sync timing

## Test plan
- [x] All 116 tests pass (`uv run --extra dev python -m pytest -v`)
- [x] 6 new tests added for both tools (formatted output, empty history, no matching dates, error handling)
- [x] Verified live: used the new tool to fix a $250k net worth chart blip caused by Chase/Vanguard balance sync delay