### PR TITLE
Fix get_spending_summary to use correct GraphQL endpoint

### DIFF
--- a/src/monarch_mcp_server/tools/summaries.py
+++ b/src/monarch_mcp_server/tools/summaries.py
@@ -1,13 +1,94 @@
 """Transaction summary tools."""
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
+
+from gql import gql
 
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
-from monarch_mcp_server.helpers import json_success, json_error
+from monarch_mcp_server.helpers import json_error, json_success
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# GraphQL constants
+# ---------------------------------------------------------------------------
+
+GET_CASHFLOW_ENTITY_AGGREGATES_QUERY = gql(
+    """
+query Common_GetCashFlowEntityAggregates($filters: TransactionFilterInput) {
+  byCategory: aggregates(filters: $filters, groupBy: ["category"]) {
+    groupBy {
+      category {
+        id
+        name
+        icon
+        group {
+          id
+          type
+          __typename
+        }
+        __typename
+      }
+      __typename
+    }
+    summary {
+      sum
+      __typename
+    }
+    __typename
+  }
+  byCategoryGroup: aggregates(filters: $filters, groupBy: ["categoryGroup"]) {
+    groupBy {
+      categoryGroup {
+        id
+        name
+        type
+        __typename
+      }
+      __typename
+    }
+    summary {
+      sum
+      __typename
+    }
+    __typename
+  }
+  byMerchant: aggregates(filters: $filters, groupBy: ["merchant"]) {
+    groupBy {
+      merchant {
+        id
+        name
+        logoUrl
+        __typename
+      }
+      __typename
+    }
+    summary {
+      sumIncome
+      sumExpense
+      __typename
+    }
+    __typename
+  }
+  summary: aggregates(filters: $filters, fillEmptyValues: true) {
+    summary {
+      sumIncome
+      sumExpense
+      savings
+      savingsRate
+      __typename
+    }
+    __typename
+  }
+}
+"""
+)
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
 
 
 @mcp.tool()
@@ -33,72 +114,106 @@ async def get_transactions_summary() -> str:
 async def get_spending_summary(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
-    limit: int = 100,
 ) -> str:
     """
-    Get a spending summary broken down by category.
+    Get a spending summary broken down by category, category group, and merchant.
 
-    Shows how much you've spent in each category over a time period.
-    Great for understanding where your money is going.
+    Shows how much you've spent in each category over a time period, plus
+    overall income, expenses, and savings rate.
 
     Args:
-        start_date: Start date in YYYY-MM-DD format
-        end_date: End date in YYYY-MM-DD format
-        limit: Maximum number of categories to return (default: 100)
+        start_date: Start date in YYYY-MM-DD format.
+        end_date: End date in YYYY-MM-DD format.
 
     Returns:
-        Spending breakdown by category with totals.
+        Spending breakdown with by_category, by_category_group, by_merchant,
+        and overall totals (income, expenses, savings, savings_rate).
 
     Examples:
         Get spending summary for current month:
-            get_spending_summary(start_date="2024-02-01", end_date="2024-02-29")
+            get_spending_summary(start_date="2026-05-01", end_date="2026-05-31")
 
         Get spending summary for the year:
-            get_spending_summary(start_date="2024-01-01")
+            get_spending_summary(start_date="2026-01-01", end_date="2026-12-31")
     """
     try:
         client = await get_monarch_client()
 
-        params: Dict[str, Any] = {"limit": limit}
+        filters: Dict[str, Any] = {}
         if start_date:
-            params["start_date"] = start_date
+            filters["startDate"] = start_date
         if end_date:
-            params["end_date"] = end_date
+            filters["endDate"] = end_date
 
-        result = await client.get_cashflow_summary(**params)
+        result = await client.gql_call(
+            operation="Common_GetCashFlowEntityAggregates",
+            graphql_query=GET_CASHFLOW_ENTITY_AGGREGATES_QUERY,
+            variables={"filters": filters},
+        )
 
-        summary = result.get("summary", [])
+        by_category: List[Dict[str, Any]] = []
+        for item in result.get("byCategory", []):
+            cat = item.get("groupBy", {}).get("category") or {}
+            group = cat.get("group") or {}
+            by_category.append(
+                {
+                    "category": cat.get("name"),
+                    "category_id": cat.get("id"),
+                    "icon": cat.get("icon"),
+                    "group_id": group.get("id"),
+                    "group_type": group.get("type"),
+                    "sum": item.get("summary", {}).get("sum", 0),
+                }
+            )
+        by_category.sort(key=lambda x: abs(x.get("sum", 0)), reverse=True)
+
+        by_category_group: List[Dict[str, Any]] = []
+        for item in result.get("byCategoryGroup", []):
+            grp = item.get("groupBy", {}).get("categoryGroup") or {}
+            by_category_group.append(
+                {
+                    "group": grp.get("name"),
+                    "group_id": grp.get("id"),
+                    "group_type": grp.get("type"),
+                    "sum": item.get("summary", {}).get("sum", 0),
+                }
+            )
+        by_category_group.sort(key=lambda x: abs(x.get("sum", 0)), reverse=True)
+
+        by_merchant: List[Dict[str, Any]] = []
+        for item in result.get("byMerchant", []):
+            merch = item.get("groupBy", {}).get("merchant") or {}
+            by_merchant.append(
+                {
+                    "merchant": merch.get("name"),
+                    "merchant_id": merch.get("id"),
+                    "income": item.get("summary", {}).get("sumIncome", 0),
+                    "expense": item.get("summary", {}).get("sumExpense", 0),
+                }
+            )
+        by_merchant.sort(key=lambda x: abs(x.get("expense", 0)), reverse=True)
+
+        overall = {}
+        summary_items = result.get("summary", [])
+        if summary_items:
+            s = summary_items[0].get("summary", {})
+            overall = {
+                "total_income": s.get("sumIncome", 0),
+                "total_expenses": s.get("sumExpense", 0),
+                "savings": s.get("savings", 0),
+                "savings_rate": s.get("savingsRate", 0),
+            }
 
         formatted: Dict[str, Any] = {
             "period": {
                 "start_date": start_date,
                 "end_date": end_date,
             },
-            "total_income": 0,
-            "total_expenses": 0,
-            "net": 0,
-            "by_category": []
+            **overall,
+            "by_category": by_category,
+            "by_category_group": by_category_group,
+            "by_merchant": by_merchant,
         }
-
-        for item in summary:
-            category_info = {
-                "category": item.get("category", {}).get("name") if item.get("category") else "Uncategorized",
-                "category_id": item.get("category", {}).get("id") if item.get("category") else None,
-                "group": item.get("categoryGroup", {}).get("name") if item.get("categoryGroup") else None,
-                "sum": item.get("sum", 0),
-                "avg": item.get("avg", 0),
-            }
-            formatted["by_category"].append(category_info)
-
-            amount = item.get("sum", 0)
-            if amount > 0:
-                formatted["total_income"] += amount
-            else:
-                formatted["total_expenses"] += abs(amount)
-
-        formatted["net"] = formatted["total_income"] - formatted["total_expenses"]
-
-        formatted["by_category"].sort(key=lambda x: abs(x.get("sum", 0)), reverse=True)
 
         return json_success(formatted)
     except Exception as e:

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -1,0 +1,269 @@
+"""Tests for transaction summary MCP tools."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from monarch_mcp_server.tools.summaries import (
+    get_spending_summary,
+    get_transactions_summary,
+)
+
+
+class TestGetTransactionsSummary:
+    """Tests for get_transactions_summary tool."""
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_returns_summary(self, mock_get_client):
+        """Test successful summary retrieval."""
+        mock_client = AsyncMock()
+        mock_client.get_transactions_summary.return_value = {
+            "transactionCount": 142,
+            "totalAmount": -3200.50,
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_transactions_summary()
+
+        data = json.loads(result)
+        assert data["transactionCount"] == 142
+        assert data["totalAmount"] == -3200.50
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_handles_error(self, mock_get_client):
+        """Test error handling."""
+        mock_get_client.side_effect = RuntimeError("Auth needed")
+
+        result = await get_transactions_summary()
+
+        data = json.loads(result)
+        assert data["error"] is True
+        assert "Auth needed" in data["message"]
+
+
+class TestGetSpendingSummary:
+    """Tests for get_spending_summary tool."""
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_full_response(self, mock_get_client):
+        """Test successful spending summary with all sections."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "byCategory": [
+                {
+                    "groupBy": {
+                        "category": {
+                            "id": "cat-1",
+                            "name": "Groceries",
+                            "icon": "cart",
+                            "group": {"id": "grp-1", "type": "expense"},
+                        }
+                    },
+                    "summary": {"sum": -450.0},
+                },
+                {
+                    "groupBy": {
+                        "category": {
+                            "id": "cat-2",
+                            "name": "Salary",
+                            "icon": "money",
+                            "group": {"id": "grp-2", "type": "income"},
+                        }
+                    },
+                    "summary": {"sum": 5000.0},
+                },
+            ],
+            "byCategoryGroup": [
+                {
+                    "groupBy": {
+                        "categoryGroup": {
+                            "id": "grp-1",
+                            "name": "Food",
+                            "type": "expense",
+                        }
+                    },
+                    "summary": {"sum": -450.0},
+                },
+            ],
+            "byMerchant": [
+                {
+                    "groupBy": {
+                        "merchant": {
+                            "id": "merch-1",
+                            "name": "Whole Foods",
+                            "logoUrl": "https://example.com/logo.png",
+                        }
+                    },
+                    "summary": {"sumIncome": 0, "sumExpense": -320.0},
+                },
+            ],
+            "summary": [
+                {
+                    "summary": {
+                        "sumIncome": 5000.0,
+                        "sumExpense": -450.0,
+                        "savings": 4550.0,
+                        "savingsRate": 0.91,
+                    }
+                }
+            ],
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_spending_summary(
+            start_date="2026-01-01", end_date="2026-01-31"
+        )
+
+        data = json.loads(result)
+        assert data["period"]["start_date"] == "2026-01-01"
+        assert data["period"]["end_date"] == "2026-01-31"
+        assert data["total_income"] == 5000.0
+        assert data["total_expenses"] == -450.0
+        assert data["savings"] == 4550.0
+        assert data["savings_rate"] == 0.91
+
+        assert len(data["by_category"]) == 2
+        assert data["by_category"][0]["category"] == "Salary"
+        assert data["by_category"][0]["sum"] == 5000.0
+        assert data["by_category"][1]["category"] == "Groceries"
+        assert data["by_category"][1]["category_id"] == "cat-1"
+        assert data["by_category"][1]["group_type"] == "expense"
+
+        assert len(data["by_category_group"]) == 1
+        assert data["by_category_group"][0]["group"] == "Food"
+
+        assert len(data["by_merchant"]) == 1
+        assert data["by_merchant"][0]["merchant"] == "Whole Foods"
+        assert data["by_merchant"][0]["expense"] == -320.0
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_passes_date_filters(self, mock_get_client):
+        """Test that date params are passed as filters to gql_call."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "byCategory": [],
+            "byCategoryGroup": [],
+            "byMerchant": [],
+            "summary": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        await get_spending_summary(start_date="2026-03-01", end_date="2026-03-31")
+
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert variables["filters"]["startDate"] == "2026-03-01"
+        assert variables["filters"]["endDate"] == "2026-03-31"
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_no_dates(self, mock_get_client):
+        """Test calling without date filters."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "byCategory": [],
+            "byCategoryGroup": [],
+            "byMerchant": [],
+            "summary": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        await get_spending_summary()
+
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert "startDate" not in variables["filters"]
+        assert "endDate" not in variables["filters"]
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_empty_results(self, mock_get_client):
+        """Test handling of empty aggregate results."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "byCategory": [],
+            "byCategoryGroup": [],
+            "byMerchant": [],
+            "summary": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_spending_summary()
+
+        data = json.loads(result)
+        assert data["by_category"] == []
+        assert data["by_category_group"] == []
+        assert data["by_merchant"] == []
+        assert "total_income" not in data
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_sorts_by_absolute_value(self, mock_get_client):
+        """Test that categories are sorted by absolute sum descending."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "byCategory": [
+                {
+                    "groupBy": {
+                        "category": {
+                            "id": "c1",
+                            "name": "Small",
+                            "icon": None,
+                            "group": None,
+                        }
+                    },
+                    "summary": {"sum": -10.0},
+                },
+                {
+                    "groupBy": {
+                        "category": {
+                            "id": "c2",
+                            "name": "Large",
+                            "icon": None,
+                            "group": None,
+                        }
+                    },
+                    "summary": {"sum": -500.0},
+                },
+            ],
+            "byCategoryGroup": [],
+            "byMerchant": [],
+            "summary": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_spending_summary()
+
+        data = json.loads(result)
+        assert data["by_category"][0]["category"] == "Large"
+        assert data["by_category"][1]["category"] == "Small"
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_handles_null_category(self, mock_get_client):
+        """Test handling of null category in aggregates."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "byCategory": [
+                {
+                    "groupBy": {"category": None},
+                    "summary": {"sum": -25.0},
+                },
+            ],
+            "byCategoryGroup": [],
+            "byMerchant": [],
+            "summary": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_spending_summary()
+
+        data = json.loads(result)
+        assert data["by_category"][0]["category"] is None
+        assert data["by_category"][0]["sum"] == -25.0
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_handles_error(self, mock_get_client):
+        """Test error handling."""
+        mock_get_client.side_effect = RuntimeError("Auth needed")
+
+        result = await get_spending_summary()
+
+        data = json.loads(result)
+        assert data["error"] is True
+        assert "Auth needed" in data["message"]


### PR DESCRIPTION
## Summary

`get_spending_summary` was returning zeros for all values (`total_income: 0, total_expenses: 0, by_category: [Uncategorized: 0]`). The root cause was calling `client.get_cashflow_summary()`, which returns data in a format incompatible with the tool's formatter.

Replaced with a direct `gql_call` to `Common_GetCashFlowEntityAggregates` — the same GraphQL query the Monarch web app uses for its spending breakdown page.

## Changes

**`src/monarch_mcp_server/tools/summaries.py`:**
- Added `GET_CASHFLOW_ENTITY_AGGREGATES_QUERY` GraphQL constant
- Rewrote `get_spending_summary` to use `gql_call` instead of `get_cashflow_summary`
- Response now includes `by_category`, `by_category_group`, `by_merchant`, and overall totals (income, expenses, savings, savings_rate)
- All sections sorted by absolute magnitude (largest spending first)
- Removed unused `limit` parameter (the aggregates endpoint returns all results, not paginated)
- Added `gql` import

**`tests/test_summaries.py` (new):**
- 9 tests: full response parsing, date filter passthrough, no-dates call, empty results, sort order, null category handling, error handling
- Also added 2 tests for the previously-untested `get_transactions_summary`

## Test plan

- [x] `uv run pytest tests/test_summaries.py -v` — 9/9 passed
- [x] `uv run pytest tests/ -q` — 148/148 passed (0 regressions)
- [x] `black` and `isort` formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)