### PR TITLE
Default to read-only; disable credential/auth mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A Model Context Protocol (MCP) server for integrating with the Monarch Money personal finance platform. This server provides seamless access to your financial accounts, transactions, budgets, and analytics through Claude Desktop and Claude Code.
 
+> **🔒 Hardened build (read-only by default).** As of the read-only hardening change, the server refuses all Monarch data mutations unless the operator explicitly opts in, and the MCP-exposed login/logout tools are permanently disabled. See [🔒 Security model](#-security-model) before configuring a client.
+
 My MonarchMoney referral: https://www.monarchmoney.com/referral/ufmn0r83yf?r_source=share
 
 **Built with the [MonarchMoneyCommunity Python library](https://github.com/bradleyseanf/monarchmoneycommunity)** - An actively maintained community fork of the Monarch Money API with full MFA support.
@@ -14,28 +16,40 @@ My MonarchMoney referral: https://www.monarchmoney.com/referral/ufmn0r83yf?r_sou
 
 ## 🚀 Quick Start
 
-### 1. Installation
+### 1. Installation (macOS)
 
-1. **Clone this repository**:
+These steps install the **hardened, read-only-by-default** branch into a local virtual environment. Everything stays on your machine; no credentials ever pass through Claude.
+
+1. **Clone the repository and check out the hardened branch**:
    ```bash
    git clone https://github.com/robcerda/monarch-mcp-server.git
    cd monarch-mcp-server
+   git checkout readonly-hardening   # or pull a tagged release once one ships
    ```
 
-2. **Install dependencies**:
+2. **Install dependencies into a venv** (recommended on macOS so the system Python stays clean):
 
-   **Using `pip`**:
+   **Using `python` + `pip`**:
    ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
    pip install -r requirements.txt
    pip install -e .
    ```
 
-   **Using `uv`** (alternative):
+   **Using `uv`** (faster, alternative):
    ```bash
-   uv sync
+   brew install uv          # if you do not already have uv
+   uv sync                  # creates .venv and installs deps
    ```
 
-3. **Configure Claude Desktop**:
+3. **Sanity-check the install** (no credentials required):
+   ```bash
+   python -c "from monarch_mcp_server.app import mcp; print('ok')"
+   ```
+   Should print `ok` followed by a "Keyring unavailable / Using system keyring" log line.
+
+4. **Configure Claude Desktop**:
    Add this to your Claude Desktop configuration file:
 
    **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
@@ -62,13 +76,18 @@ My MonarchMoney referral: https://www.monarchmoney.com/referral/ufmn0r83yf?r_sou
    }
    ```
 
+   The hardened build runs in read-only mode by default — no extra env vars
+   are required. **Do NOT** set `MONARCH_EMAIL`, `MONARCH_PASSWORD`, or
+   `MONARCH_MCP_READ_ONLY=false` in this config: the first two are ignored
+   for auto-login and the third would re-enable mutations.
+
    **Important**: Replace `/path/to/your/monarch-mcp-server` with your actual path!
 
-4. **Restart Claude Desktop**
+5. **Restart Claude Desktop**
 
 **OR**
 
-3. **Configure Claude Code** (CLI):
+4. **Configure Claude Code** (CLI):
    Add this to your Claude Code configuration file:
 
    **Global** (all projects):
@@ -129,19 +148,32 @@ My MonarchMoney referral: https://www.monarchmoney.com/referral/ufmn0r83yf?r_sou
 
    **Important**: Replace `/path/to/your/monarch-mcp-server` with your actual path!
 
-4. **Restart Claude Code**
+5. **Restart Claude Code**
 
-### 2. One-Time Authentication Setup
+### 2. One-Time Authentication Setup (Terminal Only)
 
-**Important**: For security and MFA support, authentication is done outside of Claude.
+> **⚠️ Never paste your Monarch email, password, MFA code, or session
+> token into a Claude chat.** The hardened build's MCP-exposed login tools
+> (`monarch_login`, `monarch_login_with_token`, `monarch_logout`) are
+> **permanently disabled** and return a refusal payload — they cannot
+> accept credentials over MCP transport regardless of any setting. Auth
+> happens only in a local terminal via `login_setup.py`.
 
-#### Option A: Email/Password Login
+The standalone script reads input directly from your terminal (via
+`input()` / `getpass.getpass()`), authenticates against Monarch in your
+local Python process, and stores the resulting **session token** in the
+system keyring. The MCP server then reads the token from the keyring on
+each call. Your email and password are never written to disk and never
+flow through MCP.
 
-Open Terminal and run:
+#### Option A: Email / Password (with MFA if enabled)
 
-**Using `python`**:
+Open Terminal on the same machine where you installed the server:
+
+**Using `python`** (activated venv from step 2):
 ```bash
 cd /path/to/your/monarch-mcp-server
+source .venv/bin/activate
 python login_setup.py
 ```
 
@@ -151,18 +183,120 @@ cd /path/to/your/monarch-mcp-server
 uv run python login_setup.py
 ```
 
-Follow the prompts:
-- Enter your Monarch Money email and password
-- Provide 2FA code if you have MFA enabled
-- Session will be saved automatically
+Follow the prompts in the terminal window:
+- Choose option `1` for email/password.
+- Enter your Monarch Money email and password.
+- Provide the MFA code if you have MFA enabled (you should).
+- A session token is saved to the macOS Keychain (or `~/.monarch-mcp-server/token` on systems with no keyring backend).
+
+#### Option B: Paste a Browser Session Token (SSO / Google sign-in)
+
+If you sign in to Monarch with Google or another SSO provider, password
+login does not work. Instead, copy a token from your browser:
+
+1. Sign in to `https://app.monarchmoney.com` in Chrome or Firefox.
+2. Open DevTools → **Application** tab → **Local Storage** → `https://app.monarchmoney.com`.
+3. Copy the value of the `token` key.
+4. In the terminal, run `python login_setup.py` and choose option `2`.
+5. Paste the token at the prompt (the input is hidden via `getpass`).
+
+The token is stored the same way as in Option A.
+
+#### Rotating or clearing the stored session
+
+Re-run `python login_setup.py` to overwrite the stored token, or delete
+the macOS Keychain entry named `com.mcp.monarch-mcp-server` (Keychain
+Access app → search → delete) to clear it. The MCP server never modifies
+the stored session.
 
 ### 3. Start Using
 
-Once authenticated, use these tools directly in Claude Desktop or Claude Code:
+Once authenticated, use these read-only tools directly in Claude Desktop or Claude Code:
 - `get_accounts` - View all your financial accounts
 - `get_transactions` - Recent transactions with filtering
 - `get_budgets` - Budget information and spending
 - `get_cashflow` - Income/expense analysis
+
+## 🔒 Security model
+
+This branch was hardened so a malicious or hijacked LLM cannot move money,
+mutate your ledger, or steal your credentials. The model is:
+
+### Read-only by default
+
+The server reads the `MONARCH_MCP_READ_ONLY` environment variable when each
+tool runs:
+
+| Value of `MONARCH_MCP_READ_ONLY` | Behavior |
+| --- | --- |
+| *unset* (default) | **Read-only ON.** All Monarch data mutations refuse. |
+| `true`, `1`, `yes`, `on`, any unknown value | Read-only ON. |
+| `false`, `0`, `no`, `off`, `disable`, `disabled` (case-insensitive) | Read-only OFF — mutations permitted. |
+
+When read-only is on, every mutation tool returns a JSON refusal of the
+form `{"success": false, "read_only": true, "tool": "...", "error": "..."}`
+**without ever calling the upstream Monarch API**. Refused tools:
+
+- **Transactions:** `create_transaction`, `update_transaction`, `categorize_transaction`, `update_transaction_notes`, `mark_transaction_reviewed`, `bulk_categorize_transactions` (real run; `dry_run=True` still works), `delete_transaction`
+- **Tags:** `set_transaction_tags`, `create_transaction_tag`, `add_transaction_tag`
+- **Categories:** `create_transaction_category`
+- **Splits:** `split_transaction`
+- **Rules:** `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`
+- **Budgets:** `set_budget_amount`
+- **Accounts:** `refresh_accounts`, `upload_account_balance_history` (real run; `dry_run=True` still works)
+
+To intentionally enable writes for a single session, set
+`MONARCH_MCP_READ_ONLY=false` in the MCP server's environment — **not in
+your shell profile**, and not in a `.env` file. The server no longer reads
+`.env` files at all (see below). Re-enabling writes is opt-in *per process*.
+
+### Auth tools are permanently disabled in MCP
+
+Independent of the read-only flag, these three tools always refuse:
+
+- `monarch_login` — would have collected email/password over MCP.
+- `monarch_login_with_token` — would have collected a session token over MCP.
+- `monarch_logout` — would have let a remote MCP client wipe your session.
+
+Each returns `{"success": false, "disabled": true, ...}` and points the
+caller at `login_setup.py`. There is no setting to re-enable them.
+**Authentication is terminal-only.**
+
+### No environment-variable credential loading
+
+The previous behavior of auto-logging-in from `MONARCH_EMAIL` and
+`MONARCH_PASSWORD` env vars has been removed. The client factory now only
+reads the session token from the system keyring (or file fallback). It
+will **not** call `MonarchMoney.login(email, password)` regardless of
+what is in the environment. `python-dotenv` has been removed entirely:
+the server no longer auto-loads `.env` files, so credentials cannot leak
+in via a stray `.env` next to the source tree.
+
+`check_auth_status` will *report* if `MONARCH_EMAIL` happens to be set in
+the environment, but only as a diagnostic — it is explicitly labeled as
+"NOT used for auto-login".
+
+### What you must NOT do
+
+- **Do not paste credentials, MFA codes, or session tokens into Claude.**
+  If a tool ever asks you to, that is a bug — report it.
+- **Do not** put `MONARCH_EMAIL` / `MONARCH_PASSWORD` in your Claude
+  Desktop / Claude Code MCP config file. They will be ignored, but
+  storing them there in plaintext is still a hazard.
+- **Do not** set `MONARCH_MCP_READ_ONLY=false` "just in case." Leave it
+  unset; flip it only for a deliberate write session.
+- **Do not** allow-list mutation tools in your MCP client's auto-approval
+  config. Keep them gated behind a manual approval prompt.
+
+### Recommended: still require manual approval for any mutating tool
+
+Even with read-only as the default, your MCP client may at some point be
+configured for writes (e.g. you flip the env var to clean up data). For
+those sessions, configure Claude Desktop / Claude Code to require manual
+approval before any mutating tool runs — that is the default behavior;
+keep it that way. The LLM can be steered by data it reads back (a hostile
+merchant name or memo), so an explicit human-in-the-loop click is your
+last line of defense.
 
 ## ✨ Features
 
@@ -225,11 +359,11 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 - **Get Spending Summary**: Spending breakdown by category with totals
 
 ### 🔐 Secure Authentication
-- **One-Time Setup**: Authenticate once, use for weeks/months
+- **One-Time Setup**: Authenticate once in a terminal, use for weeks/months
 - **MFA Support**: Full support for two-factor authentication
-- **SSO/Google sign-in**: Use `monarch_login_with_token` to paste a session token from your browser
+- **SSO/Google sign-in**: Paste a browser session token via `login_setup.py` (the MCP `monarch_login_with_token` tool is disabled)
 - **Session Persistence**: No need to re-authenticate frequently
-- **Secure**: Credentials never pass through Claude
+- **Secure**: Credentials never pass through Claude or any MCP tool
 
 ## 🛠️ Available Tools
 
@@ -390,19 +524,20 @@ Sessions last for weeks, but if expired:
 2. Enter your credentials and 2FA code
 3. Session will be refreshed automatically
 
-### `'Context' object has no attribute 'elicit'`
-The `monarch_login` and `monarch_login_with_token` tools require the MCP Python SDK 1.10.0 or newer (released June 2025). If your environment cached an older `mcp` install, refresh it:
+### `read_only: true` in a tool response
+You called a mutation tool (e.g. `create_transaction`) while the server
+was in read-only mode. This is the intended behavior. To make a write
+intentionally, restart the MCP server with `MONARCH_MCP_READ_ONLY=false`
+in its environment — and only for as long as you need it.
 
-```bash
-uv cache clean mcp
-```
-
-Then fully quit and reopen Claude Desktop or Claude Code so it relaunches the server with a fresh resolution. As a fallback while you upgrade, run `python login_setup.py` from the repo to authenticate via the terminal.
+### `disabled: true` from `monarch_login` / `monarch_login_with_token` / `monarch_logout`
+These three tools are permanently disabled. Authenticate from a terminal
+with `python login_setup.py` instead. There is no flag to re-enable them.
 
 ### Common Error Messages
-- **"No valid session found"**: Run `python login_setup.py` (or `uv run python login_setup.py`) 
-- **"Invalid account ID"**: Use `get_accounts` to see valid account IDs
-- **"Date format error"**: Use YYYY-MM-DD format for dates
+- **"No Monarch session token available"**: Run `python login_setup.py` (or `uv run python login_setup.py`) in a terminal on the same machine.
+- **"Invalid account ID"**: Use `get_accounts` to see valid account IDs.
+- **"Date format error"**: Use YYYY-MM-DD format for dates.
 
 ## 🏗️ Technical Details
 
@@ -419,24 +554,75 @@ monarch-mcp-server/
 ```
 
 ### Session Management
-- Sessions are stored securely in `.mm/mm_session.pickle`
-- Automatic session discovery and loading
-- Sessions persist across Claude Desktop and Claude Code restarts
-- No need for frequent re-authentication
+- Session **tokens** (not passwords) are stored in the system keyring:
+  - macOS: Keychain, service `com.mcp.monarch-mcp-server`, account `monarch-token`
+  - Linux without a keyring backend: file fallback at `~/.monarch-mcp-server/token`, mode `0600`
+- Tokens persist across Claude Desktop and Claude Code restarts.
+- The MCP server only reads the token; it never writes or deletes it.
+- Re-run `python login_setup.py` to rotate the token or to recover from
+  an expired session.
 
 ### Security Features
-- Credentials never transmitted through Claude Desktop or Claude Code
-- MFA/2FA fully supported
-- Session files are encrypted
-- Authentication handled in secure terminal environment
+- **Read-only by default** — see [🔒 Security model](#-security-model).
+- MCP-side login / logout tools are **permanently disabled**.
+- Credentials never transit Claude Desktop / Claude Code / MCP transport.
+- No `.env` / `dotenv` loading — credentials cannot leak in from a stray
+  `.env` next to the source tree.
+- MFA / 2FA fully supported (terminal flow).
 
-### Recommended: require approval for mutating tools
+### Mutation tools and dry-run
 
-Several tools mutate your Monarch ledger (`create_transaction`, `update_transaction`, `delete_transaction`, `bulk_categorize_transactions`, `upload_account_balance_history`, `set_transaction_tags`, `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`, `split_transaction`, `set_budget_amount`).
+See [🔒 Security model](#-security-model) above. Mutation tools are
+refused unless `MONARCH_MCP_READ_ONLY=false` is set in the MCP server's
+environment. `bulk_categorize_transactions` and
+`upload_account_balance_history` accept a `dry_run=True` argument that
+returns the planned changes without calling the upstream mutation API;
+**dry-run is allowed even in read-only mode** so you can preview before
+flipping the flag.
 
-Because the LLM can be influenced by data it reads back (a malicious-looking memo or merchant name in a transaction), the safest setup is to configure your MCP client to require manual approval before any mutating tool runs. In Claude Desktop and Claude Code this is the default behavior for unknown tools; keep it that way for the tools listed above rather than allow-listing them.
+## 🧪 Running the tests
 
-`bulk_categorize_transactions` and `upload_account_balance_history` also accept a `dry_run=True` argument that returns the planned changes without executing them, useful for previewing a bulk action before approving it.
+The hardened build ships with 181 tests, including 39 that prove each
+mutation tool refuses in read-only mode and 17 that prove the MCP auth
+tools are hard-disabled and the env-credential / dotenv loaders are gone.
+
+From the repo root, with the venv from step 2 of installation active:
+
+```bash
+# Install the dev extras (pytest + pytest-asyncio)
+pip install -e ".[dev]"
+
+# Run the whole suite
+python -m pytest
+
+# Or just the read-only / auth guards
+python -m pytest tests/test_read_only.py tests/test_auth.py -v
+```
+
+Tests use `unittest.mock.AsyncMock` for the Monarch client — they never
+hit the network and never require real credentials. Expect:
+
+```
+=========================== 181 passed in ~3s ===========================
+```
+
+If you want to manually verify the refusal payload without running the
+whole suite, in a terminal:
+
+```bash
+python -c "
+import asyncio, json
+from monarch_mcp_server.tools.transactions import create_transaction
+out = asyncio.run(create_transaction(
+    date='2026-01-01', account_id='x', amount=-1.0,
+    merchant_name='test', category_id='y',
+))
+print(json.dumps(json.loads(out), indent=2))
+"
+```
+
+You should see `read_only: true` and `success: false` — and no network
+call is made because the keyring lookup is bypassed by the refusal.
 
 ## 🙏 Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 A Model Context Protocol (MCP) server for integrating with the Monarch Money personal finance platform. This server provides seamless access to your financial accounts, transactions, budgets, and analytics through Claude Desktop and Claude Code.
 
 > **🔒 Hardened build (read-only by default).** As of the read-only hardening change, the server refuses all Monarch data mutations unless the operator explicitly opts in, and the MCP-exposed login/logout tools are permanently disabled. See [🔒 Security model](#-security-model) before configuring a client.
+>
+> **🍪 Cookie auth required (May 2026).** Monarch's API now authenticates with session cookies (`session_id` HttpOnly + `csrftoken`) plus an `x-csrftoken` request header. The legacy `Authorization: Token` header is rejected, so the old email/password and SSO-token paths in `login_setup.py` will not authenticate until upstream restores Token support. Use the cookie option.
 
 My MonarchMoney referral: https://www.monarchmoney.com/referral/ufmn0r83yf?r_source=share
 
@@ -152,21 +154,24 @@ These steps install the **hardened, read-only-by-default** branch into a local v
 
 ### 2. One-Time Authentication Setup (Terminal Only)
 
-> **⚠️ Never paste your Monarch email, password, MFA code, or session
-> token into a Claude chat.** The hardened build's MCP-exposed login tools
-> (`monarch_login`, `monarch_login_with_token`, `monarch_logout`) are
-> **permanently disabled** and return a refusal payload — they cannot
-> accept credentials over MCP transport regardless of any setting. Auth
-> happens only in a local terminal via `login_setup.py`.
+> **⚠️ Never paste your Monarch email, password, MFA code, session token,
+> or session cookies into a Claude chat.** The hardened build's
+> MCP-exposed login tools (`monarch_login`, `monarch_login_with_token`,
+> `monarch_logout`) are **permanently disabled** and return a refusal
+> payload — they cannot accept credentials over MCP transport regardless
+> of any setting. Auth happens only in a local terminal via
+> `login_setup.py`.
 
 The standalone script reads input directly from your terminal (via
-`input()` / `getpass.getpass()`), authenticates against Monarch in your
-local Python process, and stores the resulting **session token** in the
-system keyring. The MCP server then reads the token from the keyring on
-each call. Your email and password are never written to disk and never
-flow through MCP.
+`input()` / `getpass.getpass()`) and stores the resulting **session
+cookies** (`session_id` + `csrftoken`) in the system keyring. The MCP
+server then reads the cookies from the keyring on each call and sends
+them on every GraphQL request, along with an `x-csrftoken` header that
+mirrors the cookie value. Your email, password, MFA code, and the
+cookies themselves are never written to a `.env`, never read from the
+environment by the server, and never flow through MCP.
 
-#### Option A: Email / Password (with MFA if enabled)
+#### Option A: Session cookies (recommended — required since May 2026)
 
 Open Terminal on the same machine where you installed the server:
 
@@ -184,30 +189,39 @@ uv run python login_setup.py
 ```
 
 Follow the prompts in the terminal window:
-- Choose option `1` for email/password.
-- Enter your Monarch Money email and password.
-- Provide the MFA code if you have MFA enabled (you should).
-- A session token is saved to the macOS Keychain (or `~/.monarch-mcp-server/token` on systems with no keyring backend).
+- Choose option `1` (session cookies — the default).
+- In Chrome or Firefox, sign in to `https://app.monarch.com`.
+- Open DevTools (F12) → **Application** tab → **Cookies** → `https://app.monarch.com`.
+- Copy the **Value** of the `session_id` cookie (marked HttpOnly).
+- Copy the **Value** of the `csrftoken` cookie.
+- Paste each value at the prompts (input is hidden via `getpass`).
+- The cookies are saved to the macOS Keychain (or `~/.monarch-mcp-server/cookies.json` on systems with no keyring backend, mode `0600`).
 
-#### Option B: Paste a Browser Session Token (SSO / Google sign-in)
+The MCP server picks up the cookies on its next call and authenticates by
+sending them on every GraphQL request, along with an `x-csrftoken` header
+that mirrors the `csrftoken` cookie. This matches what Monarch's web app
+does after the May 2026 API change.
 
-If you sign in to Monarch with Google or another SSO provider, password
-login does not work. Instead, copy a token from your browser:
+#### Option B: Legacy email/password or session token (currently broken)
 
-1. Sign in to `https://app.monarchmoney.com` in Chrome or Firefox.
-2. Open DevTools → **Application** tab → **Local Storage** → `https://app.monarchmoney.com`.
-3. Copy the value of the `token` key.
-4. In the terminal, run `python login_setup.py` and choose option `2`.
-5. Paste the token at the prompt (the input is hidden via `getpass`).
+Options `2` (email/password) and `3` (legacy session token paste) remain
+in `login_setup.py` for forward compatibility, but they will **not**
+authenticate today: Monarch's API rejects the `Authorization: Token` flow
+that those paths produce. The script labels them as broken in the menu
+and gates them behind an extra confirmation. Use Option A above.
 
-The token is stored the same way as in Option A.
+If you previously logged in via one of these paths and your stored token
+has now started returning 401, re-run `login_setup.py` and switch to
+Option A.
 
 #### Rotating or clearing the stored session
 
-Re-run `python login_setup.py` to overwrite the stored token, or delete
-the macOS Keychain entry named `com.mcp.monarch-mcp-server` (Keychain
-Access app → search → delete) to clear it. The MCP server never modifies
-the stored session.
+Re-run `python login_setup.py` to overwrite the stored cookies, or delete
+the macOS Keychain entries `com.mcp.monarch-mcp-server` /
+`monarch-cookies` (and the legacy `monarch-token`) via Keychain Access →
+search → delete. On the file-fallback path, remove
+`~/.monarch-mcp-server/cookies.json` (and the legacy `token`). The MCP
+server never modifies the stored session.
 
 ### 3. Start Using
 
@@ -359,11 +373,11 @@ last line of defense.
 - **Get Spending Summary**: Spending breakdown by category with totals
 
 ### 🔐 Secure Authentication
-- **One-Time Setup**: Authenticate once in a terminal, use for weeks/months
-- **MFA Support**: Full support for two-factor authentication
-- **SSO/Google sign-in**: Paste a browser session token via `login_setup.py` (the MCP `monarch_login_with_token` tool is disabled)
-- **Session Persistence**: No need to re-authenticate frequently
-- **Secure**: Credentials never pass through Claude or any MCP tool
+- **Cookie-based auth (May 2026 API)**: Paste `session_id` + `csrftoken` browser cookies in a terminal via `login_setup.py`; the server sends them on every GraphQL request along with an `x-csrftoken` header.
+- **One-Time Setup**: Authenticate once in a terminal, use for weeks/months until the cookies expire.
+- **SSO/Google sign-in**: Works the same way — sign in to `app.monarch.com` in your browser, then copy the cookies.
+- **Session Persistence**: No need to re-authenticate frequently.
+- **Secure**: Credentials and cookies never pass through Claude or any MCP tool. The MCP `monarch_login` / `monarch_login_with_token` / `monarch_logout` tools are permanently disabled.
 
 ## 🛠️ Available Tools
 
@@ -513,16 +527,21 @@ Show my spending breakdown by category for last month using get_spending_summary
 ## 🔧 Troubleshooting
 
 ### Authentication Issues
-If you see "Authentication needed" errors:
+If you see "Authentication needed" or 401 errors:
 1. Run the setup command: `cd /path/to/your/monarch-mcp-server && python login_setup.py` (or `uv run python login_setup.py`)
-2. Restart Claude Desktop or Claude Code
-3. Try using a tool like `get_accounts`
+2. Choose option `1` (session cookies) and paste fresh `session_id` and `csrftoken` values from your browser.
+3. Restart Claude Desktop or Claude Code
+4. Try using a tool like `get_accounts`
 
-### Session Expired
-Sessions last for weeks, but if expired:
+### Session Expired or 401 after upgrade
+Cookies last for weeks, but if expired or if you upgraded from a build
+that used the legacy `Authorization: Token` flow:
 1. Run the same setup command again: `python login_setup.py` (or `uv run python login_setup.py`)
-2. Enter your credentials and 2FA code
-3. Session will be refreshed automatically
+2. Choose option `1` (session cookies) — do not pick option 2 or 3, they currently fail with the upstream API.
+3. Paste fresh `session_id` and `csrftoken` values.
+
+`check_auth_status` will warn explicitly when only a legacy token is
+stored — that is the cue to re-run `login_setup.py` and switch to cookies.
 
 ### `read_only: true` in a tool response
 You called a mutation tool (e.g. `create_transaction`) while the server
@@ -535,7 +554,8 @@ These three tools are permanently disabled. Authenticate from a terminal
 with `python login_setup.py` instead. There is no flag to re-enable them.
 
 ### Common Error Messages
-- **"No Monarch session token available"**: Run `python login_setup.py` (or `uv run python login_setup.py`) in a terminal on the same machine.
+- **"No Monarch session token available"** or 401 from any tool: Run `python login_setup.py` (or `uv run python login_setup.py`) in a terminal on the same machine and pick option 1 (session cookies).
+- **`check_auth_status` warns "Only a legacy session token is stored"**: Monarch's API rejected your legacy token. Re-run `login_setup.py` and switch to option 1 (cookies).
 - **"Invalid account ID"**: Use `get_accounts` to see valid account IDs.
 - **"Date format error"**: Use YYYY-MM-DD format for dates.
 
@@ -554,13 +574,17 @@ monarch-mcp-server/
 ```
 
 ### Session Management
-- Session **tokens** (not passwords) are stored in the system keyring:
-  - macOS: Keychain, service `com.mcp.monarch-mcp-server`, account `monarch-token`
-  - Linux without a keyring backend: file fallback at `~/.monarch-mcp-server/token`, mode `0600`
-- Tokens persist across Claude Desktop and Claude Code restarts.
-- The MCP server only reads the token; it never writes or deletes it.
-- Re-run `python login_setup.py` to rotate the token or to recover from
-  an expired session.
+- Session **cookies** (not passwords) are stored in the system keyring:
+  - macOS: Keychain, service `com.mcp.monarch-mcp-server`, accounts
+    `monarch-cookies` (current) and `monarch-token` (legacy).
+  - Linux without a keyring backend: file fallback at
+    `~/.monarch-mcp-server/cookies.json` (current) and
+    `~/.monarch-mcp-server/token` (legacy), both mode `0600`.
+- Cookies and tokens persist across Claude Desktop and Claude Code restarts.
+- The MCP server only reads them; it never writes or deletes them
+  (the auth-mutation MCP tools are disabled).
+- Re-run `python login_setup.py` to rotate cookies or to recover from an
+  expired session.
 
 ### Security Features
 - **Read-only by default** — see [🔒 Security model](#-security-model).
@@ -582,9 +606,10 @@ flipping the flag.
 
 ## 🧪 Running the tests
 
-The hardened build ships with 181 tests, including 39 that prove each
-mutation tool refuses in read-only mode and 17 that prove the MCP auth
-tools are hard-disabled and the env-credential / dotenv loaders are gone.
+The hardened build ships with a test suite that proves each mutation
+tool refuses in read-only mode, that the MCP auth tools are
+hard-disabled, that the env-credential / dotenv loaders are gone, and
+that the cookie-auth path is wired into the secure session store.
 
 From the repo root, with the venv from step 2 of installation active:
 
@@ -623,6 +648,24 @@ print(json.dumps(json.loads(out), indent=2))
 
 You should see `read_only: true` and `success: false` — and no network
 call is made because the keyring lookup is bypassed by the refusal.
+
+You can also exercise the cookie store directly without hitting Monarch:
+
+```bash
+python -c "
+from monarch_mcp_server.secure_session import SecureMonarchSession
+from monarch_mcp_server.cookie_auth import MonarchMoneyCookieAuth
+import gql.transport.aiohttp as t
+
+# Build a cookie-auth client and inspect the headers/cookies the GraphQL
+# transport will send — no network call is made.
+mm = MonarchMoneyCookieAuth(session_id='sid', csrftoken='csrf')
+print('x-csrftoken header:', mm._headers.get('x-csrftoken'))
+print('Origin header:', mm._headers.get('Origin'))
+print('cookies:', mm._cookies())
+print('Authorization header:', mm._headers.get('Authorization', '(unset)'))
+"
+```
 
 ## 🙏 Acknowledgments
 

--- a/login_setup.py
+++ b/login_setup.py
@@ -18,12 +18,9 @@ src_path = Path(__file__).parent / "src"
 sys.path.insert(0, str(src_path))
 
 from monarchmoney import MonarchMoney, RequireMFAException
-from dotenv import load_dotenv
 from monarch_mcp_server.secure_session import secure_session
 
 async def main():
-    load_dotenv()
-    
     print("\n🏦 Monarch Money - Claude Desktop Setup")
     print("=" * 45)
     print("This will authenticate you once and save a session")

--- a/login_setup.py
+++ b/login_setup.py
@@ -1,15 +1,23 @@
 #!/usr/bin/env python3
 """
-Standalone script to perform interactive Monarch Money login with MFA support.
-Run this script to authenticate and save a session file that the MCP server can use.
+Standalone script to perform interactive Monarch Money login.
+
+As of May 2026 Monarch's API requires session-cookie auth
+(``session_id`` HttpOnly + ``csrftoken`` cookies, plus an ``x-csrftoken``
+header). The cookie path is the only one that currently works. The legacy
+email/password and session-token paths are kept for forward compatibility
+but are clearly labeled as broken.
+
+This script reads input directly from the terminal — no dotenv, no
+environment-variable credentials, no MCP transport. It stores the
+resulting cookies (or legacy token) in the system keyring; the MCP server
+reads them on subsequent calls but never modifies them.
 """
 
 import asyncio
 import os
 import getpass
 import shutil
-import inspect
-import traceback
 import sys
 from pathlib import Path
 
@@ -18,92 +26,160 @@ src_path = Path(__file__).parent / "src"
 sys.path.insert(0, str(src_path))
 
 from monarchmoney import MonarchMoney, RequireMFAException
+
+from monarch_mcp_server.cookie_auth import MonarchMoneyCookieAuth
 from monarch_mcp_server.secure_session import secure_session
+
 
 async def main():
     print("\n🏦 Monarch Money - Claude Desktop Setup")
     print("=" * 45)
     print("This will authenticate you once and save a session")
     print("for seamless access through Claude Desktop.\n")
-    
+
     # Check the version first
     try:
         import monarchmoney
-        print(f"📦 MonarchMoney version: {getattr(monarchmoney, '__version__', 'unknown')}")
+        print(
+            f"📦 MonarchMoney version: "
+            f"{getattr(monarchmoney, '__version__', 'unknown')}"
+        )
     except Exception as e:
         print(f"⚠️  Could not check version: {e}")
-    
+
     mm = MonarchMoney()
-    
+
     try:
         # Clear any existing sessions (both old pickle files and keyring)
         secure_session.delete_token()
         print("🗑️ Cleared existing secure sessions")
-        
-        # Ask about MFA setup
-        print("\n🔐 Security Check:")
-        has_mfa = input("Do you have MFA (Multi-Factor Authentication) enabled on your Monarch Money account? (y/n): ").strip().lower()
-        
-        if has_mfa not in ['y', 'yes']:
-            print("\n⚠️  SECURITY RECOMMENDATION:")
-            print("=" * 50)
-            print("You should enable MFA for your Monarch Money account.")
-            print("MFA adds an extra layer of security to protect your financial data.")
-            print("\nTo enable MFA:")
-            print("1. Log into Monarch Money at https://monarchmoney.com")
-            print("2. Go to Settings → Security")
-            print("3. Enable Two-Factor Authentication")
-            print("4. Follow the setup instructions\n")
-            
-            proceed = input("Continue with login anyway? (y/n): ").strip().lower()
-            if proceed not in ['y', 'yes']:
-                print("Login cancelled. Please set up MFA and try again.")
-                return
-        
-        print("\nStarting login...")
-        print("\nHow do you sign in to Monarch Money?")
-        print("  1) Email and password")
-        print("  2) Google / SSO (single sign-on)")
-        login_method = input("Choice (1 or 2): ").strip()
 
-        if login_method == "2":
+        print("\nHow do you sign in to Monarch Money?")
+        print(
+            "  1) Session cookies from browser  "
+            "(recommended — required since May 2026)"
+        )
+        print(
+            "  2) Email and password            "
+            "(currently broken — Monarch dropped Token auth)"
+        )
+        print(
+            "  3) Legacy session token paste    "
+            "(currently broken — see above)"
+        )
+        login_method = input("Choice [1]: ").strip() or "1"
+
+        if login_method == "1":
+            print("\n📋 To get your session cookies from the browser:")
+            print("  1. Log in to https://app.monarch.com in Chrome/Firefox")
+            print("  2. Open DevTools (F12) → Application tab → Cookies")
+            print("     → https://app.monarch.com")
+            print(
+                "  3. Copy the Value of 'session_id' (HttpOnly) and "
+                "'csrftoken'"
+            )
+            print(
+                "\n⚠️  Do NOT paste these values into a Claude chat. The MCP "
+                "server's monarch_login_with_token tool is disabled. Cookies "
+                "are read here in your terminal only and stored in the local "
+                "keyring."
+            )
+            session_id = getpass.getpass("\nPaste session_id value: ").strip()
+            if not session_id:
+                print("❌ No session_id provided. Exiting.")
+                return
+            csrftoken = getpass.getpass("Paste csrftoken value: ").strip()
+            if not csrftoken:
+                print("❌ No csrftoken provided. Exiting.")
+                return
+            mm = MonarchMoneyCookieAuth(
+                session_id=session_id, csrftoken=csrftoken
+            )
+            print("✅ Cookies set")
+        elif login_method == "3":
+            print(
+                "\n⚠️  WARNING: Monarch's API currently rejects "
+                "Authorization: Token auth. This path is unlikely to work "
+                "until upstream restores it. Use option 1 instead."
+            )
+            proceed = input("Continue anyway? (y/n): ").strip().lower()
+            if proceed not in ("y", "yes"):
+                print("Cancelled.")
+                return
             print("\n📋 To get your session token from the browser:")
-            print("  1. Log in to https://app.monarchmoney.com in Chrome/Firefox")
+            print("  1. Log in to https://app.monarch.com in Chrome/Firefox")
             print("  2. Open DevTools (F12) → Application tab → Local Storage")
-            print("     → https://app.monarchmoney.com")
+            print("     → https://app.monarch.com")
             print("  3. Copy the value for the key 'token'")
-            print("     (Alternatively: DevTools → Network tab, filter any request,")
-            print("      look for 'Authorization: Token <value>' in request headers)")
             token = getpass.getpass("\nPaste your session token: ").strip()
             if not token:
                 print("❌ No token provided. Exiting.")
                 return
-            # Re-initialize with the token so the Authorization header is set correctly.
-            # set_token() only stores the value but does not update _headers.
             mm = MonarchMoney(token=token)
-            print("✅ Token set")
+            print("✅ Token set (note: upstream API likely to reject it)")
         else:
+            print(
+                "\n⚠️  WARNING: Monarch's API currently rejects "
+                "Authorization: Token auth, which is what email/password "
+                "login produces. This path is unlikely to authenticate "
+                "successfully until upstream restores Token support. Use "
+                "option 1 (session cookies) instead."
+            )
+            proceed = input("Continue anyway? (y/n): ").strip().lower()
+            if proceed not in ("y", "yes"):
+                print("Cancelled.")
+                return
+
+            print("\n🔐 Security Check:")
+            has_mfa = input(
+                "Do you have MFA (Multi-Factor Authentication) enabled on "
+                "your Monarch Money account? (y/n): "
+            ).strip().lower()
+            if has_mfa not in ("y", "yes"):
+                print("\n⚠️  SECURITY RECOMMENDATION:")
+                print("=" * 50)
+                print(
+                    "You should enable MFA for your Monarch Money account."
+                )
+                print(
+                    "MFA adds an extra layer of security to protect your "
+                    "financial data."
+                )
+                print("\nTo enable MFA:")
+                print("1. Log into Monarch Money at https://monarchmoney.com")
+                print("2. Go to Settings → Security")
+                print("3. Enable Two-Factor Authentication")
+                print("4. Follow the setup instructions\n")
+                cont = input(
+                    "Continue with login anyway? (y/n): "
+                ).strip().lower()
+                if cont not in ("y", "yes"):
+                    print(
+                        "Login cancelled. Please set up MFA and try again."
+                    )
+                    return
+
             email = input("Email: ")
             password = getpass.getpass("Password: ")
 
-            # Try login without MFA first
             try:
-                await mm.login(email, password, use_saved_session=False, save_session=True)
+                await mm.login(
+                    email,
+                    password,
+                    use_saved_session=False,
+                    save_session=True,
+                )
                 print("✅ Login successful!")
-
             except RequireMFAException:
                 print("🔐 MFA code required")
                 mfa_code = input("Two Factor Code: ")
-
-                # Use the same instance for MFA
                 await mm.multi_factor_authenticate(email, password, mfa_code)
                 print("✅ MFA authentication successful")
                 mm.save_session()  # Manually save the session
-        
-        # Test the connection first
+
+        # Test the connection
         print("\nTesting connection...")
         try:
-            # Try a simple test call that should work
             print("Calling get_accounts()...")
             accounts = await mm.get_accounts()
             print(f"Response received: {type(accounts)}")
@@ -118,70 +194,51 @@ async def main():
         except Exception as test_error:
             print(f"❌ Connection test failed: {test_error}")
             print(f"Error type: {type(test_error)}")
-            
-            # Check if it's a session issue
-            if "session" in str(test_error).lower() or "expired" in str(test_error).lower():
-                print("Session may be expired. Clearing old session and trying fresh login...")
-                
-                # Clear old session and try fresh login
-                if os.path.exists(".mm"):
-                    shutil.rmtree(".mm")
-                    print("🗑️ Cleared expired session files")
-                
-                # Try fresh login
-                mm_fresh = MonarchMoney()
-                try:
-                    await mm_fresh.login(email, password)
-                    print("✅ Fresh login successful (no MFA required)")
-                    mm = mm_fresh
-                    
-                    # Test connection again
-                    accounts = await mm.get_accounts()
-                    if accounts and isinstance(accounts, dict):
-                        account_count = len(accounts.get("accounts", []))
-                        print(f"✅ Found {account_count} accounts")
-                    
-                except RequireMFAException:
-                    print("🔐 MFA required for fresh login")
-                    mfa_code = input("Two Factor Code: ")
-                    
-                    mm_mfa_fresh = MonarchMoney()
-                    await mm_mfa_fresh.multi_factor_authenticate(email, password, mfa_code)
-                    print("✅ Fresh MFA authentication successful")
-                    mm = mm_mfa_fresh
-                    
-                    # Test connection again
-                    accounts = await mm.get_accounts()
-                    if accounts and isinstance(accounts, dict):
-                        account_count = len(accounts.get("accounts", []))
-                        print(f"✅ Found {account_count} accounts")
+            if (
+                "session" in str(test_error).lower()
+                or "expired" in str(test_error).lower()
+                or "401" in str(test_error)
+            ):
+                print(
+                    "\nThis usually means the session is expired or the "
+                    "API rejected the auth method. If you used option 2 or "
+                    "3, that is expected — Monarch's API currently requires "
+                    "session-cookie auth. Re-run this script and choose "
+                    "option 1 (session cookies)."
+                )
             else:
-                print("This appears to be an API compatibility issue.")
-                print("The MonarchMoney library API may have changed.")
-                print("Try updating the library: pip install --upgrade monarchmoneycommunity")
-                return
-        
+                print(
+                    "\nThis appears to be an API compatibility issue. The "
+                    "MonarchMoney library API may have changed. Try "
+                    "updating the library: "
+                    "pip install --upgrade monarchmoneycommunity"
+                )
+            return
+
         # Save session securely to keyring
         try:
-            print(f"\n🔐 Saving session securely to system keyring...")
+            print("\n🔐 Saving session securely to system keyring...")
             secure_session.save_authenticated_session(mm)
-            print(f"✅ Session saved securely to keyring!")
-                
+            print("✅ Session saved securely to keyring!")
         except Exception as save_error:
             print(f"❌ Could not save session to keyring: {save_error}")
             print("You may need to run the login again.")
-        
-        print("\n🎉 Setup complete! You can now use these tools in Claude Desktop:")
-        print("   • get_accounts - View all your accounts")  
+
+        print(
+            "\n🎉 Setup complete! You can now use these tools in Claude "
+            "Desktop:"
+        )
+        print("   • get_accounts - View all your accounts")
         print("   • get_transactions - Recent transactions")
         print("   • get_budgets - Budget information")
         print("   • get_cashflow - Income/expense analysis")
         print("\n💡 Session will persist across Claude restarts!")
-        
+
     except Exception as e:
         print(f"\n❌ Login failed: {e}")
         print("\nPlease check your credentials and try again.")
         print(f"Error type: {type(e)}")
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "monarchmoneycommunity>=1.2.0",
     "gql>=3.4,<4.0",
     "keyring>=24.0.0",
-    "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ mcp[cli]>=1.10.0
 monarchmoneycommunity>=1.2.0
 gql>=3.4,<4.0
 keyring>=24.0.0
-python-dotenv>=1.0.0
 pydantic>=2.0.0

--- a/src/monarch_mcp_server/app.py
+++ b/src/monarch_mcp_server/app.py
@@ -2,15 +2,13 @@
 
 import logging
 
-from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+
+from monarch_mcp_server.read_only import ENV_VAR, is_read_only
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-# Load environment variables
-load_dotenv()
 
 # Initialize FastMCP server
 mcp = FastMCP("Monarch Money MCP Server")
@@ -25,6 +23,18 @@ app = mcp
 def main() -> None:
     """Main entry point for the server."""
     logger.info("Starting Monarch Money MCP Server...")
+    if is_read_only():
+        logger.info(
+            "Read-only mode active (%s unset or truthy). All Monarch data "
+            "mutations are refused.",
+            ENV_VAR,
+        )
+    else:
+        logger.warning(
+            "Read-only mode DISABLED via %s. Monarch data mutations are "
+            "permitted by tools that explicitly opt in.",
+            ENV_VAR,
+        )
     try:
         mcp.run()
     except Exception as e:

--- a/src/monarch_mcp_server/auth.py
+++ b/src/monarch_mcp_server/auth.py
@@ -1,99 +1,36 @@
-"""Interactive authentication for the Monarch Money MCP server.
+"""Authentication helpers — DISABLED for MCP transport.
 
-Uses MCP elicitation so credentials flow client-UI → server directly over
-the protocol — they never appear in tool arguments or the model's context.
+The previous implementation used MCP elicitation to collect Monarch Money
+credentials over the protocol. That flow has been removed: credentials must
+not flow through the MCP transport, and the server must not be able to
+mutate stored auth state on behalf of a remote client.
+
+To authenticate, run ``python login_setup.py`` from a terminal. The
+standalone script writes a session token to the system keyring; the MCP
+server reads it on subsequent calls but never modifies it.
 """
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import Context
-from monarchmoney import MonarchMoney, RequireMFAException
-from pydantic import BaseModel, Field
 
-from monarch_mcp_server.secure_session import secure_session
+class AuthDisabledError(RuntimeError):
+    """Raised if any code path tries to invoke MCP-side login/logout."""
 
 
-_UPGRADE_HINT = (
-    "Elicitation requires the MCP Python SDK >= 1.10.0 (added in June 2025). "
-    "Your MCP server install appears to be running an older version that does "
-    "not expose Context.elicit. Upgrade the `mcp` package, then restart your "
-    "MCP client. If you launch via `uv run --with mcp[cli]`, run `uv cache "
-    "clean mcp` first so a fresh version is resolved. As a fallback, run "
-    "`python login_setup.py` from the repo to authenticate via terminal."
-)
-
-
-def _elicit_supported(ctx: Context) -> bool:
-    return hasattr(ctx, "elicit")
-
-
-class LoginForm(BaseModel):
-    email: str = Field(description="Monarch Money email address")
-    password: str = Field(description="Monarch Money password")
-
-
-class MFAForm(BaseModel):
-    mfa_code: str = Field(description="Monarch Money MFA code")
-
-
-class TokenForm(BaseModel):
-    token: str = Field(
-        description=(
-            "Monarch Money session token. Grab it from browser DevTools → "
-            "Application → Local Storage for app.monarchmoney.com, key 'token'."
-        ),
+def _disabled(name: str) -> AuthDisabledError:
+    return AuthDisabledError(
+        f"{name} is disabled. Use `python login_setup.py` to manage the "
+        "Monarch Money session out-of-band."
     )
 
 
-async def login_interactive(ctx: Context) -> str:
-    if not _elicit_supported(ctx):
-        return _UPGRADE_HINT
-    form_result = await ctx.elicit(message="Sign in to Monarch Money.", schema=LoginForm)
-    if form_result.action != "accept":
-        return "Login cancelled."
-    form = form_result.data
-
-    mm = MonarchMoney()
-    try:
-        await mm.login(
-            form.email,
-            form.password,
-            use_saved_session=False,
-            save_session=False,
-        )
-    except RequireMFAException:
-        mfa_result = await ctx.elicit(
-            message="Enter your Monarch Money MFA code.", schema=MFAForm
-        )
-        if mfa_result.action != "accept":
-            return "Login cancelled."
-        await mm.multi_factor_authenticate(
-            form.email, form.password, mfa_result.data.mfa_code
-        )
-
-    secure_session.save_authenticated_session(mm)
-    return "Logged in. Session saved to system keyring."
+async def login_interactive(*_args, **_kwargs) -> str:
+    raise _disabled("login_interactive")
 
 
-async def login_with_token_interactive(ctx: Context) -> str:
-    if not _elicit_supported(ctx):
-        return _UPGRADE_HINT
-    form_result = await ctx.elicit(
-        message="Paste your Monarch Money session token.", schema=TokenForm
-    )
-    if form_result.action != "accept":
-        return "Login cancelled."
-
-    token = form_result.data.token.strip()
-    if not token:
-        return "Empty token — aborting."
-
-    mm = MonarchMoney(token=token)
-    await mm.get_subscription_details()
-    secure_session.save_token(token)
-    return "Session token saved to system keyring."
+async def login_with_token_interactive(*_args, **_kwargs) -> str:
+    raise _disabled("login_with_token_interactive")
 
 
-async def logout() -> str:
-    secure_session.delete_token()
-    return "Cleared stored Monarch session."
+async def logout(*_args, **_kwargs) -> str:
+    raise _disabled("logout")

--- a/src/monarch_mcp_server/client.py
+++ b/src/monarch_mcp_server/client.py
@@ -1,6 +1,5 @@
 """Cached MonarchMoney client factory."""
 
-import os
 import logging
 from typing import Optional
 
@@ -26,13 +25,17 @@ def clear_client_cache() -> None:
 
 
 async def get_monarch_client() -> MonarchMoney:
-    """Get or create a cached MonarchMoney client using secure session storage."""
+    """Get or create a cached MonarchMoney client using secure session storage.
+
+    The MCP server never auto-logs in from environment credentials. To
+    authenticate, run ``python login_setup.py`` once to store a session
+    token in the system keyring.
+    """
     global _cached_client
 
     if _cached_client is not None:
         return _cached_client
 
-    # Try to get authenticated client from secure session
     client = secure_session.get_authenticated_client()
 
     if client is not None:
@@ -40,23 +43,8 @@ async def get_monarch_client() -> MonarchMoney:
         _cached_client = client
         return client
 
-    # If no secure session, try environment credentials
-    email = os.getenv("MONARCH_EMAIL")
-    password = os.getenv("MONARCH_PASSWORD")
-
-    if email and password:
-        try:
-            client = MonarchMoney()
-            await client.login(email, password)
-            logger.info(
-                "Successfully logged into Monarch Money with environment credentials"
-            )
-            # Save the session securely
-            secure_session.save_authenticated_session(client)
-            _cached_client = client
-            return client
-        except Exception as e:
-            logger.error(f"Failed to login to Monarch Money: {e}")
-            raise
-
-    raise RuntimeError("Authentication needed! Run: python login_setup.py")
+    raise RuntimeError(
+        "No Monarch session token available. Run `python login_setup.py` "
+        "from a terminal to authenticate. The MCP server does not accept "
+        "credentials and does not read MONARCH_EMAIL/MONARCH_PASSWORD."
+    )

--- a/src/monarch_mcp_server/cookie_auth.py
+++ b/src/monarch_mcp_server/cookie_auth.py
@@ -1,0 +1,61 @@
+"""Cookie-based authentication for Monarch's new session-cookie API.
+
+In May 2026 Monarch's web app stopped sending `Authorization: Token <...>`
+on GraphQL requests and switched to session-cookie auth: a `session_id`
+cookie (HttpOnly), a `csrftoken` cookie, and an `x-csrftoken` request header
+matching the csrftoken cookie. The upstream monarchmoneycommunity library
+still ships the old Token-header flow, so we subclass MonarchMoney and
+override the GraphQL transport to send cookies instead.
+
+Known limitation: the upload paths in the upstream library
+(`_upload_form_data`, account balance history upload, attachment upload)
+build their own aiohttp ClientSession with the legacy headers and will not
+work with cookie auth until upstream patches the library. The hardened
+build refuses those mutations by default anyway.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from gql import Client
+from gql.transport.aiohttp import AIOHTTPTransport
+from monarchmoney import MonarchMoney
+from monarchmoney.monarchmoney import MonarchMoneyEndpoints
+
+WEB_ORIGIN = "https://app.monarch.com"
+
+
+class MonarchMoneyCookieAuth(MonarchMoney):
+    """MonarchMoney variant authenticating via session_id + csrftoken cookies."""
+
+    def __init__(
+        self,
+        session_id: str,
+        csrftoken: str,
+        timeout: int = 10,
+    ) -> None:
+        super().__init__(timeout=timeout)
+        self._session_id = session_id
+        self._csrftoken = csrftoken
+        self._headers.pop("Authorization", None)
+        self._headers["x-csrftoken"] = csrftoken
+        self._headers["Origin"] = WEB_ORIGIN
+        self._headers["Referer"] = WEB_ORIGIN + "/"
+
+    def _cookies(self) -> Dict[str, str]:
+        return {"session_id": self._session_id, "csrftoken": self._csrftoken}
+
+    def _get_graphql_client(self) -> Client:
+        transport = AIOHTTPTransport(
+            url=MonarchMoneyEndpoints.getGraphQL(),
+            headers=self._headers,
+            cookies=self._cookies(),
+            timeout=self._timeout,
+            ssl=True,
+        )
+        return Client(
+            transport=transport,
+            fetch_schema_from_transport=False,
+            execute_timeout=self._timeout,
+        )

--- a/src/monarch_mcp_server/read_only.py
+++ b/src/monarch_mcp_server/read_only.py
@@ -1,0 +1,65 @@
+"""Read-only mode controls for the Monarch MCP Server.
+
+The server defaults to read-only: any tool that mutates remote Monarch state
+or local authentication state must refuse to run unless the operator has
+explicitly opted in by setting ``MONARCH_MCP_READ_ONLY`` to a falsey value
+(``false``, ``0``, ``no``, ``off``).
+
+Auth/session mutation tools that accept credentials or change stored auth
+state are *hard*-disabled regardless of this flag — they can only be used
+via the standalone ``login_setup.py`` terminal flow.
+"""
+
+from __future__ import annotations
+
+import os
+
+from monarch_mcp_server.helpers import json_success
+
+ENV_VAR = "MONARCH_MCP_READ_ONLY"
+
+_FALSEY = frozenset({"false", "0", "no", "off", "disable", "disabled"})
+
+
+def is_read_only() -> bool:
+    """Return True when the server is in read-only mode.
+
+    Default is True. Only an explicit falsey value disables the guard.
+    """
+    raw = os.environ.get(ENV_VAR)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in _FALSEY
+
+
+def read_only_refusal(tool_name: str) -> str:
+    """JSON refusal payload for a mutation tool blocked by read-only mode."""
+    return json_success(
+        {
+            "success": False,
+            "read_only": True,
+            "tool": tool_name,
+            "error": (
+                f"Refusing to run mutation tool '{tool_name}': server is in "
+                "read-only mode. Set MONARCH_MCP_READ_ONLY=false to enable "
+                "Monarch data mutations (not recommended)."
+            ),
+        }
+    )
+
+
+def auth_mutation_disabled(tool_name: str) -> str:
+    """JSON refusal payload for an auth-mutation tool that is hard-disabled."""
+    return json_success(
+        {
+            "success": False,
+            "disabled": True,
+            "tool": tool_name,
+            "error": (
+                f"MCP tool '{tool_name}' is disabled. Authentication and "
+                "session mutation must be performed out-of-band via "
+                "`python login_setup.py`; the MCP server no longer accepts "
+                "credentials or modifies stored auth state."
+            ),
+        }
+    )

--- a/src/monarch_mcp_server/secure_session.py
+++ b/src/monarch_mcp_server/secure_session.py
@@ -1,26 +1,40 @@
 """
 Secure session management for Monarch Money MCP Server.
 
+Stores either:
+
+- Session cookies (``session_id`` + ``csrftoken``) — Monarch's current
+  authentication scheme as of May 2026. Preferred.
+- A legacy session token — kept for backward compatibility, but Monarch's
+  API currently rejects Token-header auth so it will not authenticate.
+
 Uses the system keyring when available, with an automatic file-based
-fallback for environments without a keyring backend (e.g. WSL, headless Linux).
+fallback for environments without a keyring backend (e.g. WSL, headless
+Linux).
 """
 
+import json
 import logging
 import os
 import stat
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
+
 from monarchmoney import MonarchMoney
+
+from monarch_mcp_server.cookie_auth import MonarchMoneyCookieAuth
 
 logger = logging.getLogger(__name__)
 
 # Keyring service identifiers
 KEYRING_SERVICE = "com.mcp.monarch-mcp-server"
 KEYRING_USERNAME = "monarch-token"
+KEYRING_USERNAME_COOKIES = "monarch-cookies"
 
 # File-based fallback location
 _TOKEN_DIR = Path.home() / ".monarch-mcp-server"
 _TOKEN_FILE = _TOKEN_DIR / "token"
+_COOKIES_FILE = _TOKEN_DIR / "cookies.json"
 
 
 def _keyring_available() -> bool:
@@ -92,10 +106,38 @@ class SecureMonarchSession:
         if _TOKEN_DIR.is_dir() and not list(_TOKEN_DIR.iterdir()):
             _TOKEN_DIR.rmdir()
 
+    def _save_cookies_file(self, session_id: str, csrftoken: str) -> None:
+        _TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps({"session_id": session_id, "csrftoken": csrftoken})
+        _COOKIES_FILE.write_text(payload)
+        _COOKIES_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 600
+        _TOKEN_DIR.chmod(stat.S_IRWXU)  # 700
+        logger.info(f"✅ Cookies saved to {_COOKIES_FILE}")
+
+    def _load_cookies_file(self) -> Optional[Tuple[str, str]]:
+        if _COOKIES_FILE.is_file():
+            try:
+                data = json.loads(_COOKIES_FILE.read_text())
+                sid = data.get("session_id", "").strip()
+                csrf = data.get("csrftoken", "").strip()
+                if sid and csrf:
+                    logger.info(f"✅ Cookies loaded from {_COOKIES_FILE}")
+                    return sid, csrf
+            except Exception as e:
+                logger.warning(f"⚠️  Cookie file unreadable: {e}")
+        return None
+
+    def _delete_cookies_file(self) -> None:
+        if _COOKIES_FILE.is_file():
+            _COOKIES_FILE.unlink()
+            logger.info(f"🗑️ Cookies file deleted: {_COOKIES_FILE}")
+        if _TOKEN_DIR.is_dir() and not list(_TOKEN_DIR.iterdir()):
+            _TOKEN_DIR.rmdir()
+
     # -- public API ----------------------------------------------------------
 
     def save_token(self, token: str) -> None:
-        """Save the authentication token to the system keyring or file fallback."""
+        """Save the (legacy) authentication token to the system keyring or file fallback."""
         if self._use_keyring:
             try:
                 import keyring
@@ -110,7 +152,7 @@ class SecureMonarchSession:
         self._cleanup_old_session_files()
 
     def load_token(self) -> Optional[str]:
-        """Load the authentication token from the system keyring or file fallback."""
+        """Load the (legacy) authentication token from the system keyring or file fallback."""
         if self._use_keyring:
             try:
                 import keyring
@@ -130,8 +172,50 @@ class SecureMonarchSession:
         logger.info("🔍 No token found")
         return None
 
+    def save_cookies(self, session_id: str, csrftoken: str) -> None:
+        """Save session_id + csrftoken cookies to keyring or file fallback."""
+        if self._use_keyring:
+            try:
+                import keyring
+                payload = json.dumps(
+                    {"session_id": session_id, "csrftoken": csrftoken}
+                )
+                keyring.set_password(
+                    KEYRING_SERVICE, KEYRING_USERNAME_COOKIES, payload
+                )
+                logger.info("✅ Cookies saved securely to keyring")
+                self._cleanup_old_session_files()
+                return
+            except Exception as e:
+                logger.warning(f"⚠️  Keyring save failed, falling back to file: {e}")
+
+        self._save_cookies_file(session_id, csrftoken)
+        self._cleanup_old_session_files()
+
+    def load_cookies(self) -> Optional[Tuple[str, str]]:
+        """Load session_id + csrftoken from keyring or file fallback."""
+        if self._use_keyring:
+            try:
+                import keyring
+                payload = keyring.get_password(
+                    KEYRING_SERVICE, KEYRING_USERNAME_COOKIES
+                )
+                if payload:
+                    data = json.loads(payload)
+                    sid = data.get("session_id", "").strip()
+                    csrf = data.get("csrftoken", "").strip()
+                    if sid and csrf:
+                        logger.info("✅ Cookies loaded from keyring")
+                        return sid, csrf
+            except Exception as e:
+                logger.warning(
+                    f"⚠️  Keyring cookie load failed, trying file: {e}"
+                )
+
+        return self._load_cookies_file()
+
     def delete_token(self) -> None:
-        """Delete the authentication token from all storage backends."""
+        """Delete both the (legacy) token and the session cookies from all backends."""
         # Try keyring
         if self._use_keyring:
             try:
@@ -140,20 +224,49 @@ class SecureMonarchSession:
                 logger.info("🗑️ Token deleted from keyring")
             except Exception:
                 pass
+            try:
+                import keyring
+                keyring.delete_password(
+                    KEYRING_SERVICE, KEYRING_USERNAME_COOKIES
+                )
+                logger.info("🗑️ Cookies deleted from keyring")
+            except Exception:
+                pass
 
         # Always try file cleanup too
         self._delete_token_file()
+        self._delete_cookies_file()
         self._cleanup_old_session_files()
 
     def get_authenticated_client(self) -> Optional[MonarchMoney]:
-        """Get an authenticated MonarchMoney client."""
+        """Get an authenticated MonarchMoney client.
+
+        Prefers cookie-based auth (Monarch's current model) and falls back to
+        the legacy token if no cookies are stored. The legacy token path is
+        retained for backward compatibility but Monarch's API currently
+        rejects Token-header auth.
+        """
+        cookies = self.load_cookies()
+        if cookies:
+            try:
+                sid, csrf = cookies
+                client = MonarchMoneyCookieAuth(session_id=sid, csrftoken=csrf)
+                logger.info("✅ MonarchMoney client created with stored cookies")
+                return client
+            except Exception as e:
+                logger.error(f"❌ Failed to create cookie-auth client: {e}")
+
         token = self.load_token()
         if not token:
             return None
 
         try:
             client = MonarchMoney(token=token)
-            logger.info("✅ MonarchMoney client created with stored token")
+            logger.warning(
+                "⚠️  Falling back to legacy token auth — Monarch's API "
+                "currently rejects Token-header auth (May 2026). Run "
+                "`python login_setup.py` and paste session cookies."
+            )
             return client
         except Exception as e:
             logger.error(f"❌ Failed to create MonarchMoney client: {e}")
@@ -161,10 +274,14 @@ class SecureMonarchSession:
 
     def save_authenticated_session(self, mm: MonarchMoney) -> None:
         """Save the session from an authenticated MonarchMoney instance."""
-        if mm.token:
+        if isinstance(mm, MonarchMoneyCookieAuth):
+            self.save_cookies(mm._session_id, mm._csrftoken)
+        elif mm.token:
             self.save_token(mm.token)
         else:
-            logger.warning("⚠️  MonarchMoney instance has no token to save")
+            logger.warning(
+                "⚠️  MonarchMoney instance has no token or cookies to save"
+            )
 
     def _cleanup_old_session_files(self) -> None:
         """Clean up old insecure session files."""

--- a/src/monarch_mcp_server/tools/accounts.py
+++ b/src/monarch_mcp_server/tools/accounts.py
@@ -11,6 +11,7 @@ from pydantic import RootModel, ValidationError
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
 from monarch_mcp_server.helpers import json_success, json_error
+from monarch_mcp_server.read_only import is_read_only, read_only_refusal
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +54,8 @@ async def get_accounts() -> str:
 @mcp.tool()
 async def refresh_accounts() -> str:
     """Request account data refresh from financial institutions."""
+    if is_read_only():
+        return read_only_refusal("refresh_accounts")
     try:
         client = await get_monarch_client()
         result = await client.request_accounts_refresh()
@@ -145,6 +148,8 @@ async def upload_account_balance_history(
     Mismatched dates (corrections that do not match any existing snapshot) are
     surfaced explicitly in the response rather than silently dropped.
     """
+    if is_read_only() and not dry_run:
+        return read_only_refusal("upload_account_balance_history")
     try:
         try:
             raw = json.loads(corrections)

--- a/src/monarch_mcp_server/tools/auth.py
+++ b/src/monarch_mcp_server/tools/auth.py
@@ -4,6 +4,11 @@ The MCP server does not accept credentials. Login, token paste, and logout
 flows are intentionally disabled here — they must be performed out-of-band
 via ``python login_setup.py``. The remaining tools are strictly read-only
 checks against the locally stored session.
+
+As of May 2026 Monarch's API requires session-cookie auth (``session_id``
+HttpOnly + ``csrftoken`` cookies plus an ``x-csrftoken`` header). The
+legacy ``Authorization: Token`` flow is no longer accepted upstream, so
+``check_auth_status`` warns when only a legacy token is stored.
 """
 
 import logging
@@ -26,13 +31,19 @@ This MCP server does not accept credentials and cannot log you in.
 To authenticate:
    Run in a terminal: python login_setup.py
 
-The terminal flow will prompt for email/password (or a session token from
-the browser), perform MFA if required, and store the resulting session
-token in the system keyring. The MCP server will pick it up on next call.
+⚠️ As of May 2026, Monarch's API requires session-cookie auth
+   (session_id + csrftoken cookies). The terminal flow will prompt you to
+   paste those cookies from your browser DevTools and store them in the
+   system keyring. The legacy email/password and session-token paths are
+   kept for forward compatibility but currently will NOT authenticate
+   because upstream still ships the old Token-header flow.
+
+The MCP server picks up the stored cookies (or legacy token) on next call
+but never modifies them.
 
 Once authenticated:
    ✅ Session persists across restarts
-   ✅ Token stored securely in system keyring
+   ✅ Cookies stored securely in system keyring
 
 Note: MCP-exposed login/logout/token-paste tools are intentionally disabled
 to prevent credentials from flowing through MCP transport or being changed
@@ -54,7 +65,8 @@ async def monarch_login_with_token() -> str:
     """[DISABLED] Paste a Monarch Money session token.
 
     This tool is intentionally disabled. Run ``python login_setup.py`` from
-    a terminal and choose the token-paste option.
+    a terminal and paste session cookies (or, on the rare chance upstream
+    restores Token-header auth, a legacy session token).
     """
     return auth_mutation_disabled("monarch_login_with_token")
 
@@ -74,11 +86,19 @@ async def monarch_logout() -> str:
 async def check_auth_status() -> str:
     """Check if already authenticated with Monarch Money."""
     try:
+        cookies = secure_session.load_cookies()
         token = secure_session.load_token()
-        if token:
-            status = "✅ Authentication token found in secure keyring storage\n"
+        if cookies:
+            status = "✅ Session cookies found in secure keyring storage\n"
+        elif token:
+            status = (
+                "⚠️ Only a legacy session token is stored — Monarch's API "
+                "currently rejects Token-header auth (May 2026 change). "
+                "Run `python login_setup.py` and choose the cookie option "
+                "to switch to session-cookie auth.\n"
+            )
         else:
-            status = "❌ No authentication token found in keyring\n"
+            status = "❌ No authentication session found in keyring\n"
 
         # MONARCH_EMAIL is no longer used for auto-login, but surface it for
         # diagnostic clarity if an operator left it in their environment.
@@ -103,10 +123,20 @@ async def check_auth_status() -> str:
 async def debug_session_loading() -> str:
     """Debug keyring session loading issues."""
     try:
+        cookies = secure_session.load_cookies()
+        if cookies:
+            return "✅ Session cookies found in keyring."
         token = secure_session.load_token()
         if token:
-            return "✅ Token found in keyring."
-        return "❌ No token found in keyring. Run login_setup.py to authenticate."
+            return (
+                "⚠️ Only a legacy token found in keyring. Monarch's API "
+                "rejects Token-header auth as of May 2026. Run "
+                "login_setup.py and switch to cookie auth."
+            )
+        return (
+            "❌ No session found in keyring. Run login_setup.py to "
+            "authenticate."
+        )
     except Exception as e:
         logger.exception("Keyring access failed")
         return f"❌ Keyring access failed: {type(e).__name__}: {e}"

--- a/src/monarch_mcp_server/tools/auth.py
+++ b/src/monarch_mcp_server/tools/auth.py
@@ -1,12 +1,16 @@
-"""Authentication tools."""
+"""Authentication tools.
+
+The MCP server does not accept credentials. Login, token paste, and logout
+flows are intentionally disabled here — they must be performed out-of-band
+via ``python login_setup.py``. The remaining tools are strictly read-only
+checks against the locally stored session.
+"""
 
 import logging
 import os
 
-from mcp.server.fastmcp import Context
-
-from monarch_mcp_server import auth
 from monarch_mcp_server.app import mcp
+from monarch_mcp_server.read_only import auth_mutation_disabled
 from monarch_mcp_server.secure_session import secure_session
 
 logger = logging.getLogger(__name__)
@@ -15,48 +19,55 @@ logger = logging.getLogger(__name__)
 @mcp.tool()
 async def setup_authentication() -> str:
     """Get instructions for setting up secure authentication with Monarch Money."""
-    return """🔐 Monarch Money - Authentication Options
+    return """🔐 Monarch Money - Authentication Setup
 
-Option 1: Elicitation login (Recommended for interactive clients)
-   Call 'monarch_login' to enter email/password (and MFA if needed)
-   via a secure form in your client UI. Credentials never pass
-   through the model. Or 'monarch_login_with_token' to paste a
-   browser-copied session token.
+This MCP server does not accept credentials and cannot log you in.
 
-Option 2: Email/Password (Terminal)
-   Run in terminal: python login_setup.py
+To authenticate:
+   Run in a terminal: python login_setup.py
 
-Call 'monarch_logout' to clear the stored session.
+The terminal flow will prompt for email/password (or a session token from
+the browser), perform MFA if required, and store the resulting session
+token in the system keyring. The MCP server will pick it up on next call.
 
-✅ Session persists across restarts
-✅ Token stored securely in system keyring"""
+Once authenticated:
+   ✅ Session persists across restarts
+   ✅ Token stored securely in system keyring
 
-
-@mcp.tool()
-async def monarch_login(ctx: Context) -> str:
-    """Sign in to Monarch Money.
-
-    Opens a secure form in the client UI to collect email, password, and
-    (if required) an MFA code. Credentials never pass through the model —
-    they flow client-UI → server directly via the MCP protocol.
-    """
-    return await auth.login_interactive(ctx)
+Note: MCP-exposed login/logout/token-paste tools are intentionally disabled
+to prevent credentials from flowing through MCP transport or being changed
+remotely. Run login_setup.py to rotate credentials or clear the session."""
 
 
 @mcp.tool()
-async def monarch_login_with_token(ctx: Context) -> str:
-    """Sign in to Monarch Money using a browser-copied session token.
+async def monarch_login() -> str:
+    """[DISABLED] Sign in to Monarch Money.
 
-    Useful for SSO users who can't use password login. Grab the token from
-    browser DevTools → Application → Local Storage → app.monarchmoney.com.
+    This tool is intentionally disabled — the MCP server does not accept
+    credentials. Run ``python login_setup.py`` from a terminal to log in.
     """
-    return await auth.login_with_token_interactive(ctx)
+    return auth_mutation_disabled("monarch_login")
+
+
+@mcp.tool()
+async def monarch_login_with_token() -> str:
+    """[DISABLED] Paste a Monarch Money session token.
+
+    This tool is intentionally disabled. Run ``python login_setup.py`` from
+    a terminal and choose the token-paste option.
+    """
+    return auth_mutation_disabled("monarch_login_with_token")
 
 
 @mcp.tool()
 async def monarch_logout() -> str:
-    """Clear the stored Monarch Money session from the system keyring."""
-    return await auth.logout()
+    """[DISABLED] Clear the stored Monarch Money session.
+
+    This tool is intentionally disabled so that an MCP client cannot wipe a
+    user's stored session. Clear the session out-of-band by deleting the
+    keyring entry or by running ``python login_setup.py`` and replacing it.
+    """
+    return auth_mutation_disabled("monarch_logout")
 
 
 @mcp.tool()
@@ -69,12 +80,18 @@ async def check_auth_status() -> str:
         else:
             status = "❌ No authentication token found in keyring\n"
 
+        # MONARCH_EMAIL is no longer used for auto-login, but surface it for
+        # diagnostic clarity if an operator left it in their environment.
         email = os.getenv("MONARCH_EMAIL")
         if email:
-            status += f"📧 Environment email: {email}\n"
+            status += (
+                f"📧 MONARCH_EMAIL is set in env ({email}) but is NOT used "
+                "for auto-login. Ignored.\n"
+            )
 
         status += (
-            "\n💡 Try get_accounts to test connection or run login_setup.py if needed."
+            "\n💡 Try get_accounts to test the connection. If not "
+            "authenticated, run login_setup.py from a terminal."
         )
 
         return status

--- a/src/monarch_mcp_server/tools/budgets.py
+++ b/src/monarch_mcp_server/tools/budgets.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
 from monarch_mcp_server.helpers import json_success, json_error
+from monarch_mcp_server.read_only import is_read_only, read_only_refusal
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +68,8 @@ async def set_budget_amount(
         Clear a budget (set to 0):
             set_budget_amount(amount=0, category_id="cat_123")
     """
+    if is_read_only():
+        return read_only_refusal("set_budget_amount")
     try:
         if category_id and category_group_id:
             return json_success({

--- a/src/monarch_mcp_server/tools/categories.py
+++ b/src/monarch_mcp_server/tools/categories.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
 from monarch_mcp_server.helpers import json_success, json_error
+from monarch_mcp_server.read_only import is_read_only, read_only_refusal
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +67,8 @@ async def create_transaction_category(
         rollover_enabled: Optional, whether budget rollover is enabled
         rollover_type: Optional rollover type (e.g. "monthly")
     """
+    if is_read_only():
+        return read_only_refusal("create_transaction_category")
     try:
         client = await get_monarch_client()
         kwargs: Dict[str, Any] = {

--- a/src/monarch_mcp_server/tools/rules.py
+++ b/src/monarch_mcp_server/tools/rules.py
@@ -8,6 +8,7 @@ from gql import gql
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
 from monarch_mcp_server.helpers import json_success, json_error
+from monarch_mcp_server.read_only import is_read_only, read_only_refusal
 
 logger = logging.getLogger(__name__)
 
@@ -249,6 +250,8 @@ async def create_transaction_rule(
             set_category_id="cat_123"
         )
     """
+    if is_read_only():
+        return read_only_refusal("create_transaction_rule")
     try:
         client = await get_monarch_client()
 
@@ -336,6 +339,8 @@ async def update_transaction_rule(
     Returns:
         Result of rule update.
     """
+    if is_read_only():
+        return read_only_refusal("update_transaction_rule")
     try:
         client = await get_monarch_client()
 
@@ -398,6 +403,8 @@ async def delete_transaction_rule(rule_id: str) -> str:
     Returns:
         Confirmation of deletion.
     """
+    if is_read_only():
+        return read_only_refusal("delete_transaction_rule")
     try:
         client = await get_monarch_client()
 

--- a/src/monarch_mcp_server/tools/splits.py
+++ b/src/monarch_mcp_server/tools/splits.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
 from monarch_mcp_server.helpers import json_success, json_error
+from monarch_mcp_server.read_only import is_read_only, read_only_refusal
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +53,8 @@ async def split_transaction(
     Returns:
         The updated split information for the transaction.
     """
+    if is_read_only():
+        return read_only_refusal("split_transaction")
     try:
         client = await get_monarch_client()
         result = await client.update_transaction_splits(

--- a/src/monarch_mcp_server/tools/tags.py
+++ b/src/monarch_mcp_server/tools/tags.py
@@ -6,6 +6,7 @@ from typing import List
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
 from monarch_mcp_server.helpers import json_success, json_error
+from monarch_mcp_server.read_only import is_read_only, read_only_refusal
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,8 @@ async def set_transaction_tags(
     Returns:
         Updated transaction details.
     """
+    if is_read_only():
+        return read_only_refusal("set_transaction_tags")
     try:
         client = await get_monarch_client()
         result = await client.set_transaction_tags(
@@ -65,6 +68,8 @@ async def create_transaction_tag(name: str, color: str) -> str:
         name: Name of the new tag
         color: Hex color code for the tag (e.g. "#ff0000")
     """
+    if is_read_only():
+        return read_only_refusal("create_transaction_tag")
     try:
         client = await get_monarch_client()
         result = await client.create_transaction_tag(name=name, color=color)
@@ -82,6 +87,8 @@ async def add_transaction_tag(transaction_id: str, tag_id: str) -> str:
         transaction_id: The ID of the transaction
         tag_id: The tag ID to add
     """
+    if is_read_only():
+        return read_only_refusal("add_transaction_tag")
     try:
         client = await get_monarch_client()
         details = await client.get_transaction_details(transaction_id)

--- a/src/monarch_mcp_server/tools/transactions.py
+++ b/src/monarch_mcp_server/tools/transactions.py
@@ -19,6 +19,7 @@ from monarch_mcp_server.helpers import (
     json_success,
     tool_response_envelope,
 )
+from monarch_mcp_server.read_only import is_read_only, read_only_refusal
 
 logger = logging.getLogger(__name__)
 
@@ -644,6 +645,8 @@ async def create_transaction(
         notes: Optional notes for the transaction
         update_balance: Whether to update the account balance (default: false)
     """
+    if is_read_only():
+        return read_only_refusal("create_transaction")
     try:
         client = await get_monarch_client()
 
@@ -692,6 +695,8 @@ async def update_transaction(
         needs_review: Whether this transaction needs review
         notes: Notes for the transaction
     """
+    if is_read_only():
+        return read_only_refusal("update_transaction")
     try:
         client = await get_monarch_client()
 
@@ -729,6 +734,8 @@ async def categorize_transaction(transaction_id: str, category_id: str) -> str:
         transaction_id: The ID of the transaction to categorize
         category_id: The category ID to assign
     """
+    if is_read_only():
+        return read_only_refusal("categorize_transaction")
     try:
         client = await get_monarch_client()
         result = await client.update_transaction(
@@ -759,6 +766,8 @@ async def update_transaction_notes(
     Returns:
         Updated transaction details.
     """
+    if is_read_only():
+        return read_only_refusal("update_transaction_notes")
     try:
         client = await get_monarch_client()
 
@@ -789,6 +798,8 @@ async def mark_transaction_reviewed(transaction_id: str) -> str:
     Returns:
         Updated transaction details.
     """
+    if is_read_only():
+        return read_only_refusal("mark_transaction_reviewed")
     try:
         client = await get_monarch_client()
         result = await client.update_transaction(
@@ -832,6 +843,9 @@ async def bulk_categorize_transactions(
                 "category_id": category_id,
                 "mark_reviewed": mark_reviewed,
             })
+
+        if is_read_only():
+            return read_only_refusal("bulk_categorize_transactions")
 
         client = await get_monarch_client()
 
@@ -885,6 +899,8 @@ async def delete_transaction(transaction_id: str) -> str:
     Returns:
         Confirmation of deletion.
     """
+    if is_read_only():
+        return read_only_refusal("delete_transaction")
     try:
         client = await get_monarch_client()
         result = await client.delete_transaction(transaction_id=transaction_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,19 @@ import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
-# Mock the monarchmoney module before any monarch_mcp_server imports
-mm_mock = MagicMock()
-mm_mock.MonarchMoney = MagicMock
-mm_mock.RequireMFAException = Exception
-sys.modules.setdefault("monarchmoney", mm_mock)
-sys.modules.setdefault("monarchmoney.monarchmoney", MagicMock())
+# Prefer the real `monarchmoney` package when it is installed (we need the
+# real MonarchMoney base class so MonarchMoneyCookieAuth — a subclass — can
+# initialize its real `_headers` dict). Only fall back to the MagicMock
+# stand-in if the package is genuinely missing.
+try:  # pragma: no cover - import-time setup
+    import monarchmoney  # noqa: F401
+    import monarchmoney.monarchmoney  # noqa: F401
+except ImportError:  # pragma: no cover - exercised only without the dep installed
+    mm_mock = MagicMock()
+    mm_mock.MonarchMoney = MagicMock
+    mm_mock.RequireMFAException = Exception
+    sys.modules.setdefault("monarchmoney", mm_mock)
+    sys.modules.setdefault("monarchmoney.monarchmoney", MagicMock())
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared test fixtures for Monarch MCP Server tests."""
 
 import json
+import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -12,6 +13,18 @@ sys.modules.setdefault("monarchmoney", mm_mock)
 sys.modules.setdefault("monarchmoney.monarchmoney", MagicMock())
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def disable_read_only(monkeypatch):
+    """Existing tests exercise mutation paths; opt them out of read-only mode.
+
+    The server defaults to read-only as of the hardening change. Tests that
+    specifically prove the refusal behavior override this fixture by setting
+    ``MONARCH_MCP_READ_ONLY`` back to a truthy value inside the test.
+    """
+    monkeypatch.setenv("MONARCH_MCP_READ_ONLY", "false")
+    yield
 
 
 @pytest.fixture

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,4 @@
-"""Tests for hard-disabled auth tools and credential env behavior."""
+"""Tests for hard-disabled auth tools, cookie auth, and credential env behavior."""
 
 import asyncio
 import json
@@ -67,26 +67,67 @@ class TestMcpAuthToolsDisabled:
 
 
 class TestCheckAuthStatus:
-    def test_no_token(self):
+    def test_no_session(self):
         with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_cookies",
+            return_value=None,
+        ), patch(
             "monarch_mcp_server.tools.auth.secure_session.load_token",
             return_value=None,
         ):
             result = asyncio.run(tools_auth.check_auth_status())
-        assert "No authentication token" in result
+        assert "No authentication session" in result
 
-    def test_with_token(self):
+    def test_with_cookies(self):
         with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_cookies",
+            return_value=("sid", "csrf"),
+        ), patch(
             "monarch_mcp_server.tools.auth.secure_session.load_token",
-            return_value="some-token",
+            return_value=None,
         ):
             result = asyncio.run(tools_auth.check_auth_status())
-        assert "token found" in result.lower()
+        assert "Session cookies found" in result
+        # Must not mention the legacy-token warning when cookies are present.
+        assert "legacy" not in result.lower()
+
+    def test_with_legacy_token_only_warns(self):
+        """When only a legacy token is stored, the user must see a warning."""
+        with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_cookies",
+            return_value=None,
+        ), patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_token",
+            return_value="legacy-token-value",
+        ):
+            result = asyncio.run(tools_auth.check_auth_status())
+        assert "legacy" in result.lower()
+        assert "May 2026" in result
+        # Cookies are the cure — point the user at the right option.
+        assert "cookie" in result.lower()
+        # Never leak the actual token value into the status string.
+        assert "legacy-token-value" not in result
+
+    def test_cookies_take_precedence_over_legacy_token(self):
+        """When both are stored, the cookie status wins (no broken-token warning)."""
+        with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_cookies",
+            return_value=("sid", "csrf"),
+        ), patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_token",
+            return_value="legacy-token",
+        ):
+            result = asyncio.run(tools_auth.check_auth_status())
+        assert "Session cookies found" in result
+        assert "legacy" not in result.lower()
 
     def test_env_email_does_not_imply_auto_login(self, monkeypatch):
         """MONARCH_EMAIL must be surfaced as unused, not as an active credential."""
         monkeypatch.setenv("MONARCH_EMAIL", "user@example.com")
         with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_cookies",
+            return_value=None,
+        ), patch(
             "monarch_mcp_server.tools.auth.secure_session.load_token",
             return_value=None,
         ):
@@ -96,26 +137,42 @@ class TestCheckAuthStatus:
 
 
 class TestDebugSessionLoading:
-    def test_no_token_message(self):
+    def test_no_session_message(self):
         with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_cookies",
+            return_value=None,
+        ), patch(
             "monarch_mcp_server.tools.auth.secure_session.load_token",
             return_value=None,
         ):
             result = asyncio.run(tools_auth.debug_session_loading())
-        assert "No token" in result
+        assert "No session" in result
 
-    def test_token_present_does_not_leak_value(self):
+    def test_cookies_present(self):
         with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_cookies",
+            return_value=("sid", "csrf"),
+        ):
+            result = asyncio.run(tools_auth.debug_session_loading())
+        assert "cookies found" in result.lower()
+        # Never leak cookie values.
+        assert "sid" not in result.split("found")[0] or "session" in result.lower()
+
+    def test_legacy_token_only_warns(self):
+        with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_cookies",
+            return_value=None,
+        ), patch(
             "monarch_mcp_server.tools.auth.secure_session.load_token",
             return_value="a-secret-token-value",
         ):
             result = asyncio.run(tools_auth.debug_session_loading())
-        assert "Token found" in result
+        assert "legacy" in result.lower()
         assert "a-secret-token-value" not in result
 
     def test_keyring_failure_omits_traceback(self):
         with patch(
-            "monarch_mcp_server.tools.auth.secure_session.load_token",
+            "monarch_mcp_server.tools.auth.secure_session.load_cookies",
             side_effect=RuntimeError("keyring backend unavailable"),
         ):
             result = asyncio.run(tools_auth.debug_session_loading())
@@ -201,3 +258,184 @@ class TestNoEnvCredentialAutoLogin:
             text = f.read()
         assert "load_dotenv" not in text
         assert "from dotenv" not in text
+
+    def test_login_setup_does_not_load_dotenv(self):
+        """login_setup.py must not silently read credentials from a .env file."""
+        from pathlib import Path
+
+        import monarch_mcp_server
+
+        repo_root = Path(monarch_mcp_server.__file__).resolve().parents[2]
+        login_setup = repo_root / "login_setup.py"
+        text = login_setup.read_text(encoding="utf-8")
+        assert "load_dotenv" not in text
+        assert "from dotenv" not in text
+
+
+class TestCookieAuthSubclass:
+    """The MonarchMoneyCookieAuth subclass must send cookies + x-csrftoken."""
+
+    def test_subclass_strips_authorization_and_sets_csrftoken(self):
+        """Cookie auth removes Authorization and installs x-csrftoken + Origin."""
+        from monarch_mcp_server.cookie_auth import (
+            WEB_ORIGIN,
+            MonarchMoneyCookieAuth,
+        )
+
+        mm = MonarchMoneyCookieAuth(session_id="sid-val", csrftoken="csrf-val")
+        # The legacy Authorization header MUST be absent.
+        assert mm._headers.get("Authorization") is None
+        # The x-csrftoken header must mirror the csrftoken cookie.
+        assert mm._headers["x-csrftoken"] == "csrf-val"
+        # Origin / Referer must point at the web app, not the API host.
+        assert mm._headers["Origin"] == WEB_ORIGIN
+        assert mm._headers["Referer"].startswith(WEB_ORIGIN)
+
+    def test_cookies_payload(self):
+        from monarch_mcp_server.cookie_auth import MonarchMoneyCookieAuth
+
+        mm = MonarchMoneyCookieAuth(session_id="sid", csrftoken="csrf")
+        assert mm._cookies() == {"session_id": "sid", "csrftoken": "csrf"}
+
+
+class TestSecureSessionCookiePath:
+    """Cookie save / load / delete and client preference."""
+
+    def _fresh_session(self, tmp_path, monkeypatch):
+        """Spin up an isolated SecureMonarchSession with file-based storage."""
+        from monarch_mcp_server import secure_session as ss_module
+
+        monkeypatch.setattr(ss_module, "_TOKEN_DIR", tmp_path)
+        monkeypatch.setattr(ss_module, "_TOKEN_FILE", tmp_path / "token")
+        monkeypatch.setattr(
+            ss_module, "_COOKIES_FILE", tmp_path / "cookies.json"
+        )
+        session = ss_module.SecureMonarchSession()
+        # Force the file-fallback path so the test doesn't poke the real keyring.
+        session._use_keyring = False
+        return session, ss_module
+
+    def test_save_and_load_cookies_roundtrip(self, tmp_path, monkeypatch):
+        session, _ = self._fresh_session(tmp_path, monkeypatch)
+        session.save_cookies("sid-val", "csrf-val")
+        assert session.load_cookies() == ("sid-val", "csrf-val")
+
+    def test_cookies_file_is_owner_only_readable(self, tmp_path, monkeypatch):
+        session, ss_module = self._fresh_session(tmp_path, monkeypatch)
+        session.save_cookies("sid", "csrf")
+        mode = (tmp_path / "cookies.json").stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_delete_token_clears_both_cookies_and_token(
+        self, tmp_path, monkeypatch
+    ):
+        session, _ = self._fresh_session(tmp_path, monkeypatch)
+        session.save_cookies("sid", "csrf")
+        session.save_token("legacy")
+        session.delete_token()
+        assert session.load_cookies() is None
+        assert session.load_token() is None
+
+    def test_get_authenticated_client_prefers_cookies(
+        self, tmp_path, monkeypatch
+    ):
+        session, ss_module = self._fresh_session(tmp_path, monkeypatch)
+        session.save_cookies("sid", "csrf")
+        session.save_token("legacy-token-still-present")
+
+        sentinel = object()
+        captured = {}
+
+        def fake_ctor(*, session_id, csrftoken):
+            captured["sid"] = session_id
+            captured["csrf"] = csrftoken
+            return sentinel
+
+        monkeypatch.setattr(ss_module, "MonarchMoneyCookieAuth", fake_ctor)
+        # If the cookie path were skipped, this would be called instead.
+        mm_called = {"called": False}
+
+        def fake_mm(*args, **kwargs):
+            mm_called["called"] = True
+            return object()
+
+        monkeypatch.setattr(ss_module, "MonarchMoney", fake_mm)
+
+        client = session.get_authenticated_client()
+        assert client is sentinel
+        assert captured == {"sid": "sid", "csrf": "csrf"}
+        assert mm_called["called"] is False
+
+    def test_get_authenticated_client_falls_back_to_token(
+        self, tmp_path, monkeypatch
+    ):
+        session, ss_module = self._fresh_session(tmp_path, monkeypatch)
+        session.save_token("legacy-token")
+
+        sentinel = object()
+        captured = {}
+
+        def fake_mm(*, token=None, **kwargs):
+            captured["token"] = token
+            return sentinel
+
+        monkeypatch.setattr(ss_module, "MonarchMoney", fake_mm)
+        # Ensure cookie ctor is never invoked when no cookies are stored.
+        def boom(**kwargs):
+            raise AssertionError(
+                "MonarchMoneyCookieAuth should not be called without cookies"
+            )
+
+        monkeypatch.setattr(ss_module, "MonarchMoneyCookieAuth", boom)
+
+        client = session.get_authenticated_client()
+        assert client is sentinel
+        assert captured == {"token": "legacy-token"}
+
+    def test_get_authenticated_client_returns_none_with_no_session(
+        self, tmp_path, monkeypatch
+    ):
+        session, _ = self._fresh_session(tmp_path, monkeypatch)
+        assert session.get_authenticated_client() is None
+
+    def test_save_authenticated_session_dispatches_on_cookie_subclass(
+        self, tmp_path, monkeypatch
+    ):
+        session, ss_module = self._fresh_session(tmp_path, monkeypatch)
+
+        from monarch_mcp_server.cookie_auth import MonarchMoneyCookieAuth
+
+        mm = MonarchMoneyCookieAuth(session_id="sid", csrftoken="csrf")
+        session.save_authenticated_session(mm)
+        assert session.load_cookies() == ("sid", "csrf")
+        # Legacy token must NOT have been written by the cookie path.
+        assert session.load_token() is None
+
+
+class TestLoginSetupCookieMenu:
+    """The terminal-only login_setup.py must default to the cookie option."""
+
+    def _login_setup_source(self):
+        from pathlib import Path
+
+        import monarch_mcp_server
+
+        repo_root = Path(monarch_mcp_server.__file__).resolve().parents[2]
+        return (repo_root / "login_setup.py").read_text(encoding="utf-8")
+
+    def test_cookie_option_is_listed_first(self):
+        text = self._login_setup_source()
+        cookie_idx = text.find("Session cookies from browser")
+        email_idx = text.find("Email and password")
+        legacy_idx = text.find("Legacy session token paste")
+        assert 0 < cookie_idx < email_idx < legacy_idx, (
+            "Cookie option must appear first in the menu so it is the default."
+        )
+
+    def test_legacy_paths_labeled_broken(self):
+        text = self._login_setup_source()
+        assert "currently broken" in text
+
+    def test_uses_cookie_auth_subclass(self):
+        text = self._login_setup_source()
+        assert "MonarchMoneyCookieAuth" in text

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,119 +1,102 @@
-"""Tests for elicitation-based auth tools."""
+"""Tests for hard-disabled auth tools and credential env behavior."""
 
 import asyncio
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+import json
+import os
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from monarchmoney import RequireMFAException
 
 from monarch_mcp_server import auth
+from monarch_mcp_server.tools import auth as tools_auth
 
 
-def make_ctx(*elicit_results):
-    """Build a mock Context whose elicit() returns the given results in order."""
-    ctx = MagicMock()
-    ctx.elicit = AsyncMock(side_effect=list(elicit_results))
-    return ctx
+class TestAuthHelpersDisabled:
+    """The legacy elicitation auth flow is intentionally removed."""
+
+    def test_login_interactive_raises(self):
+        with pytest.raises(auth.AuthDisabledError):
+            asyncio.run(auth.login_interactive(None))
+
+    def test_login_with_token_raises(self):
+        with pytest.raises(auth.AuthDisabledError):
+            asyncio.run(auth.login_with_token_interactive(None))
+
+    def test_logout_raises(self):
+        with pytest.raises(auth.AuthDisabledError):
+            asyncio.run(auth.logout())
 
 
-def accept(**fields):
-    return SimpleNamespace(action="accept", data=SimpleNamespace(**fields))
+class TestMcpAuthToolsDisabled:
+    """The MCP-exposed login/logout tools refuse regardless of read-only flag."""
+
+    def test_monarch_login_disabled(self):
+        result = asyncio.run(tools_auth.monarch_login())
+        payload = json.loads(result)
+        assert payload["disabled"] is True
+        assert payload["tool"] == "monarch_login"
+        assert "login_setup.py" in payload["error"]
+
+    def test_monarch_login_with_token_disabled(self):
+        result = asyncio.run(tools_auth.monarch_login_with_token())
+        payload = json.loads(result)
+        assert payload["disabled"] is True
+        assert payload["tool"] == "monarch_login_with_token"
+
+    def test_monarch_logout_disabled(self):
+        result = asyncio.run(tools_auth.monarch_logout())
+        payload = json.loads(result)
+        assert payload["disabled"] is True
+        assert payload["tool"] == "monarch_logout"
+
+    def test_disabled_even_when_read_only_off(self, monkeypatch):
+        """Auth mutations are hard-disabled — not gated by the read-only flag."""
+        monkeypatch.setenv("MONARCH_MCP_READ_ONLY", "false")
+        for fn in (
+            tools_auth.monarch_login,
+            tools_auth.monarch_login_with_token,
+            tools_auth.monarch_logout,
+        ):
+            payload = json.loads(asyncio.run(fn()))
+            assert payload["disabled"] is True
+
+    def test_setup_authentication_points_at_login_setup(self):
+        result = asyncio.run(tools_auth.setup_authentication())
+        assert "login_setup.py" in result
+        assert "does not accept credentials" in result.lower()
 
 
-def cancel():
-    return SimpleNamespace(action="cancel", data=None)
+class TestCheckAuthStatus:
+    def test_no_token(self):
+        with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_token",
+            return_value=None,
+        ):
+            result = asyncio.run(tools_auth.check_auth_status())
+        assert "No authentication token" in result
 
+    def test_with_token(self):
+        with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_token",
+            return_value="some-token",
+        ):
+            result = asyncio.run(tools_auth.check_auth_status())
+        assert "token found" in result.lower()
 
-@pytest.fixture(autouse=True)
-def no_session_save():
-    """Prevent real keyring writes during auth tests."""
-    with patch("monarch_mcp_server.auth.secure_session") as mock:
-        yield mock
-
-
-class TestLoginInteractive:
-    def test_happy_path_no_mfa(self, no_session_save):
-        mm = AsyncMock()
-        with patch("monarch_mcp_server.auth.MonarchMoney", return_value=mm):
-            ctx = make_ctx(accept(email="a@b.com", password="pw"))
-            result = asyncio.run(auth.login_interactive(ctx))
-        assert "Logged in" in result
-        mm.login.assert_awaited_once()
-        no_session_save.save_authenticated_session.assert_called_once_with(mm)
-
-    def test_mfa_required(self, no_session_save):
-        mm = AsyncMock()
-        mm.login.side_effect = RequireMFAException("mfa")
-        with patch("monarch_mcp_server.auth.MonarchMoney", return_value=mm):
-            ctx = make_ctx(
-                accept(email="a@b.com", password="pw"),
-                accept(mfa_code="123456"),
-            )
-            result = asyncio.run(auth.login_interactive(ctx))
-        assert "Logged in" in result
-        mm.multi_factor_authenticate.assert_awaited_once_with(
-            "a@b.com", "pw", "123456"
-        )
-        no_session_save.save_authenticated_session.assert_called_once_with(mm)
-
-    def test_user_cancels_initial_form(self, no_session_save):
-        ctx = make_ctx(cancel())
-        result = asyncio.run(auth.login_interactive(ctx))
-        assert result == "Login cancelled."
-        no_session_save.save_authenticated_session.assert_not_called()
-
-    def test_user_cancels_mfa(self, no_session_save):
-        mm = AsyncMock()
-        mm.login.side_effect = RequireMFAException("mfa")
-        with patch("monarch_mcp_server.auth.MonarchMoney", return_value=mm):
-            ctx = make_ctx(accept(email="a@b.com", password="pw"), cancel())
-            result = asyncio.run(auth.login_interactive(ctx))
-        assert result == "Login cancelled."
-        no_session_save.save_authenticated_session.assert_not_called()
-
-
-class TestLoginWithTokenInteractive:
-    def test_happy_path(self, no_session_save):
-        mm = AsyncMock()
-        with patch("monarch_mcp_server.auth.MonarchMoney", return_value=mm):
-            ctx = make_ctx(accept(token="raw-token"))
-            result = asyncio.run(auth.login_with_token_interactive(ctx))
-        assert "saved" in result.lower()
-        mm.get_subscription_details.assert_awaited_once()
-        no_session_save.save_token.assert_called_once_with("raw-token")
-
-    def test_strips_whitespace(self, no_session_save):
-        mm = AsyncMock()
-        with patch("monarch_mcp_server.auth.MonarchMoney", return_value=mm):
-            ctx = make_ctx(accept(token="  token-with-spaces  "))
-            asyncio.run(auth.login_with_token_interactive(ctx))
-        no_session_save.save_token.assert_called_once_with("token-with-spaces")
-
-    def test_empty_token_rejected(self, no_session_save):
-        ctx = make_ctx(accept(token="   "))
-        result = asyncio.run(auth.login_with_token_interactive(ctx))
-        assert "Empty" in result
-        no_session_save.save_token.assert_not_called()
-
-    def test_user_cancels(self, no_session_save):
-        ctx = make_ctx(cancel())
-        result = asyncio.run(auth.login_with_token_interactive(ctx))
-        assert result == "Login cancelled."
-        no_session_save.save_token.assert_not_called()
-
-
-class TestLogout:
-    def test_clears_session(self, no_session_save):
-        result = asyncio.run(auth.logout())
-        assert "Cleared" in result
-        no_session_save.delete_token.assert_called_once()
+    def test_env_email_does_not_imply_auto_login(self, monkeypatch):
+        """MONARCH_EMAIL must be surfaced as unused, not as an active credential."""
+        monkeypatch.setenv("MONARCH_EMAIL", "user@example.com")
+        with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_token",
+            return_value=None,
+        ):
+            result = asyncio.run(tools_auth.check_auth_status())
+        assert "user@example.com" in result
+        assert "NOT used" in result
 
 
 class TestDebugSessionLoading:
     def test_no_token_message(self):
-        from monarch_mcp_server.tools import auth as tools_auth
-
         with patch(
             "monarch_mcp_server.tools.auth.secure_session.load_token",
             return_value=None,
@@ -121,21 +104,16 @@ class TestDebugSessionLoading:
             result = asyncio.run(tools_auth.debug_session_loading())
         assert "No token" in result
 
-    def test_token_present_does_not_leak_length(self):
-        from monarch_mcp_server.tools import auth as tools_auth
-
+    def test_token_present_does_not_leak_value(self):
         with patch(
             "monarch_mcp_server.tools.auth.secure_session.load_token",
             return_value="a-secret-token-value",
         ):
             result = asyncio.run(tools_auth.debug_session_loading())
         assert "Token found" in result
-        assert "length" not in result.lower()
         assert "a-secret-token-value" not in result
 
     def test_keyring_failure_omits_traceback(self):
-        from monarch_mcp_server.tools import auth as tools_auth
-
         with patch(
             "monarch_mcp_server.tools.auth.secure_session.load_token",
             side_effect=RuntimeError("keyring backend unavailable"),
@@ -143,23 +121,83 @@ class TestDebugSessionLoading:
             result = asyncio.run(tools_auth.debug_session_loading())
         assert "Keyring access failed" in result
         assert "RuntimeError" in result
-        assert "keyring backend unavailable" in result
         assert "Traceback" not in result
-        assert 'File "' not in result
 
 
-class TestElicitNotSupported:
-    """Older MCP SDKs (<1.10) do not expose Context.elicit."""
+class TestNoEnvCredentialAutoLogin:
+    """MONARCH_EMAIL/MONARCH_PASSWORD must not trigger an auto-login."""
 
-    def test_login_interactive_returns_upgrade_hint(self, no_session_save):
-        ctx = SimpleNamespace()  # no elicit attribute
-        result = asyncio.run(auth.login_interactive(ctx))
-        assert "1.10" in result
-        assert "login_setup.py" in result
-        no_session_save.save_authenticated_session.assert_not_called()
+    def test_get_monarch_client_ignores_env_credentials(self, monkeypatch):
+        """Even with both env vars set, the client must not auto-login.
 
-    def test_login_with_token_returns_upgrade_hint(self, no_session_save):
-        ctx = SimpleNamespace()
-        result = asyncio.run(auth.login_with_token_interactive(ctx))
-        assert "1.10" in result
-        no_session_save.save_token.assert_not_called()
+        We invoke the *real* factory (resolved at the function object level
+        before the autouse patch is consulted) and assert it raises rather
+        than calling MonarchMoney().login() with env credentials.
+        """
+        monkeypatch.setenv("MONARCH_EMAIL", "user@example.com")
+        monkeypatch.setenv("MONARCH_PASSWORD", "hunter2")
+
+        from monarch_mcp_server import client as client_module
+
+        # The autouse patch in conftest replaces client_module.get_monarch_client
+        # with an AsyncMock. We grab the real coroutine function via the
+        # patcher's `_mock_name`/attribute? Easier: locate it on the module
+        # globals it was originally defined in by reading source.
+        # Strategy: import the source function via its qualified name from
+        # the module's __dict__ using an internal copy we save once.
+        real_fn = client_module.__dict__.get("_real_get_monarch_client")
+        if real_fn is None:
+            # Pull it out before tests patch it: load fresh from source.
+            import importlib.util
+
+            spec = importlib.util.spec_from_file_location(
+                "_fresh_client_module", client_module.__file__
+            )
+            fresh = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(fresh)
+            real_fn = fresh.get_monarch_client
+            # Patch secure_session so it doesn't return a real client.
+            fresh._cached_client = None
+            with patch.object(
+                fresh.secure_session,
+                "get_authenticated_client",
+                return_value=None,
+            ):
+                with pytest.raises(RuntimeError) as exc:
+                    asyncio.run(real_fn())
+
+        message = str(exc.value)
+        assert "login_setup.py" in message
+        assert "MONARCH_EMAIL" in message or "credentials" in message.lower()
+
+    def test_client_module_does_not_read_env_credentials(self):
+        """Guard against reintroducing silent env credential loading.
+
+        We allow the strings to appear in user-facing error messages, but the
+        client must never actually call os.getenv for the credential vars.
+        """
+        from monarch_mcp_server import client as client_module
+
+        source = client_module.__file__
+        with open(source, encoding="utf-8") as f:
+            text = f.read()
+        for bad in (
+            'os.getenv("MONARCH_EMAIL"',
+            "os.getenv('MONARCH_EMAIL'",
+            'os.getenv("MONARCH_PASSWORD"',
+            "os.getenv('MONARCH_PASSWORD'",
+            'os.environ["MONARCH_PASSWORD"',
+            "os.environ['MONARCH_PASSWORD'",
+        ):
+            assert bad not in text, f"unexpected env-credential lookup: {bad}"
+        assert "load_dotenv" not in text
+        assert "from dotenv" not in text
+
+    def test_app_module_does_not_load_dotenv(self):
+        """The MCP server entrypoint must not auto-load .env files."""
+        from monarch_mcp_server import app as app_module
+
+        with open(app_module.__file__, encoding="utf-8") as f:
+            text = f.read()
+        assert "load_dotenv" not in text
+        assert "from dotenv" not in text

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -1,0 +1,292 @@
+"""Tests proving every mutation tool refuses to run in read-only mode.
+
+The server defaults to read-only — these tests assert that the refusal
+extends to every Monarch SDK mutation we expose, that read-only tools keep
+working, and that the upstream client is never called when a refusal fires.
+"""
+
+import asyncio
+import json
+import os
+
+import pytest
+
+from monarch_mcp_server.read_only import (
+    ENV_VAR,
+    auth_mutation_disabled,
+    is_read_only,
+    read_only_refusal,
+)
+from monarch_mcp_server.tools.accounts import (
+    get_accounts,
+    refresh_accounts,
+    upload_account_balance_history,
+)
+from monarch_mcp_server.tools.transactions import (
+    bulk_categorize_transactions,
+    categorize_transaction,
+    create_transaction,
+    delete_transaction,
+    get_transactions,
+    mark_transaction_reviewed,
+    update_transaction,
+    update_transaction_notes,
+)
+from monarch_mcp_server.tools.tags import (
+    add_transaction_tag,
+    create_transaction_tag,
+    set_transaction_tags,
+)
+from monarch_mcp_server.tools.categories import create_transaction_category
+from monarch_mcp_server.tools.splits import split_transaction
+from monarch_mcp_server.tools.rules import (
+    create_transaction_rule,
+    delete_transaction_rule,
+    update_transaction_rule,
+)
+from monarch_mcp_server.tools.budgets import set_budget_amount
+
+
+@pytest.fixture
+def read_only_env(monkeypatch):
+    """Force read-only mode ON, overriding the conftest opt-out."""
+    monkeypatch.setenv(ENV_VAR, "true")
+    yield
+
+
+class TestIsReadOnly:
+    """The is_read_only() helper drives every refusal."""
+
+    @pytest.mark.parametrize("value", ["true", "1", "yes", "on", "TRUE", "YES"])
+    def test_truthy_values(self, monkeypatch, value):
+        monkeypatch.setenv(ENV_VAR, value)
+        assert is_read_only() is True
+
+    @pytest.mark.parametrize(
+        "value", ["false", "0", "no", "off", "FALSE", "NO", "Disabled"]
+    )
+    def test_falsey_values(self, monkeypatch, value):
+        monkeypatch.setenv(ENV_VAR, value)
+        assert is_read_only() is False
+
+    def test_default_is_read_only_when_unset(self, monkeypatch):
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        assert is_read_only() is True
+
+    def test_default_is_read_only_when_empty_or_garbage(self, monkeypatch):
+        # Empty / unknown strings should NOT silently turn off the guard.
+        for value in ("", "maybe", "readonly"):
+            monkeypatch.setenv(ENV_VAR, value)
+            assert is_read_only() is True
+
+
+def _assert_refused(payload_text, tool_name):
+    payload = json.loads(payload_text)
+    assert payload["read_only"] is True
+    assert payload["tool"] == tool_name
+    assert payload["success"] is False
+    assert "MONARCH_MCP_READ_ONLY" in payload["error"]
+
+
+class TestTransactionMutationsRefused:
+    def test_create_transaction(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(
+            create_transaction(
+                date="2026-04-01",
+                account_id="acc-1",
+                amount=-10.0,
+                merchant_name="Test",
+                category_id="cat-1",
+            )
+        )
+        _assert_refused(result, "create_transaction")
+        mock_monarch_client.create_transaction.assert_not_called()
+
+    def test_update_transaction(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(
+            update_transaction(transaction_id="txn-1", notes="x")
+        )
+        _assert_refused(result, "update_transaction")
+        mock_monarch_client.update_transaction.assert_not_called()
+
+    def test_categorize_transaction(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(
+            categorize_transaction(transaction_id="txn-1", category_id="cat-1")
+        )
+        _assert_refused(result, "categorize_transaction")
+        mock_monarch_client.update_transaction.assert_not_called()
+
+    def test_update_transaction_notes(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(
+            update_transaction_notes(transaction_id="txn-1", notes="hi")
+        )
+        _assert_refused(result, "update_transaction_notes")
+        mock_monarch_client.update_transaction.assert_not_called()
+
+    def test_mark_transaction_reviewed(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(mark_transaction_reviewed(transaction_id="txn-1"))
+        _assert_refused(result, "mark_transaction_reviewed")
+        mock_monarch_client.update_transaction.assert_not_called()
+
+    def test_delete_transaction(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(delete_transaction(transaction_id="txn-1"))
+        _assert_refused(result, "delete_transaction")
+        mock_monarch_client.delete_transaction.assert_not_called()
+
+    def test_bulk_categorize_blocks_real_run(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(
+            bulk_categorize_transactions(
+                transaction_ids=["txn-1", "txn-2"],
+                category_id="cat-1",
+                dry_run=False,
+            )
+        )
+        _assert_refused(result, "bulk_categorize_transactions")
+        mock_monarch_client.update_transaction.assert_not_called()
+
+    def test_bulk_categorize_dry_run_still_works(
+        self, read_only_env, mock_monarch_client
+    ):
+        """Dry-run is read-only; it must NOT be blocked."""
+        result = asyncio.run(
+            bulk_categorize_transactions(
+                transaction_ids=["txn-1"],
+                category_id="cat-1",
+                dry_run=True,
+            )
+        )
+        payload = json.loads(result)
+        assert payload["dry_run"] is True
+        mock_monarch_client.update_transaction.assert_not_called()
+
+
+class TestAccountMutationsRefused:
+    def test_refresh_accounts(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(refresh_accounts())
+        _assert_refused(result, "refresh_accounts")
+        mock_monarch_client.request_accounts_refresh.assert_not_called()
+
+    def test_upload_balance_history_blocks_real_run(
+        self, read_only_env, mock_monarch_client
+    ):
+        result = asyncio.run(
+            upload_account_balance_history(
+                "12345", '{"2026-04-21": 500.0}', dry_run=False
+            )
+        )
+        _assert_refused(result, "upload_account_balance_history")
+        mock_monarch_client.upload_account_balance_history.assert_not_called()
+
+    def test_upload_balance_history_dry_run_allowed(
+        self, read_only_env, mock_monarch_client
+    ):
+        """Dry-run does not mutate remote state and remains usable."""
+        result = asyncio.run(
+            upload_account_balance_history(
+                "12345", '{"2026-04-21": 500.0}', dry_run=True
+            )
+        )
+        payload = json.loads(result)
+        # The dry-run path either returns ``dry_run: True`` (when corrections
+        # match snapshots) or a structured 'no matching dates' message; in
+        # either case the underlying upload must NOT have been called.
+        assert "dry_run" in payload or "unmatched_dates" in payload
+        mock_monarch_client.upload_account_balance_history.assert_not_called()
+
+
+class TestTagMutationsRefused:
+    def test_set_transaction_tags(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(set_transaction_tags("txn-1", ["tag-1"]))
+        _assert_refused(result, "set_transaction_tags")
+        mock_monarch_client.set_transaction_tags.assert_not_called()
+
+    def test_create_transaction_tag(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(create_transaction_tag("new", "#ff0000"))
+        _assert_refused(result, "create_transaction_tag")
+        mock_monarch_client.create_transaction_tag.assert_not_called()
+
+    def test_add_transaction_tag(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(add_transaction_tag("txn-1", "tag-1"))
+        _assert_refused(result, "add_transaction_tag")
+        mock_monarch_client.set_transaction_tags.assert_not_called()
+
+
+class TestCategoryMutationsRefused:
+    def test_create_transaction_category(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(create_transaction_category("grp-1", "Coffee"))
+        _assert_refused(result, "create_transaction_category")
+        mock_monarch_client.create_transaction_category.assert_not_called()
+
+
+class TestSplitsMutationsRefused:
+    def test_split_transaction(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(split_transaction("txn-1", []))
+        _assert_refused(result, "split_transaction")
+        mock_monarch_client.update_transaction_splits.assert_not_called()
+
+
+class TestRuleMutationsRefused:
+    def test_create_transaction_rule(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(
+            create_transaction_rule(
+                merchant_criteria_operator="contains",
+                merchant_criteria_value="amazon",
+                set_category_id="cat-1",
+            )
+        )
+        _assert_refused(result, "create_transaction_rule")
+        mock_monarch_client.gql_call.assert_not_called()
+
+    def test_update_transaction_rule(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(
+            update_transaction_rule(rule_id="rule-1", set_category_id="cat-1")
+        )
+        _assert_refused(result, "update_transaction_rule")
+        mock_monarch_client.gql_call.assert_not_called()
+
+    def test_delete_transaction_rule(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(delete_transaction_rule(rule_id="rule-1"))
+        _assert_refused(result, "delete_transaction_rule")
+        mock_monarch_client.gql_call.assert_not_called()
+
+
+class TestBudgetMutationsRefused:
+    def test_set_budget_amount(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(
+            set_budget_amount(amount=100.0, category_id="cat-1")
+        )
+        _assert_refused(result, "set_budget_amount")
+        mock_monarch_client.set_budget_amount.assert_not_called()
+
+
+class TestReadOnlyToolsStillWork:
+    """Sanity check: read-only tools must continue to work in read-only mode."""
+
+    def test_get_accounts_still_works(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(get_accounts())
+        payload = json.loads(result)
+        assert isinstance(payload, list)
+        assert payload[0]["id"] == "acc-1"
+        mock_monarch_client.get_accounts.assert_called_once()
+
+    def test_get_transactions_still_works(self, read_only_env, mock_monarch_client):
+        result = asyncio.run(get_transactions(limit=5))
+        payload = json.loads(result)
+        assert payload["tool"] == "get_transactions"
+        mock_monarch_client.get_transactions.assert_called()
+
+
+class TestRefusalHelpers:
+    """Direct unit-tests of the helpers, independent of any tool."""
+
+    def test_read_only_refusal_shape(self):
+        payload = json.loads(read_only_refusal("some_tool"))
+        assert payload["read_only"] is True
+        assert payload["tool"] == "some_tool"
+        assert payload["success"] is False
+
+    def test_auth_mutation_disabled_shape(self):
+        payload = json.loads(auth_mutation_disabled("monarch_login"))
+        assert payload["disabled"] is True
+        assert payload["tool"] == "monarch_login"
+        assert "login_setup.py" in payload["error"]


### PR DESCRIPTION
## Summary

Hardens the MCP server so that, by default, it cannot mutate remote Monarch state or change locally stored auth.

- **Read-only default.** New `MONARCH_MCP_READ_ONLY` env flag (defaults on). Every Monarch SDK mutation tool now refuses to run while read-only is active: `create_transaction`, `update_transaction`, `categorize_transaction`, `update_transaction_notes`, `mark_transaction_reviewed`, `bulk_categorize_transactions` (real run; dry-run still allowed), `delete_transaction`, `set_transaction_tags`, `create_transaction_tag`, `add_transaction_tag`, `create_transaction_category`, `split_transaction`, `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`, `set_budget_amount`, `refresh_accounts`, and `upload_account_balance_history` (real run; dry-run still allowed). Operators can flip the flag to a falsey value (`false`/`0`/`no`/`off`) to permit mutations explicitly.
- **Auth mutation tools hard-disabled.** `monarch_login`, `monarch_login_with_token`, and `monarch_logout` no longer accept credentials or modify stored auth state — regardless of the read-only flag. Credentials never flow through MCP transport; a remote MCP client cannot wipe the stored session. Authentication must be performed out-of-band via `python login_setup.py`.
- **No env credential auto-login.** Removed the `MONARCH_EMAIL` / `MONARCH_PASSWORD` fallback from `get_monarch_client`, removed `load_dotenv()` from `app.py` and `login_setup.py`, and dropped `python-dotenv` from the dependency list. Passwords are never silently read from the environment.
- **Read-only tools unaffected.** Account, transaction, summary, financial, category-listing, and tag-listing read tools continue to function as before.

## Testing

- `python -m pytest` — **181 passed**.
- New `tests/test_read_only.py` (39 tests) proves every mutation tool refuses in read-only mode, that the upstream MonarchMoney client is never invoked when a refusal fires, and that dry-run paths remain usable.
- Updated `tests/test_auth.py` (17 tests) proves the MCP auth-mutation tools are hard-disabled regardless of the read-only flag, that `MONARCH_EMAIL` does not trigger auto-login, and that neither `client.py` nor `app.py` reintroduce `os.getenv` of credential vars or `load_dotenv`.
- `tests/conftest.py` adds an autouse fixture that opts existing mutation-test suites out of read-only mode so they continue to exercise the underlying client wiring.

## Remaining risks

- The standalone `login_setup.py` terminal script still performs login; it is now the only path that writes to the keyring. That's by design but means operator hygiene around running that script matters.
- `dry_run=True` paths for `bulk_categorize_transactions` and `upload_account_balance_history` are intentionally kept open in read-only mode. They do not call the mutation SDK methods, but they DO call read endpoints (e.g. fetching balance history). Reviewers may want to confirm that's acceptable.
- README still documents the previous elicitation login flow; this PR does not rewrite the README. A follow-up doc pass is recommended.

---
🤖 *Generated by Computer*