### PR TITLE
Add cookie-based auth for Monarch's May 2026 API change

### DIFF
--- a/login_setup.py
+++ b/login_setup.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(src_path))
 
 from monarchmoney import MonarchMoney, RequireMFAException
 from dotenv import load_dotenv
+from monarch_mcp_server.cookie_auth import MonarchMoneyCookieAuth
 from monarch_mcp_server.secure_session import secure_session
 
 async def main():
@@ -42,38 +43,34 @@ async def main():
         # Clear any existing sessions (both old pickle files and keyring)
         secure_session.delete_token()
         print("🗑️ Cleared existing secure sessions")
-        
-        # Ask about MFA setup
-        print("\n🔐 Security Check:")
-        has_mfa = input("Do you have MFA (Multi-Factor Authentication) enabled on your Monarch Money account? (y/n): ").strip().lower()
-        
-        if has_mfa not in ['y', 'yes']:
-            print("\n⚠️  SECURITY RECOMMENDATION:")
-            print("=" * 50)
-            print("You should enable MFA for your Monarch Money account.")
-            print("MFA adds an extra layer of security to protect your financial data.")
-            print("\nTo enable MFA:")
-            print("1. Log into Monarch Money at https://monarchmoney.com")
-            print("2. Go to Settings → Security")
-            print("3. Enable Two-Factor Authentication")
-            print("4. Follow the setup instructions\n")
-            
-            proceed = input("Continue with login anyway? (y/n): ").strip().lower()
-            if proceed not in ['y', 'yes']:
-                print("Login cancelled. Please set up MFA and try again.")
-                return
-        
-        print("\nStarting login...")
-        print("\nHow do you sign in to Monarch Money?")
-        print("  1) Email and password")
-        print("  2) Google / SSO (single sign-on)")
-        login_method = input("Choice (1 or 2): ").strip()
 
-        if login_method == "2":
+        print("\nHow do you sign in to Monarch Money?")
+        print("  1) Session cookies from browser  (recommended — required since May 2026)")
+        print("  2) Email and password            (currently broken — Monarch dropped Token auth)")
+        print("  3) Legacy session token paste    (currently broken — see above)")
+        login_method = input("Choice [1]: ").strip() or "1"
+
+        if login_method == "1":
+            print("\n📋 To get your session cookies from the browser:")
+            print("  1. Log in to https://app.monarch.com in Chrome/Firefox")
+            print("  2. Open DevTools (F12) → Application tab → Cookies")
+            print("     → https://app.monarch.com")
+            print("  3. Copy the Value of 'session_id' (HttpOnly) and 'csrftoken'")
+            session_id = getpass.getpass("\nPaste session_id value: ").strip()
+            if not session_id:
+                print("❌ No session_id provided. Exiting.")
+                return
+            csrftoken = getpass.getpass("Paste csrftoken value: ").strip()
+            if not csrftoken:
+                print("❌ No csrftoken provided. Exiting.")
+                return
+            mm = MonarchMoneyCookieAuth(session_id=session_id, csrftoken=csrftoken)
+            print("✅ Cookies set")
+        elif login_method == "3":
             print("\n📋 To get your session token from the browser:")
-            print("  1. Log in to https://app.monarchmoney.com in Chrome/Firefox")
+            print("  1. Log in to https://app.monarch.com in Chrome/Firefox")
             print("  2. Open DevTools (F12) → Application tab → Local Storage")
-            print("     → https://app.monarchmoney.com")
+            print("     → https://app.monarch.com")
             print("  3. Copy the value for the key 'token'")
             print("     (Alternatively: DevTools → Network tab, filter any request,")
             print("      look for 'Authorization: Token <value>' in request headers)")
@@ -81,27 +78,40 @@ async def main():
             if not token:
                 print("❌ No token provided. Exiting.")
                 return
-            # Re-initialize with the token so the Authorization header is set correctly.
-            # set_token() only stores the value but does not update _headers.
             mm = MonarchMoney(token=token)
             print("✅ Token set")
         else:
+            print("\n🔐 Security Check:")
+            has_mfa = input(
+                "Do you have MFA (Multi-Factor Authentication) enabled on your Monarch Money account? (y/n): "
+            ).strip().lower()
+            if has_mfa not in ['y', 'yes']:
+                print("\n⚠️  SECURITY RECOMMENDATION:")
+                print("=" * 50)
+                print("You should enable MFA for your Monarch Money account.")
+                print("MFA adds an extra layer of security to protect your financial data.")
+                print("\nTo enable MFA:")
+                print("1. Log into Monarch Money at https://monarchmoney.com")
+                print("2. Go to Settings → Security")
+                print("3. Enable Two-Factor Authentication")
+                print("4. Follow the setup instructions\n")
+                proceed = input("Continue with login anyway? (y/n): ").strip().lower()
+                if proceed not in ['y', 'yes']:
+                    print("Login cancelled. Please set up MFA and try again.")
+                    return
+
             email = input("Email: ")
             password = getpass.getpass("Password: ")
 
-            # Try login without MFA first
             try:
                 await mm.login(email, password, use_saved_session=False, save_session=True)
                 print("✅ Login successful!")
-
             except RequireMFAException:
                 print("🔐 MFA code required")
                 mfa_code = input("Two Factor Code: ")
-
-                # Use the same instance for MFA
                 await mm.multi_factor_authenticate(email, password, mfa_code)
                 print("✅ MFA authentication successful")
-                mm.save_session()  # Manually save the session
+                mm.save_session()
         
         # Test the connection first
         print("\nTesting connection...")

--- a/src/monarch_mcp_server/auth.py
+++ b/src/monarch_mcp_server/auth.py
@@ -10,6 +10,7 @@ from mcp.server.fastmcp import Context
 from monarchmoney import MonarchMoney, RequireMFAException
 from pydantic import BaseModel, Field
 
+from monarch_mcp_server.cookie_auth import MonarchMoneyCookieAuth
 from monarch_mcp_server.secure_session import secure_session
 
 
@@ -41,6 +42,21 @@ class TokenForm(BaseModel):
         description=(
             "Monarch Money session token. Grab it from browser DevTools → "
             "Application → Local Storage for app.monarchmoney.com, key 'token'."
+        ),
+    )
+
+
+class CookiesForm(BaseModel):
+    session_id: str = Field(
+        description=(
+            "Monarch session_id cookie (HttpOnly). DevTools → Application → "
+            "Cookies → https://app.monarch.com → row 'session_id', copy Value."
+        ),
+    )
+    csrftoken: str = Field(
+        description=(
+            "Monarch csrftoken cookie. Same Cookies pane, row 'csrftoken', "
+            "copy Value."
         ),
     )
 
@@ -92,6 +108,31 @@ async def login_with_token_interactive(ctx: Context) -> str:
     await mm.get_subscription_details()
     secure_session.save_token(token)
     return "Session token saved to system keyring."
+
+
+async def login_with_cookies_interactive(ctx: Context) -> str:
+    if not _elicit_supported(ctx):
+        return _UPGRADE_HINT
+    form_result = await ctx.elicit(
+        message=(
+            "Paste your Monarch session cookies. From DevTools → Application "
+            "→ Cookies → https://app.monarch.com, copy the Value of "
+            "'session_id' (HttpOnly) and 'csrftoken'."
+        ),
+        schema=CookiesForm,
+    )
+    if form_result.action != "accept":
+        return "Login cancelled."
+
+    sid = form_result.data.session_id.strip()
+    csrf = form_result.data.csrftoken.strip()
+    if not sid or not csrf:
+        return "Empty cookie value — aborting."
+
+    mm = MonarchMoneyCookieAuth(session_id=sid, csrftoken=csrf)
+    await mm.get_subscription_details()
+    secure_session.save_cookies(sid, csrf)
+    return "Session cookies saved to system keyring."
 
 
 async def logout() -> str:

--- a/src/monarch_mcp_server/cookie_auth.py
+++ b/src/monarch_mcp_server/cookie_auth.py
@@ -1,0 +1,60 @@
+"""Cookie-based authentication for Monarch's new session-cookie API.
+
+In May 2026 Monarch's web app stopped sending `Authorization: Token <...>`
+on GraphQL requests and switched to session-cookie auth: a `session_id`
+cookie (HttpOnly), a `csrftoken` cookie, and an `x-csrftoken` request header
+matching the csrftoken cookie. The upstream monarchmoneycommunity library
+still ships the old Token-header flow, so we subclass MonarchMoney and
+override the GraphQL transport to send cookies instead.
+
+Known limitation: the upload paths in the upstream library
+(`_upload_form_data`, account balance history upload, attachment upload)
+build their own aiohttp ClientSession with the legacy headers and will not
+work with cookie auth until upstream patches the library.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from gql import Client
+from gql.transport.aiohttp import AIOHTTPTransport
+from monarchmoney import MonarchMoney
+from monarchmoney.monarchmoney import MonarchMoneyEndpoints
+
+WEB_ORIGIN = "https://app.monarch.com"
+
+
+class MonarchMoneyCookieAuth(MonarchMoney):
+    """MonarchMoney variant authenticating via session_id + csrftoken cookies."""
+
+    def __init__(
+        self,
+        session_id: str,
+        csrftoken: str,
+        timeout: int = 10,
+    ) -> None:
+        super().__init__(timeout=timeout)
+        self._session_id = session_id
+        self._csrftoken = csrftoken
+        self._headers.pop("Authorization", None)
+        self._headers["x-csrftoken"] = csrftoken
+        self._headers["Origin"] = WEB_ORIGIN
+        self._headers["Referer"] = WEB_ORIGIN + "/"
+
+    def _cookies(self) -> Dict[str, str]:
+        return {"session_id": self._session_id, "csrftoken": self._csrftoken}
+
+    def _get_graphql_client(self) -> Client:
+        transport = AIOHTTPTransport(
+            url=MonarchMoneyEndpoints.getGraphQL(),
+            headers=self._headers,
+            cookies=self._cookies(),
+            timeout=self._timeout,
+            ssl=True,
+        )
+        return Client(
+            transport=transport,
+            fetch_schema_from_transport=False,
+            execute_timeout=self._timeout,
+        )

--- a/src/monarch_mcp_server/secure_session.py
+++ b/src/monarch_mcp_server/secure_session.py
@@ -5,22 +5,27 @@ Uses the system keyring when available, with an automatic file-based
 fallback for environments without a keyring backend (e.g. WSL, headless Linux).
 """
 
+import json
 import logging
 import os
 import stat
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 from monarchmoney import MonarchMoney
+
+from monarch_mcp_server.cookie_auth import MonarchMoneyCookieAuth
 
 logger = logging.getLogger(__name__)
 
 # Keyring service identifiers
 KEYRING_SERVICE = "com.mcp.monarch-mcp-server"
 KEYRING_USERNAME = "monarch-token"
+KEYRING_USERNAME_COOKIES = "monarch-cookies"
 
 # File-based fallback location
 _TOKEN_DIR = Path.home() / ".monarch-mcp-server"
 _TOKEN_FILE = _TOKEN_DIR / "token"
+_COOKIES_FILE = _TOKEN_DIR / "cookies.json"
 
 
 def _keyring_available() -> bool:
@@ -92,6 +97,34 @@ class SecureMonarchSession:
         if _TOKEN_DIR.is_dir() and not list(_TOKEN_DIR.iterdir()):
             _TOKEN_DIR.rmdir()
 
+    def _save_cookies_file(self, session_id: str, csrftoken: str) -> None:
+        _TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps({"session_id": session_id, "csrftoken": csrftoken})
+        _COOKIES_FILE.write_text(payload)
+        _COOKIES_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 600
+        _TOKEN_DIR.chmod(stat.S_IRWXU)  # 700
+        logger.info(f"✅ Cookies saved to {_COOKIES_FILE}")
+
+    def _load_cookies_file(self) -> Optional[Tuple[str, str]]:
+        if _COOKIES_FILE.is_file():
+            try:
+                data = json.loads(_COOKIES_FILE.read_text())
+                sid = data.get("session_id", "").strip()
+                csrf = data.get("csrftoken", "").strip()
+                if sid and csrf:
+                    logger.info(f"✅ Cookies loaded from {_COOKIES_FILE}")
+                    return sid, csrf
+            except Exception as e:
+                logger.warning(f"⚠️  Cookie file unreadable: {e}")
+        return None
+
+    def _delete_cookies_file(self) -> None:
+        if _COOKIES_FILE.is_file():
+            _COOKIES_FILE.unlink()
+            logger.info(f"🗑️ Cookies file deleted: {_COOKIES_FILE}")
+        if _TOKEN_DIR.is_dir() and not list(_TOKEN_DIR.iterdir()):
+            _TOKEN_DIR.rmdir()
+
     # -- public API ----------------------------------------------------------
 
     def save_token(self, token: str) -> None:
@@ -131,8 +164,7 @@ class SecureMonarchSession:
         return None
 
     def delete_token(self) -> None:
-        """Delete the authentication token from all storage backends."""
-        # Try keyring
+        """Delete the authentication token and cookies from all storage backends."""
         if self._use_keyring:
             try:
                 import keyring
@@ -140,13 +172,65 @@ class SecureMonarchSession:
                 logger.info("🗑️ Token deleted from keyring")
             except Exception:
                 pass
+            try:
+                import keyring
+                keyring.delete_password(KEYRING_SERVICE, KEYRING_USERNAME_COOKIES)
+                logger.info("🗑️ Cookies deleted from keyring")
+            except Exception:
+                pass
 
-        # Always try file cleanup too
         self._delete_token_file()
+        self._delete_cookies_file()
         self._cleanup_old_session_files()
 
+    def save_cookies(self, session_id: str, csrftoken: str) -> None:
+        """Save session_id + csrftoken cookies to keyring or file fallback."""
+        if self._use_keyring:
+            try:
+                import keyring
+                payload = json.dumps({"session_id": session_id, "csrftoken": csrftoken})
+                keyring.set_password(KEYRING_SERVICE, KEYRING_USERNAME_COOKIES, payload)
+                logger.info("✅ Cookies saved securely to keyring")
+                return
+            except Exception as e:
+                logger.warning(f"⚠️  Keyring save failed, falling back to file: {e}")
+
+        self._save_cookies_file(session_id, csrftoken)
+
+    def load_cookies(self) -> Optional[Tuple[str, str]]:
+        """Load session_id + csrftoken from keyring or file fallback."""
+        if self._use_keyring:
+            try:
+                import keyring
+                payload = keyring.get_password(KEYRING_SERVICE, KEYRING_USERNAME_COOKIES)
+                if payload:
+                    data = json.loads(payload)
+                    sid = data.get("session_id", "").strip()
+                    csrf = data.get("csrftoken", "").strip()
+                    if sid and csrf:
+                        logger.info("✅ Cookies loaded from keyring")
+                        return sid, csrf
+            except Exception as e:
+                logger.warning(f"⚠️  Keyring cookie load failed, trying file: {e}")
+
+        return self._load_cookies_file()
+
     def get_authenticated_client(self) -> Optional[MonarchMoney]:
-        """Get an authenticated MonarchMoney client."""
+        """Get an authenticated MonarchMoney client.
+
+        Prefers cookie-based auth (Monarch's current model) and falls back to
+        the legacy token if no cookies are stored.
+        """
+        cookies = self.load_cookies()
+        if cookies:
+            try:
+                sid, csrf = cookies
+                client = MonarchMoneyCookieAuth(session_id=sid, csrftoken=csrf)
+                logger.info("✅ MonarchMoney client created with stored cookies")
+                return client
+            except Exception as e:
+                logger.error(f"❌ Failed to create cookie-auth client: {e}")
+
         token = self.load_token()
         if not token:
             return None
@@ -161,10 +245,12 @@ class SecureMonarchSession:
 
     def save_authenticated_session(self, mm: MonarchMoney) -> None:
         """Save the session from an authenticated MonarchMoney instance."""
-        if mm.token:
+        if isinstance(mm, MonarchMoneyCookieAuth):
+            self.save_cookies(mm._session_id, mm._csrftoken)
+        elif mm.token:
             self.save_token(mm.token)
         else:
-            logger.warning("⚠️  MonarchMoney instance has no token to save")
+            logger.warning("⚠️  MonarchMoney instance has no token or cookies to save")
 
     def _cleanup_old_session_files(self) -> None:
         """Clean up old insecure session files."""

--- a/src/monarch_mcp_server/tools/auth.py
+++ b/src/monarch_mcp_server/tools/auth.py
@@ -17,19 +17,22 @@ async def setup_authentication() -> str:
     """Get instructions for setting up secure authentication with Monarch Money."""
     return """🔐 Monarch Money - Authentication Options
 
-Option 1: Elicitation login (Recommended for interactive clients)
-   Call 'monarch_login' to enter email/password (and MFA if needed)
-   via a secure form in your client UI. Credentials never pass
-   through the model. Or 'monarch_login_with_token' to paste a
-   browser-copied session token.
+⚠️ As of May 2026, Monarch's API rejects the legacy Token header. Use the
+   cookie flow below. Email/password and token-paste flows are kept for
+   when upstream restores Token support but currently won't authenticate.
 
-Option 2: Email/Password (Terminal)
-   Run in terminal: python login_setup.py
+Option 1: Cookie login (Recommended — works today)
+   Call 'monarch_login_with_cookies'. From browser DevTools → Application
+   → Cookies → https://app.monarch.com, copy the Value of 'session_id'
+   (HttpOnly) and 'csrftoken', then paste into the form.
+
+Option 2: Email/Password (likely broken until upstream patch)
+   Call 'monarch_login' or run: python login_setup.py
 
 Call 'monarch_logout' to clear the stored session.
 
 ✅ Session persists across restarts
-✅ Token stored securely in system keyring"""
+✅ Credentials stored securely in system keyring"""
 
 
 @mcp.tool()
@@ -47,10 +50,24 @@ async def monarch_login(ctx: Context) -> str:
 async def monarch_login_with_token(ctx: Context) -> str:
     """Sign in to Monarch Money using a browser-copied session token.
 
-    Useful for SSO users who can't use password login. Grab the token from
-    browser DevTools → Application → Local Storage → app.monarchmoney.com.
+    Note: As of May 2026 Monarch's API rejects Token-header auth, so this
+    flow will not currently authenticate. Use `monarch_login_with_cookies`
+    instead. This tool stays for forward compatibility once upstream
+    restores token support.
     """
     return await auth.login_with_token_interactive(ctx)
+
+
+@mcp.tool()
+async def monarch_login_with_cookies(ctx: Context) -> str:
+    """Sign in to Monarch Money using browser session cookies.
+
+    Monarch's web app authenticates via two cookies on app.monarch.com:
+    `session_id` (HttpOnly) and `csrftoken`. Open DevTools → Application →
+    Cookies → https://app.monarch.com and copy the Value of each, then
+    paste them into the form this tool opens.
+    """
+    return await auth.login_with_cookies_interactive(ctx)
 
 
 @mcp.tool()
@@ -63,18 +80,25 @@ async def monarch_logout() -> str:
 async def check_auth_status() -> str:
     """Check if already authenticated with Monarch Money."""
     try:
+        cookies = secure_session.load_cookies()
         token = secure_session.load_token()
-        if token:
-            status = "✅ Authentication token found in secure keyring storage\n"
+        if cookies:
+            status = "✅ Session cookies found in secure keyring storage\n"
+        elif token:
+            status = (
+                "⚠️ Only legacy token found — Monarch's API currently rejects "
+                "Token-header auth. Call monarch_login_with_cookies to switch.\n"
+            )
         else:
-            status = "❌ No authentication token found in keyring\n"
+            status = "❌ No session credentials found in keyring\n"
 
         email = os.getenv("MONARCH_EMAIL")
         if email:
             status += f"📧 Environment email: {email}\n"
 
         status += (
-            "\n💡 Try get_accounts to test connection or run login_setup.py if needed."
+            "\n💡 Try get_accounts to test the connection, or call "
+            "monarch_login_with_cookies to authenticate."
         )
 
         return status

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -103,6 +103,51 @@ class TestLoginWithTokenInteractive:
         no_session_save.save_token.assert_not_called()
 
 
+class TestLoginWithCookiesInteractive:
+    def test_happy_path(self, no_session_save):
+        mm = AsyncMock()
+        with patch(
+            "monarch_mcp_server.auth.MonarchMoneyCookieAuth", return_value=mm
+        ) as ctor:
+            ctx = make_ctx(accept(session_id="sid-value", csrftoken="csrf-value"))
+            result = asyncio.run(auth.login_with_cookies_interactive(ctx))
+        assert "saved" in result.lower()
+        ctor.assert_called_once_with(session_id="sid-value", csrftoken="csrf-value")
+        mm.get_subscription_details.assert_awaited_once()
+        no_session_save.save_cookies.assert_called_once_with(
+            "sid-value", "csrf-value"
+        )
+
+    def test_strips_whitespace(self, no_session_save):
+        mm = AsyncMock()
+        with patch(
+            "monarch_mcp_server.auth.MonarchMoneyCookieAuth", return_value=mm
+        ):
+            ctx = make_ctx(
+                accept(session_id="  sid  ", csrftoken="\tcsrf\n")
+            )
+            asyncio.run(auth.login_with_cookies_interactive(ctx))
+        no_session_save.save_cookies.assert_called_once_with("sid", "csrf")
+
+    def test_empty_session_id_rejected(self, no_session_save):
+        ctx = make_ctx(accept(session_id="   ", csrftoken="csrf"))
+        result = asyncio.run(auth.login_with_cookies_interactive(ctx))
+        assert "Empty" in result
+        no_session_save.save_cookies.assert_not_called()
+
+    def test_empty_csrftoken_rejected(self, no_session_save):
+        ctx = make_ctx(accept(session_id="sid", csrftoken=""))
+        result = asyncio.run(auth.login_with_cookies_interactive(ctx))
+        assert "Empty" in result
+        no_session_save.save_cookies.assert_not_called()
+
+    def test_user_cancels(self, no_session_save):
+        ctx = make_ctx(cancel())
+        result = asyncio.run(auth.login_with_cookies_interactive(ctx))
+        assert result == "Login cancelled."
+        no_session_save.save_cookies.assert_not_called()
+
+
 class TestLogout:
     def test_clears_session(self, no_session_save):
         result = asyncio.run(auth.logout())
@@ -163,3 +208,9 @@ class TestElicitNotSupported:
         result = asyncio.run(auth.login_with_token_interactive(ctx))
         assert "1.10" in result
         no_session_save.save_token.assert_not_called()
+
+    def test_login_with_cookies_returns_upgrade_hint(self, no_session_save):
+        ctx = SimpleNamespace()
+        result = asyncio.run(auth.login_with_cookies_interactive(ctx))
+        assert "1.10" in result
+        no_session_save.save_cookies.assert_not_called()


### PR DESCRIPTION
- **New `MonarchMoneyCookieAuth`** (`src/monarch_mcp_server/cookie_auth.py`) — subclass of `MonarchMoney` that overrides `_get_graphql_client()` to send cookies via `AIOHTTPTransport` with the `x-csrftoken` header.
- **`secure_session.py`** — added `save_cookies` / `load_cookies` / `delete_cookies` keyring helpers. `get_authenticated_client()` now prefers cookies and falls back to the legacy token. `save_authenticated_session()` dispatches on `isinstance(MonarchMoneyCookieAuth)`.
- **MCP elicitation** — added `CookiesForm` schema, `login_with_cookies_interactive()`, and the `monarch_login_with_cookies` tool. `check_auth_status()` now warns when only a legacy token is stored. `setup_authentication()` reflects the API change.
- **`login_setup.py`** — reordered the terminal menu so session cookies are the default option; moved the MFA-enabled prompt to only fire for the email/password path.