### PR TITLE
Require mcp[cli] >= 1.10.0 for elicitation login

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,15 @@ Sessions last for weeks, but if expired:
 2. Enter your credentials and 2FA code
 3. Session will be refreshed automatically
 
+### `'Context' object has no attribute 'elicit'`
+The `monarch_login` and `monarch_login_with_token` tools require the MCP Python SDK 1.10.0 or newer (released June 2025). If your environment cached an older `mcp` install, refresh it:
+
+```bash
+uv cache clean mcp
+```
+
+Then fully quit and reopen Claude Desktop or Claude Code so it relaunches the server with a fresh resolution. As a fallback while you upgrade, run `python login_setup.py` from the repo to authenticate via the terminal.
+
 ### Common Error Messages
 - **"No valid session found"**: Run `python login_setup.py` (or `uv run python login_setup.py`) 
 - **"Invalid account ID"**: Use `get_accounts` to see valid account IDs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.12,<3.14"
 dependencies = [
-    "mcp[cli]>=1.0.0",
+    "mcp[cli]>=1.10.0",
     "monarchmoneycommunity>=1.2.0",
     "gql>=3.4,<4.0",
     "keyring>=24.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mcp[cli]>=1.0.0
+mcp[cli]>=1.10.0
 monarchmoneycommunity>=1.2.0
 gql>=3.4,<4.0
 keyring>=24.0.0

--- a/src/monarch_mcp_server/auth.py
+++ b/src/monarch_mcp_server/auth.py
@@ -13,6 +13,20 @@ from pydantic import BaseModel, Field
 from monarch_mcp_server.secure_session import secure_session
 
 
+_UPGRADE_HINT = (
+    "Elicitation requires the MCP Python SDK >= 1.10.0 (added in June 2025). "
+    "Your MCP server install appears to be running an older version that does "
+    "not expose Context.elicit. Upgrade the `mcp` package, then restart your "
+    "MCP client. If you launch via `uv run --with mcp[cli]`, run `uv cache "
+    "clean mcp` first so a fresh version is resolved. As a fallback, run "
+    "`python login_setup.py` from the repo to authenticate via terminal."
+)
+
+
+def _elicit_supported(ctx: Context) -> bool:
+    return hasattr(ctx, "elicit")
+
+
 class LoginForm(BaseModel):
     email: str = Field(description="Monarch Money email address")
     password: str = Field(description="Monarch Money password")
@@ -32,6 +46,8 @@ class TokenForm(BaseModel):
 
 
 async def login_interactive(ctx: Context) -> str:
+    if not _elicit_supported(ctx):
+        return _UPGRADE_HINT
     form_result = await ctx.elicit(message="Sign in to Monarch Money.", schema=LoginForm)
     if form_result.action != "accept":
         return "Login cancelled."
@@ -60,6 +76,8 @@ async def login_interactive(ctx: Context) -> str:
 
 
 async def login_with_token_interactive(ctx: Context) -> str:
+    if not _elicit_supported(ctx):
+        return _UPGRADE_HINT
     form_result = await ctx.elicit(
         message="Paste your Monarch Money session token.", schema=TokenForm
     )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -146,3 +146,20 @@ class TestDebugSessionLoading:
         assert "keyring backend unavailable" in result
         assert "Traceback" not in result
         assert 'File "' not in result
+
+
+class TestElicitNotSupported:
+    """Older MCP SDKs (<1.10) do not expose Context.elicit."""
+
+    def test_login_interactive_returns_upgrade_hint(self, no_session_save):
+        ctx = SimpleNamespace()  # no elicit attribute
+        result = asyncio.run(auth.login_interactive(ctx))
+        assert "1.10" in result
+        assert "login_setup.py" in result
+        no_session_save.save_authenticated_session.assert_not_called()
+
+    def test_login_with_token_returns_upgrade_hint(self, no_session_save):
+        ctx = SimpleNamespace()
+        result = asyncio.run(auth.login_with_token_interactive(ctx))
+        assert "1.10" in result
+        no_session_save.save_token.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ requires-dist = [
     { name = "gql", specifier = ">=3.4,<4.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "keyring", specifier = ">=24.0.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.0.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.10.0" },
     { name = "monarchmoneycommunity", specifier = ">=1.2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },


### PR DESCRIPTION
The `monarch_login` and `monarch_login_with_token` tools call `Context.elicit`, which only exists in the MCP Python SDK 1.10.0 and newer (released June 2025). The previous floor of `>=1.0.0` let users resolve to older versions, in which case the tools crashed with a cryptic `AttributeError: 'Context' object has no attribute 'elicit'`.

- `pyproject.toml`, `requirements.txt`, `uv.lock` floor bumped to `mcp[cli]>=1.10.0`. The locked version stays at 1.13.1.
- `auth.login_interactive` and `auth.login_with_token_interactive` now check `hasattr(ctx, "elicit")` and return a clear message pointing to `uv cache clean` and the `login_setup.py` fallback if the SDK is too old.
- README documents the recovery path under Troubleshooting.

Existing users with mcp 1.10 or newer are unaffected. Users on older mcp will see the constraint failure at install time with the actual cause, rather than a runtime crash later.

## Test plan
- [x] `uv run --extra dev pytest tests/` (118 passing, 2 new)