### PR TITLE
Add merchant management and recurring stream review tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 - **Update Transaction Rule**: Modify existing rules
 - **Delete Transaction Rule**: Remove a rule
 
+### 🔄 Merchant & Recurring Stream Management
+- **Get Merchant**: View a merchant's details including recurring transaction stream configuration
+- **Update Merchant**: Modify a merchant's name and/or recurring stream settings (frequency, amount, base date)
+- **Review Recurring Stream**: Accept, ignore, or reset recurring transaction streams detected by Monarch
+
 ### ✂️ Transaction Splits
 - **Get Transaction Splits**: View how a transaction has been split into parts
 - **Split Transaction**: Divide a single transaction into multiple parts with different categories or merchants
@@ -267,6 +272,9 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 | `create_transaction_rule` | Create an auto-categorization rule | `merchant_criteria_operator`, `merchant_criteria_value`, `set_category_id`, `add_tag_ids`, `amount_operator`, `amount_value` |
 | `update_transaction_rule` | Update an existing rule | `rule_id`, `merchant_criteria_operator`, `merchant_criteria_value`, `set_category_id` |
 | `delete_transaction_rule` | Delete a rule | `rule_id` |
+| `get_merchant` | Get merchant details with recurring stream | `merchant_id` |
+| `update_merchant` | Update merchant name/recurring stream | `merchant_id`, `name`, `is_recurring`, `frequency`, `base_date`, `amount`, `is_active` |
+| `review_recurring_stream` | Set recurring stream review status | `stream_id`, `review_status` |
 | `get_transaction_splits` | Get splits for a transaction | `transaction_id` |
 | `split_transaction` | Split a transaction into parts | `transaction_id`, `splits` (JSON array) |
 | `get_transactions_summary` | Get high-level transaction statistics | None |
@@ -371,6 +379,16 @@ Give me a quick summary of my transactions using get_transactions_summary
 Show my spending breakdown by category for last month using get_spending_summary
 ```
 
+### Update a Recurring Bill Amount
+```
+Update PennyMac's recurring stream to $1,460.93 monthly using update_merchant
+```
+
+### Review Recurring Streams
+```
+Approve the Netflix recurring stream using review_recurring_stream
+```
+
 ## 📅 Date Formats
 
 - All dates should be in `YYYY-MM-DD` format (e.g., "2024-01-15")
@@ -432,7 +450,7 @@ monarch-mcp-server/
 
 ### Recommended: require approval for mutating tools
 
-Several tools mutate your Monarch ledger (`create_transaction`, `update_transaction`, `delete_transaction`, `bulk_categorize_transactions`, `upload_account_balance_history`, `set_transaction_tags`, `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`, `split_transaction`, `set_budget_amount`).
+Several tools mutate your Monarch ledger (`create_transaction`, `update_transaction`, `delete_transaction`, `bulk_categorize_transactions`, `upload_account_balance_history`, `set_transaction_tags`, `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`, `split_transaction`, `set_budget_amount`, `update_merchant`, `review_recurring_stream`).
 
 Because the LLM can be influenced by data it reads back (a malicious-looking memo or merchant name in a transaction), the safest setup is to configure your MCP client to require manual approval before any mutating tool runs. In Claude Desktop and Claude Code this is the default behavior for unknown tools; keep it that way for the tools listed above rather than allow-listing them.
 

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -74,6 +74,11 @@ from monarch_mcp_server.tools.financial import (  # noqa: F401
     get_net_worth,
     get_net_worth_by_account_type,
 )
+from monarch_mcp_server.tools.merchants import (  # noqa: F401
+    get_merchant,
+    update_merchant,
+    review_recurring_stream,
+)
 
 if __name__ == "__main__":
     main()

--- a/src/monarch_mcp_server/tools/__init__.py
+++ b/src/monarch_mcp_server/tools/__init__.py
@@ -11,4 +11,5 @@ from monarch_mcp_server.tools import (  # noqa: F401
     categories,
     budgets,
     financial,
+    merchants,
 )

--- a/src/monarch_mcp_server/tools/merchants.py
+++ b/src/monarch_mcp_server/tools/merchants.py
@@ -1,0 +1,335 @@
+"""Merchant and recurring stream management tools with GraphQL queries."""
+
+import logging
+from typing import Any, Dict, Optional
+
+from gql import gql
+
+from monarch_mcp_server.app import mcp
+from monarch_mcp_server.client import get_monarch_client
+from monarch_mcp_server.helpers import json_error, json_success
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# GraphQL constants
+# ---------------------------------------------------------------------------
+
+GET_MERCHANT_QUERY = gql(
+    """
+query Common_GetEditMerchant($merchantId: ID!) {
+  merchant(id: $merchantId) {
+    id
+    name
+    logoUrl
+    transactionCount
+    ruleCount
+    canBeDeleted
+    hasActiveRecurringStreams
+    recurringTransactionStream {
+      id
+      frequency
+      amount
+      baseDate
+      isActive
+      __typename
+    }
+    __typename
+  }
+}
+"""
+)
+
+UPDATE_MERCHANT_MUTATION = gql(
+    """
+mutation Common_UpdateMerchant($input: UpdateMerchantInput!) {
+  updateMerchant(input: $input) {
+    merchant {
+      id
+      name
+      recurringTransactionStream {
+        id
+        frequency
+        amount
+        baseDate
+        isActive
+        __typename
+      }
+      __typename
+    }
+    errors {
+      fieldErrors {
+        field
+        messages
+        __typename
+      }
+      message
+      code
+      __typename
+    }
+    __typename
+  }
+}
+"""
+)
+
+REVIEW_STREAM_MUTATION = gql(
+    """
+mutation Web_ReviewStream($input: ReviewRecurringStreamInput!) {
+  reviewRecurringStream(input: $input) {
+    stream {
+      id
+      reviewStatus
+      __typename
+    }
+    errors {
+      fieldErrors {
+        field
+        messages
+        __typename
+      }
+      message
+      code
+      __typename
+    }
+    __typename
+  }
+}
+"""
+)
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def get_merchant(merchant_id: str) -> str:
+    """
+    Get a merchant's details including recurring transaction stream configuration.
+
+    Use this to look up a merchant's current recurring stream settings before
+    updating them with update_merchant.
+
+    Args:
+        merchant_id: The Monarch merchant ID (find via get_transactions or
+            get_recurring_transactions, which include merchant IDs in their
+            responses).
+
+    Returns:
+        Merchant details with name, transaction count, rule count, and
+        recurring stream configuration (frequency, amount, base date).
+
+    Example:
+        Look up PennyMac merchant details:
+            get_merchant(merchant_id="160319777541808781")
+    """
+    try:
+        client = await get_monarch_client()
+        result = await client.gql_call(
+            operation="Common_GetEditMerchant",
+            graphql_query=GET_MERCHANT_QUERY,
+            variables={"merchantId": merchant_id},
+        )
+
+        merchant = result.get("merchant")
+        if not merchant:
+            return json_success(
+                {
+                    "merchant": None,
+                    "message": "No merchant found with the given ID",
+                }
+            )
+
+        stream = merchant.get("recurringTransactionStream")
+        merchant_info: Dict[str, Any] = {
+            "id": merchant.get("id"),
+            "name": merchant.get("name"),
+            "logo_url": merchant.get("logoUrl"),
+            "transaction_count": merchant.get("transactionCount"),
+            "rule_count": merchant.get("ruleCount"),
+            "can_be_deleted": merchant.get("canBeDeleted"),
+            "has_active_recurring_streams": merchant.get("hasActiveRecurringStreams"),
+            "recurring_stream": (
+                {
+                    "id": stream.get("id"),
+                    "frequency": stream.get("frequency"),
+                    "amount": stream.get("amount"),
+                    "base_date": stream.get("baseDate"),
+                    "is_active": stream.get("isActive"),
+                }
+                if stream
+                else None
+            ),
+        }
+
+        return json_success({"merchant": merchant_info})
+    except Exception as e:
+        return json_error("get_merchant", e)
+
+
+@mcp.tool()
+async def update_merchant(
+    merchant_id: str,
+    name: Optional[str] = None,
+    is_recurring: Optional[bool] = None,
+    frequency: Optional[str] = None,
+    base_date: Optional[str] = None,
+    amount: Optional[float] = None,
+    is_active: Optional[bool] = None,
+) -> str:
+    """
+    Update a merchant's name and/or recurring transaction stream settings.
+
+    This is the only way to modify recurring stream configurations (frequency,
+    amount, base date, active status). Use get_merchant first to see current
+    settings, then update_merchant to change them.
+
+    Args:
+        merchant_id: The Monarch merchant ID.
+        name: New merchant display name.
+        is_recurring: Whether this merchant has a recurring stream.
+        frequency: Recurrence frequency. Known values: "weekly", "biweekly",
+            "twice_a_month", "monthly", "quarterly", "semiannually",
+            "annually".
+        base_date: Anchor date for recurrence in YYYY-MM-DD format.
+        amount: Expected recurring amount (negative for expenses, positive
+            for income).
+        is_active: Whether the recurring stream is actively tracked.
+
+    Returns:
+        Updated merchant details with recurring stream configuration.
+
+    Example:
+        Fix PennyMac mortgage to $1,460.93 monthly:
+            update_merchant(
+                merchant_id="160319777541808781",
+                is_recurring=True,
+                frequency="monthly",
+                base_date="2026-05-06",
+                amount=-1460.93,
+                is_active=True,
+            )
+    """
+    try:
+        recurrence_fields: Dict[str, Any] = {
+            k: v
+            for k, v in {
+                "isRecurring": is_recurring,
+                "frequency": frequency,
+                "baseDate": base_date,
+                "amount": amount,
+                "isActive": is_active,
+            }.items()
+            if v is not None
+        }
+
+        if name is None and not recurrence_fields:
+            return json_success(
+                {
+                    "success": False,
+                    "message": "At least one field (name or recurrence) "
+                    "must be provided",
+                }
+            )
+
+        merchant_input: Dict[str, Any] = {"merchantId": merchant_id}
+
+        if name is not None:
+            merchant_input["name"] = name
+
+        if recurrence_fields:
+            merchant_input["recurrence"] = recurrence_fields
+
+        client = await get_monarch_client()
+        result = await client.gql_call(
+            operation="Common_UpdateMerchant",
+            graphql_query=UPDATE_MERCHANT_MUTATION,
+            variables={"input": merchant_input},
+        )
+
+        errors = result.get("updateMerchant", {}).get("errors")
+        if errors:
+            return json_success({"success": False, "errors": errors})
+
+        merchant = result.get("updateMerchant", {}).get("merchant", {})
+        stream = merchant.get("recurringTransactionStream")
+        return json_success(
+            {
+                "success": True,
+                "merchant": {
+                    "id": merchant.get("id"),
+                    "name": merchant.get("name"),
+                    "recurring_stream": (
+                        {
+                            "id": stream.get("id"),
+                            "frequency": stream.get("frequency"),
+                            "amount": stream.get("amount"),
+                            "base_date": stream.get("baseDate"),
+                            "is_active": stream.get("isActive"),
+                        }
+                        if stream
+                        else None
+                    ),
+                },
+            }
+        )
+    except Exception as e:
+        return json_error("update_merchant", e)
+
+
+@mcp.tool()
+async def review_recurring_stream(
+    stream_id: str,
+    review_status: str,
+) -> str:
+    """
+    Set the review status of a recurring transaction stream.
+
+    When Monarch detects new recurring patterns, they appear as pending review.
+    Use this to accept, dismiss, or reset them.
+
+    Args:
+        stream_id: The recurring stream ID (find via get_recurring_transactions
+            or get_merchant, which include stream IDs).
+        review_status: The review status to set. Known values: "approved"
+            (accept the detected pattern), "ignored" (dismiss it), "pending"
+            (reset to pending review).
+
+    Returns:
+        Updated stream ID and review status.
+
+    Example:
+        Approve a detected Netflix recurring stream:
+            review_recurring_stream(
+                stream_id="235281502498808806",
+                review_status="approved",
+            )
+    """
+    try:
+        client = await get_monarch_client()
+        result = await client.gql_call(
+            operation="Web_ReviewStream",
+            graphql_query=REVIEW_STREAM_MUTATION,
+            variables={
+                "input": {
+                    "streamId": stream_id,
+                    "reviewStatus": review_status,
+                }
+            },
+        )
+
+        errors = result.get("reviewRecurringStream", {}).get("errors")
+        if errors:
+            return json_success({"success": False, "errors": errors})
+
+        stream = result.get("reviewRecurringStream", {}).get("stream", {})
+        return json_success(
+            {
+                "success": True,
+                "stream_id": stream.get("id"),
+                "review_status": stream.get("reviewStatus"),
+            }
+        )
+    except Exception as e:
+        return json_error("review_recurring_stream", e)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,6 +239,7 @@ _TOOL_MODULES = [
     "monarch_mcp_server.tools.categories",
     "monarch_mcp_server.tools.budgets",
     "monarch_mcp_server.tools.financial",
+    "monarch_mcp_server.tools.merchants",
 ]
 
 

--- a/tests/test_merchants.py
+++ b/tests/test_merchants.py
@@ -1,0 +1,365 @@
+"""Tests for merchant and recurring stream MCP tools."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from monarch_mcp_server.tools.merchants import (
+    get_merchant,
+    review_recurring_stream,
+    update_merchant,
+)
+
+
+class TestGetMerchant:
+    """Tests for get_merchant tool."""
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_get_merchant_success(self, mock_get_client):
+        """Test successful retrieval of merchant with recurring stream."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "merchant": {
+                "id": "160319777541808781",
+                "name": "PennyMac",
+                "logoUrl": "https://example.com/logo.png",
+                "transactionCount": 24,
+                "ruleCount": 1,
+                "canBeDeleted": False,
+                "hasActiveRecurringStreams": True,
+                "recurringTransactionStream": {
+                    "id": "stream_123",
+                    "frequency": "monthly",
+                    "amount": -1460.93,
+                    "baseDate": "2026-05-06",
+                    "isActive": True,
+                },
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_merchant(merchant_id="160319777541808781")
+
+        data = json.loads(result)
+        assert data["merchant"]["id"] == "160319777541808781"
+        assert data["merchant"]["name"] == "PennyMac"
+        assert data["merchant"]["transaction_count"] == 24
+        assert data["merchant"]["rule_count"] == 1
+        assert data["merchant"]["can_be_deleted"] is False
+        assert data["merchant"]["has_active_recurring_streams"] is True
+        assert data["merchant"]["recurring_stream"]["frequency"] == "monthly"
+        assert data["merchant"]["recurring_stream"]["amount"] == -1460.93
+        assert data["merchant"]["recurring_stream"]["base_date"] == "2026-05-06"
+        assert data["merchant"]["recurring_stream"]["is_active"] is True
+
+        call_args = mock_client.gql_call.call_args
+        assert call_args.kwargs["variables"]["merchantId"] == "160319777541808781"
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_get_merchant_no_recurring_stream(self, mock_get_client):
+        """Test merchant that exists but has no recurring stream."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "merchant": {
+                "id": "999",
+                "name": "One-Time Shop",
+                "logoUrl": None,
+                "transactionCount": 2,
+                "ruleCount": 0,
+                "canBeDeleted": True,
+                "hasActiveRecurringStreams": False,
+                "recurringTransactionStream": None,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_merchant(merchant_id="999")
+
+        data = json.loads(result)
+        assert data["merchant"]["id"] == "999"
+        assert data["merchant"]["name"] == "One-Time Shop"
+        assert data["merchant"]["recurring_stream"] is None
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_get_merchant_not_found(self, mock_get_client):
+        """Test when merchant ID does not exist."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {"merchant": None}
+        mock_get_client.return_value = mock_client
+
+        result = await get_merchant(merchant_id="nonexistent")
+
+        data = json.loads(result)
+        assert data["merchant"] is None
+        assert "message" in data
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_get_merchant_auth_error(self, mock_get_client):
+        """Test error handling when not authenticated."""
+        mock_get_client.side_effect = RuntimeError("Authentication needed")
+
+        result = await get_merchant(merchant_id="123")
+
+        data = json.loads(result)
+        assert data["error"] is True
+        assert "Authentication needed" in data["message"]
+
+
+class TestUpdateMerchant:
+    """Tests for update_merchant tool."""
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_update_name_only(self, mock_get_client):
+        """Test updating only the merchant name."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateMerchant": {
+                "merchant": {
+                    "id": "123",
+                    "name": "New Name",
+                    "recurringTransactionStream": None,
+                },
+                "errors": None,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await update_merchant(merchant_id="123", name="New Name")
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["merchant"]["name"] == "New Name"
+
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert variables["input"]["name"] == "New Name"
+        assert "recurrence" not in variables["input"]
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_update_recurrence_only(self, mock_get_client):
+        """Test updating only recurrence settings."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateMerchant": {
+                "merchant": {
+                    "id": "123",
+                    "name": "PennyMac",
+                    "recurringTransactionStream": {
+                        "id": "stream_123",
+                        "frequency": "monthly",
+                        "amount": -1460.93,
+                        "baseDate": "2026-06-01",
+                        "isActive": True,
+                    },
+                },
+                "errors": None,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await update_merchant(
+            merchant_id="123",
+            is_recurring=True,
+            frequency="monthly",
+            base_date="2026-06-01",
+            amount=-1460.93,
+            is_active=True,
+        )
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["merchant"]["recurring_stream"]["frequency"] == "monthly"
+        assert data["merchant"]["recurring_stream"]["amount"] == -1460.93
+
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert "name" not in variables["input"]
+        assert variables["input"]["recurrence"]["isRecurring"] is True
+        assert variables["input"]["recurrence"]["frequency"] == "monthly"
+        assert variables["input"]["recurrence"]["baseDate"] == "2026-06-01"
+        assert variables["input"]["recurrence"]["amount"] == -1460.93
+        assert variables["input"]["recurrence"]["isActive"] is True
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_update_both(self, mock_get_client):
+        """Test updating name and recurrence together."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateMerchant": {
+                "merchant": {
+                    "id": "123",
+                    "name": "Updated Name",
+                    "recurringTransactionStream": {
+                        "id": "stream_123",
+                        "frequency": "biweekly",
+                        "amount": 2038.37,
+                        "baseDate": "2025-07-04",
+                        "isActive": True,
+                    },
+                },
+                "errors": None,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await update_merchant(
+            merchant_id="123",
+            name="Updated Name",
+            frequency="biweekly",
+            amount=2038.37,
+        )
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["merchant"]["name"] == "Updated Name"
+
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert variables["input"]["name"] == "Updated Name"
+        assert "recurrence" in variables["input"]
+        assert variables["input"]["recurrence"]["frequency"] == "biweekly"
+
+    async def test_update_no_fields(self):
+        """Test that calling with no updatable fields returns an error."""
+        result = await update_merchant(merchant_id="123")
+
+        data = json.loads(result)
+        assert data["success"] is False
+        assert "At least one field" in data["message"]
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_update_graphql_error(self, mock_get_client):
+        """Test handling of GraphQL-level errors."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateMerchant": {
+                "merchant": None,
+                "errors": {
+                    "message": "Merchant not found",
+                    "code": "NOT_FOUND",
+                    "fieldErrors": [],
+                },
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await update_merchant(
+            merchant_id="invalid",
+            name="Test",
+        )
+
+        data = json.loads(result)
+        assert data["success"] is False
+        assert data["errors"]["message"] == "Merchant not found"
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_update_auth_error(self, mock_get_client):
+        """Test error handling when not authenticated."""
+        mock_get_client.side_effect = RuntimeError("Auth needed")
+
+        result = await update_merchant(
+            merchant_id="123",
+            name="Test",
+        )
+
+        data = json.loads(result)
+        assert data["error"] is True
+        assert "Auth needed" in data["message"]
+
+
+class TestReviewRecurringStream:
+    """Tests for review_recurring_stream tool."""
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_review_approve(self, mock_get_client):
+        """Test approving a recurring stream."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "reviewRecurringStream": {
+                "stream": {
+                    "id": "stream_456",
+                    "reviewStatus": "approved",
+                },
+                "errors": None,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await review_recurring_stream(
+            stream_id="stream_456",
+            review_status="approved",
+        )
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["stream_id"] == "stream_456"
+        assert data["review_status"] == "approved"
+
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert variables["input"]["streamId"] == "stream_456"
+        assert variables["input"]["reviewStatus"] == "approved"
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_review_ignore(self, mock_get_client):
+        """Test ignoring a recurring stream."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "reviewRecurringStream": {
+                "stream": {
+                    "id": "stream_789",
+                    "reviewStatus": "ignored",
+                },
+                "errors": None,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await review_recurring_stream(
+            stream_id="stream_789",
+            review_status="ignored",
+        )
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["review_status"] == "ignored"
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_review_graphql_error(self, mock_get_client):
+        """Test handling of GraphQL-level errors."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "reviewRecurringStream": {
+                "stream": None,
+                "errors": {
+                    "message": "Stream not found",
+                    "code": "NOT_FOUND",
+                    "fieldErrors": [],
+                },
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await review_recurring_stream(
+            stream_id="invalid",
+            review_status="approved",
+        )
+
+        data = json.loads(result)
+        assert data["success"] is False
+        assert data["errors"]["message"] == "Stream not found"
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_review_auth_error(self, mock_get_client):
+        """Test error handling when not authenticated."""
+        mock_get_client.side_effect = RuntimeError("Auth needed")
+
+        result = await review_recurring_stream(
+            stream_id="stream_123",
+            review_status="approved",
+        )
+
+        data = json.loads(result)
+        assert data["error"] is True
+        assert "Auth needed" in data["message"]


### PR DESCRIPTION
## Summary

- **`get_merchant`**: Query a merchant's details including recurring transaction stream configuration (frequency, amount, base date, active status). Needed to inspect current state before updates.
- **`update_merchant`**: Modify a merchant's name and/or recurring stream settings. This is the only way to fix recurring stream configurations — there is no direct "update recurring stream" endpoint in the Monarch API.
- **`review_recurring_stream`**: Accept, ignore, or reset recurring transaction streams that Monarch detects automatically.

All three tools use custom GraphQL via `gql_call`, following the same pattern as the existing transaction rules tools in `tools/rules.py`.

## Motivation

During a financial review session, we needed to fix recurring stream configurations (frequency, amount, base date) for several merchants. The only way to do this was through raw GraphQL calls because the MCP server had no merchant management tools. These three tools cover the gap.

## Changes

- New module: `src/monarch_mcp_server/tools/merchants.py` (3 tools, 3 GraphQL operations)
- New test file: `tests/test_merchants.py` (14 tests)
- Wiring: `tools/__init__.py`, `server.py` re-exports, `conftest.py` `_TOOL_MODULES`
- README: new feature section, tool table entries, usage examples, mutating tools list

## Design decisions

- **No client-side validation of `frequency` or `review_status` values** — documented known values in docstrings but let the API validate, so the tools don't reject valid future values.
- **`update_merchant` validates that at least one field is provided** — prevents pointless no-op API calls.
- **GraphQL errors passed through unchanged** — follows the `rules.py` pattern of returning `{"success": false, "errors": <raw API errors>}` rather than parsing the error structure.
- **`get_merchant` wraps result in `{"merchant": ...}`** — both success and not-found paths share the same top-level key for consistent return shape.

## Test plan

- [x] `uv run pytest tests/test_merchants.py -v` — 14/14 passed
- [x] `uv run pytest tests/ -v` — 153/153 passed (0 regressions)
- [x] `black` and `isort` formatting applied
- [x] Wiring audit: verified all 4 registration points (\_\_init\_\_.py, server.py, conftest.py, README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)