### PR TITLE
Fix get_net_worth and get_net_worth_by_account_type

### DIFF
--- a/src/monarch_mcp_server/tools/financial.py
+++ b/src/monarch_mcp_server/tools/financial.py
@@ -67,10 +67,12 @@ async def get_net_worth(
         client = await get_monarch_client()
 
         params: Dict[str, Any] = {}
+        # Pass ISO strings directly; upstream serializes via gql JSON and
+        # cannot handle datetime.date objects in GraphQL variables.
         if start_date:
-            params["start_date"] = dt.strptime(start_date, "%Y-%m-%d").date()
+            params["start_date"] = start_date
         if end_date:
-            params["end_date"] = dt.strptime(end_date, "%Y-%m-%d").date()
+            params["end_date"] = end_date
         if account_type:
             params["account_type"] = account_type
 
@@ -145,7 +147,9 @@ async def get_net_worth_by_account_type(
             timeframe=timeframe,
         )
 
-        account_types = result.get("accountTypeSnapshots", [])
+        # Upstream returns a flat list under key "snapshotsByAccountType"
+        # with shape [{"accountType": str, "month": "YYYY-MM" or "YYYY", "balance": float}, ...]
+        rows = result.get("snapshotsByAccountType", [])
 
         formatted: Dict[str, Any] = {
             "timeframe": timeframe,
@@ -153,21 +157,21 @@ async def get_net_worth_by_account_type(
             "account_types": []
         }
 
-        for acct_type in account_types:
-            type_info: Dict[str, Any] = {
-                "type": acct_type.get("accountType"),
-                "snapshots": []
-            }
+        # Group flat rows by accountType, preserving order of first appearance.
+        grouped: Dict[str, Dict[str, Any]] = {}
+        for row in rows:
+            atype = row.get("accountType")
+            if atype is None:
+                continue
+            entry = grouped.setdefault(atype, {"type": atype, "snapshots": []})
+            entry["snapshots"].append({
+                "month": row.get("month"),
+                "balance": row.get("balance"),
+            })
 
-            for snapshot in acct_type.get("snapshots", []):
-                type_info["snapshots"].append({
-                    "month": snapshot.get("month"),
-                    "balance": snapshot.get("balance"),
-                })
-
+        for type_info in grouped.values():
             if type_info["snapshots"]:
                 type_info["current_balance"] = type_info["snapshots"][-1].get("balance", 0)
-
             formatted["account_types"].append(type_info)
 
         total = sum(


### PR DESCRIPTION
Closes #54.

## Summary

Fixes two defects in `tools/financial.py` that prevented both net-worth tools from returning data.

### Bug 1: `get_net_worth` errors when caller supplies dates

The tool converts `start_date` / `end_date` strings into `datetime.date` objects via `strptime(...).date()` before forwarding them to `client.get_aggregate_snapshots()`. The upstream `monarchmoneycommunity` client puts those values directly into a GraphQL `variables` payload, and `gql`'s JSON encoder cannot serialize `datetime.date`. Every call with explicit dates returned:

```json
{"error": true, "tool": "get_net_worth",
 "message": "Object of type date is not JSON serializable"}
```

The upstream client's own default-value branch already calls `.isoformat()` before sending (see `get_aggregate_snapshots` in `monarchmoney.py`), confirming the wire format is a string and the type hint `Optional[date]` is misleading.

**Fix:** pass the YYYY-MM-DD strings through unchanged.

### Bug 2: `get_net_worth_by_account_type` always returned an empty list

The upstream query `GetSnapshotsByAccountType` returns a top-level key `snapshotsByAccountType` containing a **flat** list of `{accountType, month, balance, __typename}` rows. The tool read a nonexistent key `accountTypeSnapshots` and assumed a pre-nested `{type, snapshots: [...]}` shape, so:

```json
{"timeframe": "month", "start_date": "...",
 "account_types": [], "total_net_worth": 0}
```

was returned on every call regardless of inputs.

**Fix:** read the correct response key and group the flat rows by `accountType`, preserving order of first appearance.

## Verification

- `get_net_worth(start_date="YYYY-MM-DD", end_date="YYYY-MM-DD")` now returns the expected daily snapshot series, with summary fields populated.
- `get_net_worth_by_account_type(start_date="YYYY-MM-DD", timeframe="month")` returns one entry per account type with monthly snapshots; sum of `current_balance` across types matches `current_net_worth` from `get_net_worth` to the cent.

## Notes

- Diff is 19/-15 lines, scoped to `tools/financial.py`.
- No changes to tool signatures, docstrings, or surface area; behavior is restored to what the docstrings already describe.
- This patch was developed with assistance from Claude (Anthropic).
