### PR TITLE
Harden mutating tools and trim debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,14 @@ monarch-mcp-server/
 - Session files are encrypted
 - Authentication handled in secure terminal environment
 
+### Recommended: require approval for mutating tools
+
+Several tools mutate your Monarch ledger (`create_transaction`, `update_transaction`, `delete_transaction`, `bulk_categorize_transactions`, `upload_account_balance_history`, `set_transaction_tags`, `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`, `split_transaction`, `set_budget_amount`).
+
+Because the LLM can be influenced by data it reads back (a malicious-looking memo or merchant name in a transaction), the safest setup is to configure your MCP client to require manual approval before any mutating tool runs. In Claude Desktop and Claude Code this is the default behavior for unknown tools; keep it that way for the tools listed above rather than allow-listing them.
+
+`bulk_categorize_transactions` and `upload_account_balance_history` also accept a `dry_run=True` argument that returns the planned changes without executing them, useful for previewing a bulk action before approving it.
+
 ## 🙏 Acknowledgments
 
 This MCP server is built on top of the [MonarchMoneyCommunity Python library](https://github.com/bradleyseanf/monarchmoneycommunity), an actively maintained community fork of the original [MonarchMoney library](https://github.com/hammem/monarchmoney) by [@hammem](https://github.com/hammem). The community fork provides:

--- a/src/monarch_mcp_server/tools/accounts.py
+++ b/src/monarch_mcp_server/tools/accounts.py
@@ -2,14 +2,25 @@
 
 import json
 import logging
-from datetime import datetime
-from typing import Optional
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Dict, Optional
+
+from pydantic import RootModel, ValidationError
 
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
 from monarch_mcp_server.helpers import json_success, json_error
 
 logger = logging.getLogger(__name__)
+
+
+class BalanceCorrections(RootModel[Dict[date, Decimal]]):
+    """Validates the corrections payload for upload_account_balance_history.
+
+    Keys must be ISO dates (YYYY-MM-DD) and values must parse as decimals.
+    Pydantic raises on bad input rather than letting typos silently no-op.
+    """
 
 
 @mcp.tool()
@@ -114,7 +125,11 @@ async def get_account_balance_history(account_id: str) -> str:
 
 
 @mcp.tool()
-async def upload_account_balance_history(account_id: str, corrections: str) -> str:
+async def upload_account_balance_history(
+    account_id: str,
+    corrections: str,
+    dry_run: bool = False,
+) -> str:
     """
     Upload corrected balance snapshots for an account.
 
@@ -123,26 +138,60 @@ async def upload_account_balance_history(account_id: str, corrections: str) -> s
 
     Args:
         account_id: The ID of the account to correct
-        corrections: JSON object mapping dates to corrected balances,
-                     e.g. '{"2026-04-23": 24846.45, "2026-04-24": 24846.45}'
+        corrections: JSON object mapping ISO dates (YYYY-MM-DD) to corrected
+                     balances, e.g. '{"2026-04-23": 24846.45, "2026-04-24": 24846.45}'
+        dry_run: If True, return the planned changes without uploading
+
+    Mismatched dates (corrections that do not match any existing snapshot) are
+    surfaced explicitly in the response rather than silently dropped.
     """
     try:
-        from monarchmoney.monarchmoney import BalanceHistoryRow
+        try:
+            raw = json.loads(corrections)
+        except json.JSONDecodeError as exc:
+            return json_error(
+                "upload_account_balance_history",
+                ValueError(f"corrections is not valid JSON: {exc.msg}"),
+            )
 
-        date_to_balance = json.loads(corrections)
+        if not isinstance(raw, dict):
+            return json_error(
+                "upload_account_balance_history",
+                ValueError("corrections must be a JSON object mapping dates to numbers"),
+            )
+
+        try:
+            validated = BalanceCorrections.model_validate(raw)
+        except ValidationError as exc:
+            return json_error("upload_account_balance_history", exc)
+
+        date_to_balance: Dict[str, Decimal] = {
+            d.isoformat(): amount for d, amount in validated.root.items()
+        }
+
+        if not date_to_balance:
+            return json_success({
+                "updated": False,
+                "message": "No corrections provided",
+            })
+
+        from monarchmoney.monarchmoney import BalanceHistoryRow
 
         client = await get_monarch_client()
         snapshots = await client.get_account_history(account_id=int(account_id))
 
-        applied = []
-        rows = []
+        existing_dates = {s.get("date") for s in snapshots}
+        unmatched = sorted(d for d in date_to_balance if d not in existing_dates)
+
+        applied: list[str] = []
+        rows: list[BalanceHistoryRow] = []
         for snapshot in snapshots:
             date_str = snapshot.get("date")
             balance = snapshot.get("signedBalance", 0)
             account_name = snapshot.get("accountName", "")
 
             if date_str in date_to_balance:
-                balance = date_to_balance[date_str]
+                balance = float(date_to_balance[date_str])
                 applied.append(date_str)
 
             rows.append(BalanceHistoryRow(
@@ -152,7 +201,20 @@ async def upload_account_balance_history(account_id: str, corrections: str) -> s
             ))
 
         if not applied:
-            return json_success({"updated": False, "message": "No matching dates found in history"})
+            return json_success({
+                "updated": False,
+                "message": "No matching dates found in history",
+                "unmatched_dates": unmatched,
+            })
+
+        if dry_run:
+            return json_success({
+                "dry_run": True,
+                "account_id": account_id,
+                "dates_to_correct": applied,
+                "unmatched_dates": unmatched,
+                "total_snapshots": len(rows),
+            })
 
         result = await client.upload_account_balance_history(
             account_id=account_id,
@@ -162,6 +224,7 @@ async def upload_account_balance_history(account_id: str, corrections: str) -> s
         return json_success({
             "updated": result,
             "dates_corrected": applied,
+            "unmatched_dates": unmatched,
             "total_snapshots": len(rows),
         })
     except Exception as e:

--- a/src/monarch_mcp_server/tools/auth.py
+++ b/src/monarch_mcp_server/tools/auth.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import traceback
 
 from mcp.server.fastmcp import Context
 
@@ -89,9 +88,8 @@ async def debug_session_loading() -> str:
     try:
         token = secure_session.load_token()
         if token:
-            return f"✅ Token found in keyring (length: {len(token)})"
-        else:
-            return "❌ No token found in keyring. Run login_setup.py to authenticate."
+            return "✅ Token found in keyring."
+        return "❌ No token found in keyring. Run login_setup.py to authenticate."
     except Exception as e:
-        error_details = traceback.format_exc()
-        return f"❌ Keyring access failed:\nError: {str(e)}\nType: {type(e)}\nTraceback:\n{error_details}"
+        logger.exception("Keyring access failed")
+        return f"❌ Keyring access failed: {type(e).__name__}: {e}"

--- a/src/monarch_mcp_server/tools/transactions.py
+++ b/src/monarch_mcp_server/tools/transactions.py
@@ -392,6 +392,7 @@ async def bulk_categorize_transactions(
     transaction_ids: List[str],
     category_id: str,
     mark_reviewed: bool = True,
+    dry_run: bool = False,
 ) -> str:
     """
     Apply the same category to multiple transactions at once.
@@ -403,11 +404,22 @@ async def bulk_categorize_transactions(
         transaction_ids: List of transaction IDs to categorize
         category_id: The category ID to apply to all transactions
         mark_reviewed: Whether to also mark transactions as reviewed (default: True)
+        dry_run: If True, return what would be updated without making changes
 
     Returns:
-        Summary of results including success/failure counts.
+        Summary of results including success/failure counts. When dry_run is
+        True, the response includes a "dry_run" flag and the planned updates.
     """
     try:
+        if dry_run:
+            return json_success({
+                "dry_run": True,
+                "total": len(transaction_ids),
+                "transaction_ids": list(transaction_ids),
+                "category_id": category_id,
+                "mark_reviewed": mark_reviewed,
+            })
+
         client = await get_monarch_client()
 
         results: Dict[str, Any] = {

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -113,6 +113,7 @@ class TestUploadAccountBalanceHistory:
         result = json.loads(await upload_account_balance_history("12345", corrections))
         assert result["updated"] is True
         assert result["dates_corrected"] == ["2026-04-21"]
+        assert result["unmatched_dates"] == []
         assert result["total_snapshots"] == 3
 
         call_args = mock_monarch_client.upload_account_balance_history.call_args
@@ -123,7 +124,57 @@ class TestUploadAccountBalanceHistory:
         corrections = json.dumps({"2026-01-01": 500.0})
         result = json.loads(await upload_account_balance_history("12345", corrections))
         assert result["updated"] is False
+        assert result["unmatched_dates"] == ["2026-01-01"]
         mock_monarch_client.upload_account_balance_history.assert_not_called()
+
+    async def test_surfaces_unmatched_alongside_applied(self, mock_monarch_client):
+        corrections = json.dumps({"2026-04-21": 900.0, "2099-12-31": 1.0})
+        result = json.loads(await upload_account_balance_history("12345", corrections))
+        assert result["updated"] is True
+        assert result["dates_corrected"] == ["2026-04-21"]
+        assert result["unmatched_dates"] == ["2099-12-31"]
+
+    async def test_dry_run_skips_upload(self, mock_monarch_client):
+        corrections = json.dumps({"2026-04-21": 900.0})
+        result = json.loads(
+            await upload_account_balance_history("12345", corrections, dry_run=True)
+        )
+        assert result["dry_run"] is True
+        assert result["dates_to_correct"] == ["2026-04-21"]
+        assert result["total_snapshots"] == 3
+        mock_monarch_client.upload_account_balance_history.assert_not_called()
+
+    async def test_rejects_invalid_json(self, mock_monarch_client):
+        result = json.loads(
+            await upload_account_balance_history("12345", "not json")
+        )
+        assert result["error"] is True
+        assert "valid JSON" in result["message"]
+        mock_monarch_client.get_account_history.assert_not_called()
+
+    async def test_rejects_non_object(self, mock_monarch_client):
+        result = json.loads(
+            await upload_account_balance_history("12345", "[1, 2, 3]")
+        )
+        assert result["error"] is True
+        assert "JSON object" in result["message"]
+        mock_monarch_client.get_account_history.assert_not_called()
+
+    async def test_rejects_invalid_date_key(self, mock_monarch_client):
+        result = json.loads(
+            await upload_account_balance_history("12345", '{"yesterday": 100}')
+        )
+        assert result["error"] is True
+        mock_monarch_client.get_account_history.assert_not_called()
+
+    async def test_rejects_non_numeric_value(self, mock_monarch_client):
+        result = json.loads(
+            await upload_account_balance_history(
+                "12345", '{"2026-04-21": "not-a-number"}'
+            )
+        )
+        assert result["error"] is True
+        mock_monarch_client.get_account_history.assert_not_called()
 
     async def test_handles_api_error(self, mock_monarch_client):
         mock_monarch_client.get_account_history.side_effect = Exception("Timeout")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -108,3 +108,41 @@ class TestLogout:
         result = asyncio.run(auth.logout())
         assert "Cleared" in result
         no_session_save.delete_token.assert_called_once()
+
+
+class TestDebugSessionLoading:
+    def test_no_token_message(self):
+        from monarch_mcp_server.tools import auth as tools_auth
+
+        with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_token",
+            return_value=None,
+        ):
+            result = asyncio.run(tools_auth.debug_session_loading())
+        assert "No token" in result
+
+    def test_token_present_does_not_leak_length(self):
+        from monarch_mcp_server.tools import auth as tools_auth
+
+        with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_token",
+            return_value="a-secret-token-value",
+        ):
+            result = asyncio.run(tools_auth.debug_session_loading())
+        assert "Token found" in result
+        assert "length" not in result.lower()
+        assert "a-secret-token-value" not in result
+
+    def test_keyring_failure_omits_traceback(self):
+        from monarch_mcp_server.tools import auth as tools_auth
+
+        with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_token",
+            side_effect=RuntimeError("keyring backend unavailable"),
+        ):
+            result = asyncio.run(tools_auth.debug_session_loading())
+        assert "Keyring access failed" in result
+        assert "RuntimeError" in result
+        assert "keyring backend unavailable" in result
+        assert "Traceback" not in result
+        assert 'File "' not in result

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -370,6 +370,23 @@ class TestBulkCategorizeTransactions:
         assert data["error"] is True
         assert "Auth needed" in data["message"]
 
+    @patch('monarch_mcp_server.tools.transactions.get_monarch_client')
+    async def test_bulk_categorize_dry_run_skips_client(self, mock_get_client):
+        """dry_run returns the planned update without calling the SDK."""
+        result = await bulk_categorize_transactions(
+            transaction_ids=["txn_1", "txn_2"],
+            category_id="cat_123",
+            dry_run=True,
+        )
+
+        data = json.loads(result)
+        assert data["dry_run"] is True
+        assert data["total"] == 2
+        assert data["transaction_ids"] == ["txn_1", "txn_2"]
+        assert data["category_id"] == "cat_123"
+        assert data["mark_reviewed"] is True
+        mock_get_client.assert_not_called()
+
 
 class TestSearchTransactions:
     """Tests for search_transactions tool."""


### PR DESCRIPTION
Addresses findings from a proactive security review (related to #50, but not closing it).

- `bulk_categorize_transactions` and `upload_account_balance_history` now accept `dry_run=True` to preview planned changes without executing.
- `upload_account_balance_history` validates `corrections` with a pydantic `RootModel[Dict[date, Decimal]]`. Bad JSON, payloads that are not JSON objects, malformed date keys, and values that are not numeric now error explicitly instead of silently doing nothing. Unmatched dates surface in the response.
- `debug_session_loading` returns just the error class and message. The full traceback is logged server side and the token length is no longer disclosed.
- README documents the recommendation that MCP clients require manual approval for mutating tools.

## Test plan
- [x] `uv run --extra dev pytest tests/` (126 passing, 10 new)