### PR TITLE
Improve Monarch transaction search metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 | `setup_authentication` | Get setup instructions | None |
 | `check_auth_status` | Check authentication status | None |
 | `get_accounts` | Get all financial accounts | None |
-| `get_transactions` | Get transactions with filtering | `limit`, `offset`, `start_date`, `end_date`, `account_id` |
+| `get_transactions` | Get transactions with filtering and reconciliation fields | `limit`, `offset`, `start_date`, `end_date`, `account_id`, `account_ids`, `category_ids`, `category_group_ids`, `tag_ids`, `search`, `wide_search`, `search_scan_limit`, `has_notes`, `is_split`, `is_recurring` |
 | `get_budgets` | Get budget information | `start_date`, `end_date` |
 | `set_budget_amount` | Set budget for a category | `amount`, `category_id`, `category_group_id`, `start_date`, `apply_to_future` |
 | `get_cashflow` | Get cashflow analysis | `start_date`, `end_date` |
@@ -283,6 +283,8 @@ Use get_accounts to show me all my financial accounts
 ```
 Show me my last 50 transactions using get_transactions with limit 50
 ```
+
+`get_transactions` returns a JSON object with `tool`, `args`, `count`, `total_count`, `truncated`, `search`, and `data` so large `agent-tools/<uuid>.txt` responses are self-describing. Transaction rows live in `data` and include `original_statement` / `plaid_description` when Monarch provides the underlying Plaid statement text, plus `currency`, `direction`, `direction_source`, `transaction_type`, `category_group`, and `category_group_id` when those values can be derived from Monarch response data. When Monarch's server-side `search` errors or returns no rows, `wide_search` scans recent transactions locally across merchant, original statement, description, notes, category, account, and tags.
 
 ### Check Spending vs Budget
 ```

--- a/src/monarch_mcp_server/helpers.py
+++ b/src/monarch_mcp_server/helpers.py
@@ -2,9 +2,68 @@
 
 import json
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def format_exception(exc: Exception) -> str:
+    """Best-effort string representation for tool error responses.
+
+    Some exceptions (e.g. certain async/transport errors) stringify to ``""``;
+    fall back to ``repr`` and finally the class name so the message is never
+    blank.
+    """
+    message = str(exc).strip()
+    if message:
+        return message
+    rep = repr(exc).strip()
+    if rep:
+        return rep
+    return type(exc).__name__
+
+
+def first_present(*values: Any) -> Any:
+    """Return the first value that is not None and not an empty string."""
+    for value in values:
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def tool_response_envelope(
+    tool: str,
+    args: Dict[str, Any],
+    rows: List[Dict[str, Any]],
+    *,
+    total_count: Optional[int] = None,
+    search_info: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Wrap a list of rows in a self-describing envelope.
+
+    Lets agents see how much was returned, whether more is available, and which
+    search strategy ran without re-asking. ``truncated`` is True when the server
+    reports more rows than were returned, or when the page filled exactly to the
+    limit and total_count is unknown.
+    """
+    count = len(rows)
+    limit = args.get("limit")
+    offset = args.get("offset") or 0
+    truncated = (
+        offset + count < total_count
+        if isinstance(total_count, int)
+        else isinstance(limit, int) and count == limit
+    )
+
+    return {
+        "tool": tool,
+        "args": args,
+        "count": count,
+        "total_count": total_count,
+        "truncated": truncated,
+        "search": search_info,
+        "data": rows,
+    }
 
 
 def format_transaction(txn: Dict[str, Any], extended: bool = False) -> Dict[str, Any]:
@@ -52,7 +111,7 @@ def json_error(tool_name: str, exc: Exception) -> str:
     """Return a consistent JSON error string and log the failure."""
     logger.error(f"Failed in {tool_name}: {exc}")
     return json.dumps(
-        {"error": True, "tool": tool_name, "message": str(exc)},
+        {"error": True, "tool": tool_name, "message": format_exception(exc)},
         indent=2,
         default=str,
     )

--- a/src/monarch_mcp_server/tools/transactions.py
+++ b/src/monarch_mcp_server/tools/transactions.py
@@ -3,7 +3,10 @@
 import asyncio
 import json
 import logging
+import re
+import unicodedata
 from datetime import datetime, timedelta
+from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, List, Optional
 
 from monarch_mcp_server.app import mcp
@@ -11,6 +14,270 @@ from monarch_mcp_server.client import get_monarch_client
 from monarch_mcp_server.helpers import format_transaction, json_success, json_error
 
 logger = logging.getLogger(__name__)
+
+KNOWN_CURRENCY_CODES = {
+    "AED",
+    "AUD",
+    "BRL",
+    "CAD",
+    "CHF",
+    "CNY",
+    "EUR",
+    "GBP",
+    "HKD",
+    "JPY",
+    "MXN",
+    "NOK",
+    "NZD",
+    "SEK",
+    "SGD",
+    "THB",
+    "USD",
+    "ZAR",
+}
+
+
+def _format_exception(error: Exception) -> str:
+    message = str(error).strip()
+    if message:
+        return message
+    return repr(error) if repr(error) else type(error).__name__
+
+
+def _first_present(*values: Any) -> Any:
+    for value in values:
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _normalize_search_text(value: Any) -> str:
+    if value is None:
+        return ""
+
+    normalized = unicodedata.normalize("NFKD", str(value))
+    ascii_text = "".join(char for char in normalized if not unicodedata.combining(char))
+    return ascii_text.casefold()
+
+
+def _search_tokens(search: str) -> List[str]:
+    return [
+        token
+        for token in re.split(r"\s+", _normalize_search_text(search).strip())
+        if token
+    ]
+
+
+def _name_from_value(value: Any) -> Optional[str]:
+    if isinstance(value, dict):
+        return value.get("name")
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def _id_from_value(value: Any) -> Optional[str]:
+    if isinstance(value, dict):
+        return value.get("id")
+    return None
+
+
+def _raw_transaction_matches_search(
+    txn: Dict[str, Any],
+    category_metadata: Dict[str, Dict[str, Optional[str]]],
+    search: str,
+) -> bool:
+    tokens = _search_tokens(search)
+    if not tokens:
+        return True
+
+    category = txn.get("category") if isinstance(txn.get("category"), dict) else {}
+    account = txn.get("account") if isinstance(txn.get("account"), dict) else {}
+    merchant = txn.get("merchant")
+    category_id = category.get("id") if isinstance(category, dict) else None
+    metadata = category_metadata.get(category_id, {})
+
+    values = [
+        txn.get("description"),
+        txn.get("originalStatement"),
+        txn.get("plaidDescription"),
+        txn.get("plaidName"),
+        txn.get("notes"),
+        _name_from_value(merchant),
+        _id_from_value(merchant),
+        category.get("name") if isinstance(category, dict) else None,
+        category_id,
+        metadata.get("group"),
+        metadata.get("group_id"),
+        account.get("displayName") if isinstance(account, dict) else None,
+        account.get("name") if isinstance(account, dict) else None,
+        account.get("id") if isinstance(account, dict) else None,
+    ]
+    for tag in txn.get("tags", []):
+        if isinstance(tag, dict):
+            values.extend([tag.get("id"), tag.get("name")])
+
+    haystack = " ".join(_normalize_search_text(value) for value in values if value)
+    return all(token in haystack for token in tokens)
+
+
+def _direction_from_amount(amount: Any) -> Optional[str]:
+    if amount is None:
+        return None
+
+    try:
+        parsed = Decimal(str(amount))
+    except (InvalidOperation, ValueError):
+        return None
+
+    if parsed > 0:
+        return "inflow"
+    if parsed < 0:
+        return "outflow"
+    return "zero"
+
+
+def _currency_from_text(text: Any) -> Optional[str]:
+    if not isinstance(text, str):
+        return None
+
+    for match in re.findall(r"\b[A-Z]{3}\b", text.upper()):
+        if match in KNOWN_CURRENCY_CODES:
+            return match
+    return None
+
+
+def _currency_from_transaction(txn: Dict[str, Any]) -> Optional[str]:
+    account = txn.get("account") if isinstance(txn.get("account"), dict) else {}
+    amount = txn.get("amount") if isinstance(txn.get("amount"), dict) else {}
+
+    direct_currency = _first_present(
+        txn.get("currency"),
+        txn.get("currencyCode"),
+        txn.get("isoCurrencyCode"),
+        amount.get("currency") if isinstance(amount, dict) else None,
+        amount.get("currencyCode") if isinstance(amount, dict) else None,
+        account.get("currency") if isinstance(account, dict) else None,
+        account.get("currencyCode") if isinstance(account, dict) else None,
+        account.get("isoCurrencyCode") if isinstance(account, dict) else None,
+    )
+    if direct_currency:
+        return str(direct_currency).upper()
+
+    return _first_present(
+        _currency_from_text(
+            account.get("displayName") if isinstance(account, dict) else None
+        ),
+        _currency_from_text(account.get("name") if isinstance(account, dict) else None),
+    )
+
+
+def _tool_response_envelope(
+    tool: str,
+    args: Dict[str, Any],
+    rows: List[Dict[str, Any]],
+    *,
+    total_count: Optional[int] = None,
+    search_info: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    count = len(rows)
+    limit = args.get("limit")
+    offset = args.get("offset") or 0
+    truncated = (
+        offset + count < total_count
+        if isinstance(total_count, int)
+        else isinstance(limit, int) and count == limit
+    )
+
+    return {
+        "tool": tool,
+        "args": args,
+        "count": count,
+        "total_count": total_count,
+        "truncated": truncated,
+        "search": search_info,
+        "data": rows,
+    }
+
+
+def _format_transaction_row(
+    txn: Dict[str, Any],
+    category_metadata: Dict[str, Dict[str, Optional[str]]],
+) -> Dict[str, Any]:
+    category = txn.get("category") if isinstance(txn.get("category"), dict) else {}
+    account = txn.get("account") if isinstance(txn.get("account"), dict) else {}
+    merchant = txn.get("merchant")
+    category_id = category.get("id") if isinstance(category, dict) else None
+    txn_category_metadata = category_metadata.get(category_id, {})
+
+    if category_id:
+        category_group = (
+            category.get("group") if isinstance(category.get("group"), dict) else {}
+        )
+        txn_category_metadata = {
+            "group": _first_present(
+                txn_category_metadata.get("group"),
+                category_group.get("name"),
+            ),
+            "group_id": _first_present(
+                txn_category_metadata.get("group_id"),
+                category_group.get("id"),
+            ),
+            "group_type": _first_present(
+                txn_category_metadata.get("group_type"),
+                category_group.get("type"),
+            ),
+        }
+
+    amount = txn.get("amount")
+    direction = _direction_from_amount(amount)
+    plaid_description = _first_present(
+        txn.get("plaidDescription"),
+        txn.get("plaidName"),
+        txn.get("originalStatement"),
+    )
+    original_statement = _first_present(txn.get("originalStatement"), plaid_description)
+    transaction_type = _first_present(
+        txn.get("transactionType"),
+        txn.get("type"),
+        txn.get("kind"),
+        txn_category_metadata.get("group_type"),
+        direction,
+    )
+
+    return {
+        "id": txn.get("id"),
+        "date": txn.get("date"),
+        "amount": amount,
+        "currency": _currency_from_transaction(txn),
+        "direction": direction,
+        "direction_source": "amount_sign" if direction else None,
+        "transaction_type": transaction_type,
+        "description": txn.get("description"),
+        "original_statement": original_statement,
+        "plaid_description": plaid_description,
+        "notes": txn.get("notes"),
+        "category": category.get("name") if isinstance(category, dict) else None,
+        "category_id": category_id,
+        "category_group": txn_category_metadata.get("group"),
+        "category_group_id": txn_category_metadata.get("group_id"),
+        "account": account.get("displayName") if isinstance(account, dict) else None,
+        "account_id": account.get("id") if isinstance(account, dict) else None,
+        "merchant": _name_from_value(merchant),
+        "merchant_id": _id_from_value(merchant),
+        "is_pending": txn.get("isPending", txn.get("pending", False)),
+        "needs_review": txn.get("needsReview", False),
+        "review_status": txn.get("reviewStatus"),
+        "is_recurring": bool(
+            txn.get("isRecurring") or txn.get("recurringTransactionStream")
+        ),
+        "is_split_transaction": bool(txn.get("isSplitTransaction")),
+        "hide_from_reports": txn.get("hideFromReports", False),
+        "tags": [
+            {"id": tag.get("id"), "name": tag.get("name")}
+            for tag in (txn.get("tags") or [])
+        ],
+    }
 
 
 @mcp.tool()
@@ -22,11 +289,14 @@ async def get_transactions(
     account_id: Optional[str] = None,
     search: Optional[str] = None,
     category_ids: Optional[List[str]] = None,
+    category_group_ids: Optional[List[str]] = None,
     account_ids: Optional[List[str]] = None,
     tag_ids: Optional[List[str]] = None,
     has_notes: Optional[bool] = None,
     is_split: Optional[bool] = None,
     is_recurring: Optional[bool] = None,
+    wide_search: bool = True,
+    search_scan_limit: int = 1000,
 ) -> str:
     """
     Get transactions from Monarch Money.
@@ -39,14 +309,43 @@ async def get_transactions(
         account_id: Specific account ID to filter by (deprecated, use account_ids)
         search: Search query to filter transactions
         category_ids: List of category IDs to filter by
+        category_group_ids: List of category group IDs to filter by
         account_ids: List of account IDs to filter by
         tag_ids: List of tag IDs to filter by
         has_notes: Filter for transactions with/without notes
         is_split: Filter for split transactions
         is_recurring: Filter for recurring transactions
+        wide_search: Fall back to a local scan across richer transaction fields
+        search_scan_limit: Maximum transactions to scan for wide_search fallback
     """
     try:
         client = await get_monarch_client()
+        category_metadata: Dict[str, Dict[str, Optional[str]]] = {}
+
+        async def _load_category_metadata(required: bool = False) -> None:
+            nonlocal category_metadata
+            if category_metadata:
+                return
+
+            try:
+                data = await client.get_transaction_categories()
+            except Exception:
+                if required:
+                    raise
+                logger.info("Skipping transaction category enrichment", exc_info=True)
+                return
+
+            for cat in data.get("categories", []):
+                group = cat.get("group") if isinstance(cat.get("group"), dict) else {}
+                category_metadata[cat.get("id")] = {
+                    "group": group.get("name") if isinstance(group, dict) else None,
+                    "group_id": group.get("id") if isinstance(group, dict) else None,
+                    "group_type": (
+                        group.get("type") if isinstance(group, dict) else None
+                    ),
+                }
+
+        await _load_category_metadata()
 
         filters: Dict[str, Any] = {}
         if start_date:
@@ -62,8 +361,48 @@ async def get_transactions(
 
         if search:
             filters["search"] = search
-        if category_ids:
-            filters["category_ids"] = category_ids
+
+        merged_category_ids = list(category_ids or [])
+        if category_group_ids:
+            await _load_category_metadata(required=True)
+            group_category_ids = [
+                category_id
+                for category_id, metadata in category_metadata.items()
+                if metadata.get("group_id") in category_group_ids
+            ]
+            for category_id in group_category_ids:
+                if category_id not in merged_category_ids:
+                    merged_category_ids.append(category_id)
+
+            if not merged_category_ids:
+                empty_args = {
+                    "limit": limit,
+                    "offset": offset,
+                    "start_date": start_date,
+                    "end_date": end_date,
+                    "account_id": account_id,
+                    "search": search,
+                    "category_ids": category_ids,
+                    "category_group_ids": category_group_ids,
+                    "account_ids": account_ids,
+                    "tag_ids": tag_ids,
+                    "has_notes": has_notes,
+                    "is_split": is_split,
+                    "is_recurring": is_recurring,
+                    "wide_search": wide_search,
+                    "search_scan_limit": search_scan_limit,
+                }
+                return json_success(
+                    _tool_response_envelope(
+                        "get_transactions",
+                        empty_args,
+                        [],
+                        search_info={"strategy": "server", "fallback_reason": None},
+                    )
+                )
+
+        if merged_category_ids:
+            filters["category_ids"] = merged_category_ids
         if tag_ids:
             filters["tag_ids"] = tag_ids
         if has_notes is not None:
@@ -73,40 +412,157 @@ async def get_transactions(
         if is_recurring is not None:
             filters["is_recurring"] = is_recurring
 
-        transactions = await client.get_transactions(limit=limit, offset=offset, **filters)
+        async def _wide_search(
+            reason: str, original_error: Optional[Exception] = None
+        ) -> tuple[Dict[str, Any], Dict[str, Any]]:
+            if not search or not wide_search:
+                if original_error:
+                    raise original_error
+                return {"allTransactions": {"results": []}}, {
+                    "strategy": "server",
+                    "fallback_reason": None,
+                }
 
-        transaction_list = []
-        for txn in transactions.get("allTransactions", {}).get("results", []):
-            category = txn.get("category") or {}
-            account = txn.get("account") or {}
-            merchant = txn.get("merchant") or {}
-            transaction_info = {
-                "id": txn.get("id"),
-                "date": txn.get("date"),
-                "amount": txn.get("amount"),
-                "description": txn.get("description"),
-                "notes": txn.get("notes"),
-                "category": category.get("name"),
-                "category_id": category.get("id"),
-                "account": account.get("displayName"),
-                "account_id": account.get("id"),
-                "merchant": merchant.get("name"),
-                "is_pending": txn.get("isPending", False),
-                "needs_review": txn.get("needsReview", False),
-                "review_status": txn.get("reviewStatus"),
-                "is_recurring": bool(txn.get("isRecurring") or txn.get("recurringTransactionStream")),
-                "is_split_transaction": bool(txn.get("isSplitTransaction")),
-                "hide_from_reports": txn.get("hideFromReports", False),
-                "tags": [
-                    {"id": tag.get("id"), "name": tag.get("name")}
-                    for tag in (txn.get("tags") or [])
-                ],
+            scan_limit = max(limit, search_scan_limit)
+            fallback_filters = {
+                key: value for key, value in filters.items() if key != "search"
             }
-            transaction_list.append(transaction_info)
+            fallback_data = await client.get_transactions(
+                limit=scan_limit,
+                offset=0,
+                **fallback_filters,
+            )
+            all_fallback_transactions = fallback_data.get("allTransactions", {})
+            fallback_results = all_fallback_transactions.get("results", [])
+            matches = [
+                txn
+                for txn in fallback_results
+                if _raw_transaction_matches_search(txn, category_metadata, search)
+            ]
+            total_matches = len(matches)
+            page = matches[offset : offset + limit]
+            return {
+                **fallback_data,
+                "allTransactions": {
+                    **all_fallback_transactions,
+                    "results": page,
+                    "totalCount": total_matches,
+                },
+            }, {
+                "strategy": "wide",
+                "fallback_reason": reason,
+                "scan_limit": scan_limit,
+                "scanned_count": len(fallback_results),
+                "server_error": (
+                    _format_exception(original_error) if original_error else None
+                ),
+            }
 
-        return json_success(transaction_list)
+        try:
+            transactions = await client.get_transactions(
+                limit=limit,
+                offset=offset,
+                **filters,
+            )
+            if (
+                search
+                and wide_search
+                and not transactions.get("allTransactions", {}).get("results", [])
+            ):
+                transactions, search_info = await _wide_search("empty_server_results")
+            else:
+                search_info = {"strategy": "server", "fallback_reason": None}
+        except Exception as original_error:
+            if not search:
+                raise
+
+            retry_search = search.casefold()
+            if retry_search == search:
+                transactions, search_info = await _wide_search(
+                    "server_error", original_error
+                )
+            else:
+                retry_filters = {**filters, "search": retry_search}
+                try:
+                    transactions = await client.get_transactions(
+                        limit=limit,
+                        offset=offset,
+                        **retry_filters,
+                    )
+                    if wide_search and not transactions.get("allTransactions", {}).get(
+                        "results", []
+                    ):
+                        transactions, search_info = await _wide_search(
+                            "empty_lowercase_retry_results", original_error
+                        )
+                    else:
+                        search_info = {
+                            "strategy": "lowercase_retry",
+                            "fallback_reason": "server_error",
+                            "server_error": _format_exception(original_error),
+                        }
+                except Exception as retry_error:
+                    try:
+                        transactions, search_info = await _wide_search(
+                            "server_and_lowercase_retry_error", retry_error
+                        )
+                    except Exception as fallback_error:
+                        raise RuntimeError(
+                            "Search failed for "
+                            f"{search!r}; lowercase retry {retry_search!r} and "
+                            "wide search also failed. "
+                            f"Original error: {_format_exception(original_error)}; "
+                            f"retry error: {_format_exception(retry_error)}; "
+                            f"wide search error: {_format_exception(fallback_error)}"
+                        ) from fallback_error
+
+        all_transactions = transactions.get("allTransactions", {})
+        transaction_list = [
+            _format_transaction_row(txn, category_metadata)
+            for txn in all_transactions.get("results", [])
+        ]
+        args_summary = {
+            "limit": limit,
+            "offset": offset,
+            "start_date": start_date,
+            "end_date": end_date,
+            "account_id": account_id,
+            "search": search,
+            "category_ids": category_ids,
+            "category_group_ids": category_group_ids,
+            "account_ids": account_ids,
+            "tag_ids": tag_ids,
+            "has_notes": has_notes,
+            "is_split": is_split,
+            "is_recurring": is_recurring,
+            "wide_search": wide_search,
+            "search_scan_limit": search_scan_limit,
+        }
+        total_count = _first_present(
+            all_transactions.get("totalCount"),
+            all_transactions.get("total_count"),
+            all_transactions.get("count"),
+        )
+
+        return json_success(
+            _tool_response_envelope(
+                "get_transactions",
+                args_summary,
+                transaction_list,
+                total_count=total_count,
+                search_info=search_info,
+            )
+        )
     except Exception as e:
-        return json_error("get_transactions", e)
+        return json.dumps(
+            {
+                "error": True,
+                "tool": "get_transactions",
+                "message": _format_exception(e),
+            },
+            indent=2,
+            default=str,
+        )
 
 
 @mcp.tool()
@@ -445,10 +901,12 @@ async def bulk_categorize_transactions(
         for txn_id, outcome in zip(transaction_ids, outcomes):
             if isinstance(outcome, Exception):
                 results["failed"] += 1
-                results["errors"].append({
-                    "transaction_id": txn_id,
-                    "error": str(outcome),
-                })
+                results["errors"].append(
+                    {
+                        "transaction_id": txn_id,
+                        "error": str(outcome),
+                    }
+                )
             else:
                 results["successful"] += 1
 
@@ -513,16 +971,33 @@ async def get_recurring_transactions(
                 "amount": item.get("amount"),
                 "is_past": item.get("isPast", False),
                 "transaction_id": item.get("transactionId"),
-                "stream": {
-                    "id": item.get("stream", {}).get("id"),
-                    "frequency": item.get("stream", {}).get("frequency"),
-                    "amount": item.get("stream", {}).get("amount"),
-                    "is_approximate": item.get("stream", {}).get("isApproximate", False),
-                    "merchant": item.get("stream", {}).get("merchant", {}).get("name")
-                    if item.get("stream", {}).get("merchant") else None,
-                } if item.get("stream") else None,
-                "category": item.get("category", {}).get("name") if item.get("category") else None,
-                "account": item.get("account", {}).get("displayName") if item.get("account") else None,
+                "stream": (
+                    {
+                        "id": item.get("stream", {}).get("id"),
+                        "frequency": item.get("stream", {}).get("frequency"),
+                        "amount": item.get("stream", {}).get("amount"),
+                        "is_approximate": item.get("stream", {}).get(
+                            "isApproximate", False
+                        ),
+                        "merchant": (
+                            item.get("stream", {}).get("merchant", {}).get("name")
+                            if item.get("stream", {}).get("merchant")
+                            else None
+                        ),
+                    }
+                    if item.get("stream")
+                    else None
+                ),
+                "category": (
+                    item.get("category", {}).get("name")
+                    if item.get("category")
+                    else None
+                ),
+                "account": (
+                    item.get("account", {}).get("displayName")
+                    if item.get("account")
+                    else None
+                ),
             }
             recurring_list.append(recurring_info)
 

--- a/src/monarch_mcp_server/tools/transactions.py
+++ b/src/monarch_mcp_server/tools/transactions.py
@@ -310,7 +310,10 @@ async def get_transactions(
                     ),
                 }
 
-        await _load_category_metadata()
+        # category_metadata is loaded lazily: only when category_group_ids
+        # is in filters or when wide_search needs it for haystack matching.
+        # Ordinary calls rely on whatever Monarch returns inline on each
+        # transaction's `category.group` field.
 
         filters: Dict[str, Any] = {}
         if start_date:
@@ -399,6 +402,9 @@ async def get_transactions(
             )
             all_fallback_transactions = fallback_data.get("allTransactions", {})
             fallback_results = all_fallback_transactions.get("results", [])
+            # Load category metadata only now that we know wide_search will run;
+            # the haystack uses category group name/id in matching.
+            await _load_category_metadata()
             matches = [
                 txn
                 for txn in fallback_results

--- a/src/monarch_mcp_server/tools/transactions.py
+++ b/src/monarch_mcp_server/tools/transactions.py
@@ -260,8 +260,8 @@ async def get_transactions(
     has_notes: Optional[bool] = None,
     is_split: Optional[bool] = None,
     is_recurring: Optional[bool] = None,
-    wide_search: bool = True,
-    search_scan_limit: int = 1000,
+    wide_search: bool = False,
+    search_scan_limit: int = 200,
 ) -> str:
     """
     Get transactions from Monarch Money.
@@ -280,8 +280,15 @@ async def get_transactions(
         has_notes: Filter for transactions with/without notes
         is_split: Filter for split transactions
         is_recurring: Filter for recurring transactions
-        wide_search: Fall back to a local scan across richer transaction fields
-        search_scan_limit: Maximum transactions to scan for wide_search fallback
+        wide_search: Opt-in fallback that pulls a page of transactions and
+                     filters them locally across description, original
+                     statement, plaid name, notes, merchant, category,
+                     account, and tags when Monarch's server-side search
+                     returns empty or errors. Off by default because it can
+                     be expensive; turn on when a search you expect to match
+                     comes back empty.
+        search_scan_limit: Maximum transactions the wide_search fallback
+                           will scan locally (default 200)
     """
     try:
         client = await get_monarch_client()

--- a/src/monarch_mcp_server/tools/transactions.py
+++ b/src/monarch_mcp_server/tools/transactions.py
@@ -11,7 +11,14 @@ from typing import Any, Dict, List, Optional
 
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
-from monarch_mcp_server.helpers import format_transaction, json_success, json_error
+from monarch_mcp_server.helpers import (
+    first_present,
+    format_exception,
+    format_transaction,
+    json_error,
+    json_success,
+    tool_response_envelope,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,20 +42,6 @@ KNOWN_CURRENCY_CODES = {
     "USD",
     "ZAR",
 }
-
-
-def _format_exception(error: Exception) -> str:
-    message = str(error).strip()
-    if message:
-        return message
-    return repr(error) if repr(error) else type(error).__name__
-
-
-def _first_present(*values: Any) -> Any:
-    for value in values:
-        if value is not None and value != "":
-            return value
-    return None
 
 
 def _normalize_search_text(value: Any) -> str:
@@ -151,7 +144,7 @@ def _currency_from_transaction(txn: Dict[str, Any]) -> Optional[str]:
     account = txn.get("account") if isinstance(txn.get("account"), dict) else {}
     amount = txn.get("amount") if isinstance(txn.get("amount"), dict) else {}
 
-    direct_currency = _first_present(
+    direct_currency = first_present(
         txn.get("currency"),
         txn.get("currencyCode"),
         txn.get("isoCurrencyCode"),
@@ -164,40 +157,12 @@ def _currency_from_transaction(txn: Dict[str, Any]) -> Optional[str]:
     if direct_currency:
         return str(direct_currency).upper()
 
-    return _first_present(
+    return first_present(
         _currency_from_text(
             account.get("displayName") if isinstance(account, dict) else None
         ),
         _currency_from_text(account.get("name") if isinstance(account, dict) else None),
     )
-
-
-def _tool_response_envelope(
-    tool: str,
-    args: Dict[str, Any],
-    rows: List[Dict[str, Any]],
-    *,
-    total_count: Optional[int] = None,
-    search_info: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
-    count = len(rows)
-    limit = args.get("limit")
-    offset = args.get("offset") or 0
-    truncated = (
-        offset + count < total_count
-        if isinstance(total_count, int)
-        else isinstance(limit, int) and count == limit
-    )
-
-    return {
-        "tool": tool,
-        "args": args,
-        "count": count,
-        "total_count": total_count,
-        "truncated": truncated,
-        "search": search_info,
-        "data": rows,
-    }
 
 
 def _format_transaction_row(
@@ -215,15 +180,15 @@ def _format_transaction_row(
             category.get("group") if isinstance(category.get("group"), dict) else {}
         )
         txn_category_metadata = {
-            "group": _first_present(
+            "group": first_present(
                 txn_category_metadata.get("group"),
                 category_group.get("name"),
             ),
-            "group_id": _first_present(
+            "group_id": first_present(
                 txn_category_metadata.get("group_id"),
                 category_group.get("id"),
             ),
-            "group_type": _first_present(
+            "group_type": first_present(
                 txn_category_metadata.get("group_type"),
                 category_group.get("type"),
             ),
@@ -231,13 +196,13 @@ def _format_transaction_row(
 
     amount = txn.get("amount")
     direction = _direction_from_amount(amount)
-    plaid_description = _first_present(
+    plaid_description = first_present(
         txn.get("plaidDescription"),
         txn.get("plaidName"),
         txn.get("originalStatement"),
     )
-    original_statement = _first_present(txn.get("originalStatement"), plaid_description)
-    transaction_type = _first_present(
+    original_statement = first_present(txn.get("originalStatement"), plaid_description)
+    transaction_type = first_present(
         txn.get("transactionType"),
         txn.get("type"),
         txn.get("kind"),
@@ -393,7 +358,7 @@ async def get_transactions(
                     "search_scan_limit": search_scan_limit,
                 }
                 return json_success(
-                    _tool_response_envelope(
+                    tool_response_envelope(
                         "get_transactions",
                         empty_args,
                         [],
@@ -454,7 +419,7 @@ async def get_transactions(
                 "scan_limit": scan_limit,
                 "scanned_count": len(fallback_results),
                 "server_error": (
-                    _format_exception(original_error) if original_error else None
+                    format_exception(original_error) if original_error else None
                 ),
             }
 
@@ -499,7 +464,7 @@ async def get_transactions(
                         search_info = {
                             "strategy": "lowercase_retry",
                             "fallback_reason": "server_error",
-                            "server_error": _format_exception(original_error),
+                            "server_error": format_exception(original_error),
                         }
                 except Exception as retry_error:
                     try:
@@ -511,9 +476,9 @@ async def get_transactions(
                             "Search failed for "
                             f"{search!r}; lowercase retry {retry_search!r} and "
                             "wide search also failed. "
-                            f"Original error: {_format_exception(original_error)}; "
-                            f"retry error: {_format_exception(retry_error)}; "
-                            f"wide search error: {_format_exception(fallback_error)}"
+                            f"Original error: {format_exception(original_error)}; "
+                            f"retry error: {format_exception(retry_error)}; "
+                            f"wide search error: {format_exception(fallback_error)}"
                         ) from fallback_error
 
         all_transactions = transactions.get("allTransactions", {})
@@ -538,14 +503,14 @@ async def get_transactions(
             "wide_search": wide_search,
             "search_scan_limit": search_scan_limit,
         }
-        total_count = _first_present(
+        total_count = first_present(
             all_transactions.get("totalCount"),
             all_transactions.get("total_count"),
             all_transactions.get("count"),
         )
 
         return json_success(
-            _tool_response_envelope(
+            tool_response_envelope(
                 "get_transactions",
                 args_summary,
                 transaction_list,
@@ -558,7 +523,7 @@ async def get_transactions(
             {
                 "error": True,
                 "tool": "get_transactions",
-                "message": _format_exception(e),
+                "message": format_exception(e),
             },
             indent=2,
             default=str,

--- a/src/monarch_mcp_server/tools/transactions.py
+++ b/src/monarch_mcp_server/tools/transactions.py
@@ -464,48 +464,14 @@ async def get_transactions(
             else:
                 search_info = {"strategy": "server", "fallback_reason": None}
         except Exception as original_error:
-            if not search:
+            # Server search failed. If the caller opted into wide_search and
+            # there is a search query, try the local-scan fallback. Otherwise
+            # propagate the original error untouched.
+            if not search or not wide_search:
                 raise
-
-            retry_search = search.casefold()
-            if retry_search == search:
-                transactions, search_info = await _wide_search(
-                    "server_error", original_error
-                )
-            else:
-                retry_filters = {**filters, "search": retry_search}
-                try:
-                    transactions = await client.get_transactions(
-                        limit=limit,
-                        offset=offset,
-                        **retry_filters,
-                    )
-                    if wide_search and not transactions.get("allTransactions", {}).get(
-                        "results", []
-                    ):
-                        transactions, search_info = await _wide_search(
-                            "empty_lowercase_retry_results", original_error
-                        )
-                    else:
-                        search_info = {
-                            "strategy": "lowercase_retry",
-                            "fallback_reason": "server_error",
-                            "server_error": format_exception(original_error),
-                        }
-                except Exception as retry_error:
-                    try:
-                        transactions, search_info = await _wide_search(
-                            "server_and_lowercase_retry_error", retry_error
-                        )
-                    except Exception as fallback_error:
-                        raise RuntimeError(
-                            "Search failed for "
-                            f"{search!r}; lowercase retry {retry_search!r} and "
-                            "wide search also failed. "
-                            f"Original error: {format_exception(original_error)}; "
-                            f"retry error: {format_exception(retry_error)}; "
-                            f"wide search error: {format_exception(fallback_error)}"
-                        ) from fallback_error
+            transactions, search_info = await _wide_search(
+                "server_error", original_error
+            )
 
         all_transactions = transactions.get("allTransactions", {})
         transaction_list = [

--- a/src/monarch_mcp_server/tools/transactions.py
+++ b/src/monarch_mcp_server/tools/transactions.py
@@ -140,7 +140,15 @@ def _currency_from_text(text: Any) -> Optional[str]:
     return None
 
 
-def _currency_from_transaction(txn: Dict[str, Any]) -> Optional[str]:
+def _currency_from_transaction(txn: Dict[str, Any]) -> tuple[Optional[str], Optional[str]]:
+    """Resolve a transaction's currency and the source of that value.
+
+    Returns ``(currency, source)`` where source is one of:
+    - ``"api"``: explicit currency field on the transaction or account
+    - ``"account_name_guess"``: regex-matched a 3-letter code in the account
+      display/name (heuristic; may be wrong for accounts named "USD Bank" etc.)
+    - ``None``: no currency could be derived
+    """
     account = txn.get("account") if isinstance(txn.get("account"), dict) else {}
     amount = txn.get("amount") if isinstance(txn.get("amount"), dict) else {}
 
@@ -155,14 +163,17 @@ def _currency_from_transaction(txn: Dict[str, Any]) -> Optional[str]:
         account.get("isoCurrencyCode") if isinstance(account, dict) else None,
     )
     if direct_currency:
-        return str(direct_currency).upper()
+        return str(direct_currency).upper(), "api"
 
-    return first_present(
+    guessed = first_present(
         _currency_from_text(
             account.get("displayName") if isinstance(account, dict) else None
         ),
         _currency_from_text(account.get("name") if isinstance(account, dict) else None),
     )
+    if guessed:
+        return guessed, "account_name_guess"
+    return None, None
 
 
 def _format_transaction_row(
@@ -209,12 +220,14 @@ def _format_transaction_row(
         txn_category_metadata.get("group_type"),
         direction,
     )
+    currency, currency_source = _currency_from_transaction(txn)
 
     return {
         "id": txn.get("id"),
         "date": txn.get("date"),
         "amount": amount,
-        "currency": _currency_from_transaction(txn),
+        "currency": currency,
+        "currency_source": currency_source,
         "direction": direction,
         "direction_source": "amount_sign" if direction else None,
         "transaction_type": transaction_type,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,11 @@ def mock_monarch_client():
                     "currencyCode": "CAD",
                     "description": "Grocery Store",
                     "plaidName": "WHOLE FOODS MARKET 10234",
-                    "category": {"id": "cat-1", "name": "Groceries"},
+                    "category": {
+                        "id": "cat-1",
+                        "name": "Groceries",
+                        "group": {"id": "grp-1", "name": "Food", "type": "expense"},
+                    },
                     "account": {"id": "acc-1", "displayName": "Checking Account"},
                     "merchant": {"name": "Whole Foods"},
                     "isPending": False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,9 @@ def mock_monarch_client():
                     "id": "txn-1",
                     "date": "2026-03-01",
                     "amount": -42.50,
+                    "currencyCode": "CAD",
                     "description": "Grocery Store",
+                    "plaidName": "WHOLE FOODS MARKET 10234",
                     "category": {"id": "cat-1", "name": "Groceries"},
                     "account": {"id": "acc-1", "displayName": "Checking Account"},
                     "merchant": {"name": "Whole Foods"},
@@ -70,7 +72,7 @@ def mock_monarch_client():
                     "amount": 3000.00,
                     "description": "Paycheck",
                     "category": {"id": "cat-3", "name": "Income"},
-                    "account": {"id": "acc-1", "displayName": "Checking Account"},
+                    "account": {"id": "acc-1", "displayName": "Wise USD Balance"},
                     "merchant": None,
                     "isPending": False,
                     "needsReview": False,
@@ -149,13 +151,13 @@ def mock_monarch_client():
                 "id": "cat-1",
                 "name": "Groceries",
                 "icon": "🛒",
-                "group": {"id": "grp-1", "name": "Food"},
+                "group": {"id": "grp-1", "name": "Food", "type": "expense"},
             },
             {
                 "id": "cat-2",
                 "name": "Dining Out",
                 "icon": "🍽️",
-                "group": {"id": "grp-1", "name": "Food"},
+                "group": {"id": "grp-1", "name": "Food", "type": "expense"},
             },
         ]
     }
@@ -190,13 +192,30 @@ def mock_monarch_client():
     }
 
     client.create_transaction_tag.return_value = {
-        "createTransactionTag": {"tag": {"id": "tag-new", "name": "new", "color": "#0000ff"}}
+        "createTransactionTag": {
+            "tag": {"id": "tag-new", "name": "new", "color": "#0000ff"}
+        }
     }
 
     client.get_account_history.return_value = [
-        {"date": "2026-04-20", "signedBalance": 1000.0, "accountId": "acc-1", "accountName": "Checking Account"},
-        {"date": "2026-04-21", "signedBalance": 1200.0, "accountId": "acc-1", "accountName": "Checking Account"},
-        {"date": "2026-04-22", "signedBalance": 1100.0, "accountId": "acc-1", "accountName": "Checking Account"},
+        {
+            "date": "2026-04-20",
+            "signedBalance": 1000.0,
+            "accountId": "acc-1",
+            "accountName": "Checking Account",
+        },
+        {
+            "date": "2026-04-21",
+            "signedBalance": 1200.0,
+            "accountId": "acc-1",
+            "accountName": "Checking Account",
+        },
+        {
+            "date": "2026-04-22",
+            "signedBalance": 1100.0,
+            "accountId": "acc-1",
+            "accountName": "Checking Account",
+        },
     ]
 
     client.upload_account_balance_history.return_value = True

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -776,22 +776,13 @@ class TestGetTransactions:
         assert result["data"] == []
         mock_monarch_client.get_transactions.assert_not_called()
 
-    async def test_uppercase_search_retries_lowercase(self, mock_monarch_client):
-        response = mock_monarch_client.get_transactions.return_value
-        mock_monarch_client.get_transactions.side_effect = [
-            Exception(),
-            response,
-        ]
+    async def test_server_error_propagates_when_wide_search_off(
+        self, mock_monarch_client
+    ):
+        mock_monarch_client.get_transactions.side_effect = Exception("backend boom")
         result = await self._transaction_response(search="RRSP")
-        assert len(result["data"]) == 2
-        assert result["search"]["strategy"] == "lowercase_retry"
-        assert result["search"]["fallback_reason"] == "server_error"
-        mock_monarch_client.get_transactions.assert_has_calls(
-            [
-                call(limit=100, offset=0, search="RRSP"),
-                call(limit=100, offset=0, search="rrsp"),
-            ]
-        )
+        assert result["error"] is True
+        assert "backend boom" in result["message"]
 
     async def test_empty_search_results_fall_back_to_wide_search(
         self, mock_monarch_client
@@ -829,8 +820,7 @@ class TestGetTransactions:
     async def test_search_errors_fall_back_to_wide_search(self, mock_monarch_client):
         response = mock_monarch_client.get_transactions.return_value
         mock_monarch_client.get_transactions.side_effect = [
-            Exception(),
-            Exception(),
+            Exception("server search failed"),
             response,
         ]
         result = await self._transaction_response(
@@ -839,11 +829,11 @@ class TestGetTransactions:
         assert result["count"] == 1
         assert result["data"][0]["id"] == "txn-1"
         assert result["search"]["strategy"] == "wide"
-        assert result["search"]["fallback_reason"] == "server_and_lowercase_retry_error"
+        assert result["search"]["fallback_reason"] == "server_error"
+        assert result["search"]["server_error"] == "server search failed"
         mock_monarch_client.get_transactions.assert_has_calls(
             [
                 call(limit=10, offset=0, search="WHOLE"),
-                call(limit=10, offset=0, search="whole"),
                 call(limit=200, offset=0),
             ]
         )

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -2,7 +2,7 @@
 
 import json
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from monarch_mcp_server.tools.transactions import (
     get_transactions,
@@ -23,7 +23,7 @@ from monarch_mcp_server.tools.transactions import (
 class TestGetTransactionsNeedingReview:
     """Tests for get_transactions_needing_review tool."""
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_get_transactions_needs_review_filter(self, mock_get_client):
         """Test filtering by needs_review flag."""
         mock_client = AsyncMock()
@@ -64,7 +64,7 @@ class TestGetTransactionsNeedingReview:
         assert transactions[0]["id"] == "txn_1"
         assert transactions[0]["needs_review"] is True
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_get_transactions_uncategorized_filter(self, mock_get_client):
         """Test filtering for uncategorized transactions."""
         mock_client = AsyncMock()
@@ -99,8 +99,7 @@ class TestGetTransactionsNeedingReview:
         mock_get_client.return_value = mock_client
 
         result = await get_transactions_needing_review(
-            needs_review=True,
-            uncategorized_only=True
+            needs_review=True, uncategorized_only=True
         )
 
         transactions = json.loads(result)
@@ -108,13 +107,11 @@ class TestGetTransactionsNeedingReview:
         assert transactions[0]["id"] == "txn_1"
         assert transactions[0]["category"] is None
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_get_transactions_with_days_filter(self, mock_get_client):
         """Test filtering by days parameter."""
         mock_client = AsyncMock()
-        mock_client.get_transactions.return_value = {
-            "allTransactions": {"results": []}
-        }
+        mock_client.get_transactions.return_value = {"allTransactions": {"results": []}}
         mock_get_client.return_value = mock_client
 
         result = await get_transactions_needing_review(days=7, needs_review=False)
@@ -124,7 +121,7 @@ class TestGetTransactionsNeedingReview:
         assert "start_date" in call_kwargs
         assert "end_date" in call_kwargs
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_get_transactions_full_details(self, mock_get_client):
         """Test that full transaction details are returned."""
         mock_client = AsyncMock()
@@ -168,7 +165,7 @@ class TestGetTransactionsNeedingReview:
         assert len(txn["tags"]) == 1
         assert txn["tags"][0]["name"] == "Online"
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_get_transactions_error(self, mock_get_client):
         """Test error handling."""
         mock_get_client.side_effect = RuntimeError("Auth needed")
@@ -179,13 +176,11 @@ class TestGetTransactionsNeedingReview:
         assert data["error"] is True
         assert "Auth needed" in data["message"]
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_get_transactions_empty(self, mock_get_client):
         """Test when no transactions match criteria."""
         mock_client = AsyncMock()
-        mock_client.get_transactions.return_value = {
-            "allTransactions": {"results": []}
-        }
+        mock_client.get_transactions.return_value = {"allTransactions": {"results": []}}
         mock_get_client.return_value = mock_client
 
         result = await get_transactions_needing_review()
@@ -197,7 +192,7 @@ class TestGetTransactionsNeedingReview:
 class TestUpdateTransactionNotes:
     """Tests for update_transaction_notes tool."""
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_update_notes_simple(self, mock_get_client):
         """Test updating notes without receipt URL."""
         mock_client = AsyncMock()
@@ -205,14 +200,13 @@ class TestUpdateTransactionNotes:
         mock_get_client.return_value = mock_client
 
         await update_transaction_notes(
-            transaction_id="txn_123",
-            notes="Business lunch with client"
+            transaction_id="txn_123", notes="Business lunch with client"
         )
 
         call_kwargs = mock_client.update_transaction.call_args.kwargs
         assert call_kwargs["notes"] == "Business lunch with client"
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_update_notes_with_receipt(self, mock_get_client):
         """Test updating notes with receipt URL."""
         mock_client = AsyncMock()
@@ -222,13 +216,16 @@ class TestUpdateTransactionNotes:
         await update_transaction_notes(
             transaction_id="txn_123",
             notes="Office supplies",
-            receipt_url="https://drive.google.com/file/abc123"
+            receipt_url="https://drive.google.com/file/abc123",
         )
 
         call_kwargs = mock_client.update_transaction.call_args.kwargs
-        assert call_kwargs["notes"] == "[Receipt: https://drive.google.com/file/abc123] Office supplies"
+        assert (
+            call_kwargs["notes"]
+            == "[Receipt: https://drive.google.com/file/abc123] Office supplies"
+        )
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_update_notes_error(self, mock_get_client):
         """Test error handling."""
         mock_get_client.side_effect = RuntimeError("API error")
@@ -243,7 +240,7 @@ class TestUpdateTransactionNotes:
 class TestMarkTransactionReviewed:
     """Tests for mark_transaction_reviewed tool."""
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_mark_reviewed_success(self, mock_get_client):
         """Test marking transaction as reviewed."""
         mock_client = AsyncMock()
@@ -263,7 +260,7 @@ class TestMarkTransactionReviewed:
         data = json.loads(result)
         assert "updateTransaction" in data
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_mark_reviewed_error(self, mock_get_client):
         """Test error handling."""
         mock_get_client.side_effect = RuntimeError("API error")
@@ -278,7 +275,7 @@ class TestMarkTransactionReviewed:
 class TestBulkCategorizeTransactions:
     """Tests for bulk_categorize_transactions tool."""
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_bulk_categorize_all_success(self, mock_get_client):
         """Test successful bulk categorization of all transactions."""
         mock_client = AsyncMock()
@@ -288,7 +285,7 @@ class TestBulkCategorizeTransactions:
         result = await bulk_categorize_transactions(
             transaction_ids=["txn_1", "txn_2", "txn_3"],
             category_id="cat_123",
-            mark_reviewed=True
+            mark_reviewed=True,
         )
 
         data = json.loads(result)
@@ -300,7 +297,7 @@ class TestBulkCategorizeTransactions:
         # Verify update_transaction was called 3 times
         assert mock_client.update_transaction.call_count == 3
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_bulk_categorize_partial_failure(self, mock_get_client):
         """Test bulk categorization with some failures."""
         mock_client = AsyncMock()
@@ -313,8 +310,7 @@ class TestBulkCategorizeTransactions:
         mock_get_client.return_value = mock_client
 
         result = await bulk_categorize_transactions(
-            transaction_ids=["txn_1", "txn_2", "txn_3"],
-            category_id="cat_123"
+            transaction_ids=["txn_1", "txn_2", "txn_3"], category_id="cat_123"
         )
 
         data = json.loads(result)
@@ -324,7 +320,7 @@ class TestBulkCategorizeTransactions:
         assert len(data["errors"]) == 1
         assert data["errors"][0]["transaction_id"] == "txn_2"
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_bulk_categorize_without_mark_reviewed(self, mock_get_client):
         """Test bulk categorization without marking as reviewed."""
         mock_client = AsyncMock()
@@ -332,23 +328,20 @@ class TestBulkCategorizeTransactions:
         mock_get_client.return_value = mock_client
 
         await bulk_categorize_transactions(
-            transaction_ids=["txn_1"],
-            category_id="cat_123",
-            mark_reviewed=False
+            transaction_ids=["txn_1"], category_id="cat_123", mark_reviewed=False
         )
 
         call_kwargs = mock_client.update_transaction.call_args.kwargs
         assert "needs_review" not in call_kwargs
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_bulk_categorize_empty_list(self, mock_get_client):
         """Test bulk categorization with empty transaction list."""
         mock_client = AsyncMock()
         mock_get_client.return_value = mock_client
 
         result = await bulk_categorize_transactions(
-            transaction_ids=[],
-            category_id="cat_123"
+            transaction_ids=[], category_id="cat_123"
         )
 
         data = json.loads(result)
@@ -356,14 +349,13 @@ class TestBulkCategorizeTransactions:
         assert data["successful"] == 0
         assert data["failed"] == 0
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_bulk_categorize_client_error(self, mock_get_client):
         """Test error when client cannot be obtained."""
         mock_get_client.side_effect = RuntimeError("Auth needed")
 
         result = await bulk_categorize_transactions(
-            transaction_ids=["txn_1"],
-            category_id="cat_123"
+            transaction_ids=["txn_1"], category_id="cat_123"
         )
 
         data = json.loads(result)
@@ -391,7 +383,7 @@ class TestBulkCategorizeTransactions:
 class TestSearchTransactions:
     """Tests for search_transactions tool."""
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_search_with_text(self, mock_get_client):
         """Test text search."""
         mock_client = AsyncMock()
@@ -421,13 +413,11 @@ class TestSearchTransactions:
         transactions = json.loads(result)
         assert len(transactions) == 1
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_search_with_multiple_filters(self, mock_get_client):
         """Test search with multiple filters."""
         mock_client = AsyncMock()
-        mock_client.get_transactions.return_value = {
-            "allTransactions": {"results": []}
-        }
+        mock_client.get_transactions.return_value = {"allTransactions": {"results": []}}
         mock_get_client.return_value = mock_client
 
         await search_transactions(
@@ -437,7 +427,7 @@ class TestSearchTransactions:
             category_ids=["cat_1"],
             account_ids=["acc_1"],
             has_notes=False,
-            is_recurring=True
+            is_recurring=True,
         )
 
         call_kwargs = mock_client.get_transactions.call_args.kwargs
@@ -449,7 +439,7 @@ class TestSearchTransactions:
         assert call_kwargs["has_notes"] is False
         assert call_kwargs["is_recurring"] is True
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_search_returns_full_details(self, mock_get_client):
         """Test that search returns full transaction details."""
         mock_client = AsyncMock()
@@ -487,7 +477,7 @@ class TestSearchTransactions:
         assert txn["is_recurring"] is False
         assert len(txn["tags"]) == 1
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_search_error(self, mock_get_client):
         """Test error handling."""
         mock_get_client.side_effect = RuntimeError("API error")
@@ -502,7 +492,7 @@ class TestSearchTransactions:
 class TestGetTransactionDetails:
     """Tests for get_transaction_details tool."""
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_get_details_success(self, mock_get_client):
         """Test successful retrieval of transaction details."""
         mock_client = AsyncMock()
@@ -527,7 +517,7 @@ class TestGetTransactionDetails:
         data = json.loads(result)
         assert "getTransaction" in data
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_get_details_error(self, mock_get_client):
         """Test error handling."""
         mock_get_client.side_effect = RuntimeError("Transaction not found")
@@ -542,7 +532,7 @@ class TestGetTransactionDetails:
 class TestDeleteTransaction:
     """Tests for delete_transaction tool."""
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_delete_success(self, mock_get_client):
         """Test successful transaction deletion."""
         mock_client = AsyncMock()
@@ -553,14 +543,12 @@ class TestDeleteTransaction:
 
         result = await delete_transaction(transaction_id="txn_123")
 
-        mock_client.delete_transaction.assert_called_once_with(
-            transaction_id="txn_123"
-        )
+        mock_client.delete_transaction.assert_called_once_with(transaction_id="txn_123")
 
         data = json.loads(result)
         assert data["deleteTransaction"]["deleted"] is True
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_delete_error(self, mock_get_client):
         """Test error handling."""
         mock_get_client.side_effect = RuntimeError("Cannot delete")
@@ -575,7 +563,7 @@ class TestDeleteTransaction:
 class TestGetRecurringTransactions:
     """Tests for get_recurring_transactions tool."""
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_get_recurring_success(self, mock_get_client):
         """Test successful retrieval of recurring transactions."""
         mock_client = AsyncMock()
@@ -608,7 +596,7 @@ class TestGetRecurringTransactions:
         assert recurring[0]["stream"]["merchant"] == "Netflix"
         assert recurring[0]["stream"]["frequency"] == "monthly"
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_get_recurring_with_dates(self, mock_get_client):
         """Test with custom date range."""
         mock_client = AsyncMock()
@@ -617,16 +605,13 @@ class TestGetRecurringTransactions:
         }
         mock_get_client.return_value = mock_client
 
-        await get_recurring_transactions(
-            start_date="2024-02-01",
-            end_date="2024-02-29"
-        )
+        await get_recurring_transactions(start_date="2024-02-01", end_date="2024-02-29")
 
         call_kwargs = mock_client.get_recurring_transactions.call_args.kwargs
         assert call_kwargs["start_date"] == "2024-02-01"
         assert call_kwargs["end_date"] == "2024-02-29"
 
-    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_get_recurring_error(self, mock_get_client):
         """Test error handling."""
         mock_get_client.side_effect = RuntimeError("API error")
@@ -639,13 +624,38 @@ class TestGetRecurringTransactions:
 
 
 class TestGetTransactions:
+    async def _transaction_response(self, **kwargs):
+        return json.loads(await get_transactions(**kwargs))
+
+    async def _transaction_rows(self, **kwargs):
+        return (await self._transaction_response(**kwargs))["data"]
+
+    async def test_returns_response_envelope(self):
+        result = await self._transaction_response()
+        assert result["tool"] == "get_transactions"
+        assert result["args"]["limit"] == 100
+        assert result["args"]["offset"] == 0
+        assert result["count"] == 2
+        assert result["total_count"] is None
+        assert result["truncated"] is False
+        assert result["search"]["strategy"] == "server"
+        assert isinstance(result["data"], list)
+
     async def test_returns_formatted_transactions(self):
-        result = json.loads(await get_transactions())
+        result = await self._transaction_rows()
         assert len(result) == 2
         assert result[0]["id"] == "txn-1"
         assert result[0]["amount"] == -42.50
+        assert result[0]["currency"] == "CAD"
+        assert result[0]["direction"] == "outflow"
+        assert result[0]["direction_source"] == "amount_sign"
+        assert result[0]["transaction_type"] == "expense"
+        assert result[0]["original_statement"] == "WHOLE FOODS MARKET 10234"
+        assert result[0]["plaid_description"] == "WHOLE FOODS MARKET 10234"
         assert result[0]["category"] == "Groceries"
         assert result[0]["category_id"] == "cat-1"
+        assert result[0]["category_group"] == "Food"
+        assert result[0]["category_group_id"] == "grp-1"
         assert result[0]["account_id"] == "acc-1"
         assert result[0]["merchant"] == "Whole Foods"
         assert result[0]["needs_review"] is True
@@ -657,8 +667,10 @@ class TestGetTransactions:
         assert result[0]["tags"] == [{"id": "tag-1", "name": "business"}]
 
     async def test_handles_null_merchant(self):
-        result = json.loads(await get_transactions())
+        result = await self._transaction_rows()
         assert result[1]["merchant"] is None
+        assert result[1]["currency"] == "USD"
+        assert result[1]["direction"] == "inflow"
         assert result[1]["notes"] is None
         assert result[1]["needs_review"] is False
         assert result[1]["tags"] == []
@@ -687,7 +699,7 @@ class TestGetTransactions:
                 ]
             }
         }
-        result = json.loads(await get_transactions())
+        result = await self._transaction_rows()
         assert result[0]["category"] is None
         assert result[0]["category_id"] is None
         assert result[0]["is_pending"] is True
@@ -739,17 +751,120 @@ class TestGetTransactions:
             limit=100, offset=0, category_ids=["cat-1"], tag_ids=["tag-1", "tag-2"]
         )
 
+    async def test_category_group_filter_expands_to_categories(
+        self, mock_monarch_client
+    ):
+        await get_transactions(category_group_ids=["grp-1"])
+        mock_monarch_client.get_transactions.assert_called_once_with(
+            limit=100, offset=0, category_ids=["cat-1", "cat-2"]
+        )
+
+    async def test_category_group_filter_merges_category_ids(self, mock_monarch_client):
+        await get_transactions(category_ids=["cat-3"], category_group_ids=["grp-1"])
+        mock_monarch_client.get_transactions.assert_called_once_with(
+            limit=100, offset=0, category_ids=["cat-3", "cat-1", "cat-2"]
+        )
+
+    async def test_category_group_filter_with_no_matches_returns_empty(
+        self, mock_monarch_client
+    ):
+        result = await self._transaction_response(category_group_ids=["grp-missing"])
+        assert result["count"] == 0
+        assert result["truncated"] is False
+        assert result["data"] == []
+        mock_monarch_client.get_transactions.assert_not_called()
+
+    async def test_uppercase_search_retries_lowercase(self, mock_monarch_client):
+        response = mock_monarch_client.get_transactions.return_value
+        mock_monarch_client.get_transactions.side_effect = [
+            Exception(),
+            response,
+        ]
+        result = await self._transaction_response(search="RRSP")
+        assert len(result["data"]) == 2
+        assert result["search"]["strategy"] == "lowercase_retry"
+        assert result["search"]["fallback_reason"] == "server_error"
+        mock_monarch_client.get_transactions.assert_has_calls(
+            [
+                call(limit=100, offset=0, search="RRSP"),
+                call(limit=100, offset=0, search="rrsp"),
+            ]
+        )
+
+    async def test_empty_search_results_fall_back_to_wide_search(
+        self, mock_monarch_client
+    ):
+        response = mock_monarch_client.get_transactions.return_value
+        mock_monarch_client.get_transactions.side_effect = [
+            {"allTransactions": {"results": []}},
+            response,
+        ]
+        result = await self._transaction_response(search="whole foods", limit=10)
+        assert result["count"] == 1
+        assert result["data"][0]["id"] == "txn-1"
+        assert result["search"]["strategy"] == "wide"
+        assert result["search"]["fallback_reason"] == "empty_server_results"
+        assert result["search"]["scan_limit"] == 1000
+        mock_monarch_client.get_transactions.assert_has_calls(
+            [
+                call(limit=10, offset=0, search="whole foods"),
+                call(limit=1000, offset=0),
+            ]
+        )
+
+    async def test_search_errors_fall_back_to_wide_search(self, mock_monarch_client):
+        response = mock_monarch_client.get_transactions.return_value
+        mock_monarch_client.get_transactions.side_effect = [
+            Exception(),
+            Exception(),
+            response,
+        ]
+        result = await self._transaction_response(search="WHOLE", limit=10)
+        assert result["count"] == 1
+        assert result["data"][0]["id"] == "txn-1"
+        assert result["search"]["strategy"] == "wide"
+        assert result["search"]["fallback_reason"] == "server_and_lowercase_retry_error"
+        mock_monarch_client.get_transactions.assert_has_calls(
+            [
+                call(limit=10, offset=0, search="WHOLE"),
+                call(limit=10, offset=0, search="whole"),
+                call(limit=1000, offset=0),
+            ]
+        )
+
     async def test_handles_empty_transactions(self, mock_monarch_client):
         mock_monarch_client.get_transactions.return_value = {
             "allTransactions": {"results": []}
         }
-        result = json.loads(await get_transactions())
-        assert result == []
+        result = await self._transaction_response()
+        assert result["count"] == 0
+        assert result["truncated"] is False
+        assert result["data"] == []
+
+    async def test_truncated_when_total_count_has_more_rows(self, mock_monarch_client):
+        mock_monarch_client.get_transactions.return_value["allTransactions"][
+            "totalCount"
+        ] = 3
+        result = await self._transaction_response(limit=2)
+        assert result["count"] == 2
+        assert result["total_count"] == 3
+        assert result["truncated"] is True
+
+    async def test_truncated_when_page_is_full_without_total_count(self):
+        result = await self._transaction_response(limit=2)
+        assert result["count"] == 2
+        assert result["total_count"] is None
+        assert result["truncated"] is True
 
     async def test_handles_api_error(self, mock_monarch_client):
         mock_monarch_client.get_transactions.side_effect = Exception("Auth expired")
         result = await get_transactions()
         assert "get_transactions" in result
+
+    async def test_handles_blank_api_error(self, mock_monarch_client):
+        mock_monarch_client.get_transactions.side_effect = Exception()
+        result = await get_transactions()
+        assert "Exception()" in result
 
 
 class TestCreateTransaction:
@@ -866,4 +981,3 @@ class TestCategorizeTransaction:
         mock_monarch_client.update_transaction.side_effect = Exception("boom")
         result = await categorize_transaction("txn-1", "cat-2")
         assert "categorize_transaction" in result
-

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -799,18 +799,30 @@ class TestGetTransactions:
             {"allTransactions": {"results": []}},
             response,
         ]
-        result = await self._transaction_response(search="whole foods", limit=10)
+        result = await self._transaction_response(
+            search="whole foods", limit=10, wide_search=True
+        )
         assert result["count"] == 1
         assert result["data"][0]["id"] == "txn-1"
         assert result["search"]["strategy"] == "wide"
         assert result["search"]["fallback_reason"] == "empty_server_results"
-        assert result["search"]["scan_limit"] == 1000
+        assert result["search"]["scan_limit"] == 200
         mock_monarch_client.get_transactions.assert_has_calls(
             [
                 call(limit=10, offset=0, search="whole foods"),
-                call(limit=1000, offset=0),
+                call(limit=200, offset=0),
             ]
         )
+
+    async def test_wide_search_off_by_default(self, mock_monarch_client):
+        mock_monarch_client.get_transactions.return_value = {
+            "allTransactions": {"results": []}
+        }
+        result = await self._transaction_response(search="whole foods", limit=10)
+        assert result["count"] == 0
+        assert result["search"]["strategy"] == "server"
+        # Only one call: the server-side search. No local-scan fallback.
+        assert mock_monarch_client.get_transactions.call_count == 1
 
     async def test_search_errors_fall_back_to_wide_search(self, mock_monarch_client):
         response = mock_monarch_client.get_transactions.return_value
@@ -819,7 +831,9 @@ class TestGetTransactions:
             Exception(),
             response,
         ]
-        result = await self._transaction_response(search="WHOLE", limit=10)
+        result = await self._transaction_response(
+            search="WHOLE", limit=10, wide_search=True
+        )
         assert result["count"] == 1
         assert result["data"][0]["id"] == "txn-1"
         assert result["search"]["strategy"] == "wide"
@@ -828,7 +842,7 @@ class TestGetTransactions:
             [
                 call(limit=10, offset=0, search="WHOLE"),
                 call(limit=10, offset=0, search="whole"),
-                call(limit=1000, offset=0),
+                call(limit=200, offset=0),
             ]
         )
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -647,6 +647,7 @@ class TestGetTransactions:
         assert result[0]["id"] == "txn-1"
         assert result[0]["amount"] == -42.50
         assert result[0]["currency"] == "CAD"
+        assert result[0]["currency_source"] == "api"
         assert result[0]["direction"] == "outflow"
         assert result[0]["direction_source"] == "amount_sign"
         assert result[0]["transaction_type"] == "expense"
@@ -670,6 +671,7 @@ class TestGetTransactions:
         result = await self._transaction_rows()
         assert result[1]["merchant"] is None
         assert result[1]["currency"] == "USD"
+        assert result[1]["currency_source"] == "account_name_guess"
         assert result[1]["direction"] == "inflow"
         assert result[1]["notes"] is None
         assert result[1]["needs_review"] is False


### PR DESCRIPTION
Summary:
- add get_transactions response envelope metadata for spooled agent-tools output
- expose original statement, currency, direction metadata, category group data, and merchant id
- add wide_search fallback for empty/erroring Monarch search results across original statement, merchant, notes, category, account, and tags
- add category_group_ids filtering

Tests:
- uv run pytest -q