### PR TITLE
Add category update, details, and monthly cashflow tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 - **Update Transaction Rule**: Modify existing rules
 - **Delete Transaction Rule**: Remove a rule
 
+### 🔄 Merchant & Recurring Stream Management
+- **Get Merchant**: View a merchant's details including recurring transaction stream configuration
+- **Update Merchant**: Modify a merchant's name and/or recurring stream settings (frequency, amount, base date)
+- **Review Recurring Stream**: Accept, ignore, or reset recurring transaction streams detected by Monarch
+
 ### ✂️ Transaction Splits
 - **Get Transaction Splits**: View how a transaction has been split into parts
 - **Split Transaction**: Divide a single transaction into multiple parts with different categories or merchants
@@ -267,6 +272,9 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 | `create_transaction_rule` | Create an auto-categorization rule | `merchant_criteria_operator`, `merchant_criteria_value`, `set_category_id`, `add_tag_ids`, `amount_operator`, `amount_value` |
 | `update_transaction_rule` | Update an existing rule | `rule_id`, `merchant_criteria_operator`, `merchant_criteria_value`, `set_category_id` |
 | `delete_transaction_rule` | Delete a rule | `rule_id` |
+| `get_merchant` | Get merchant details with recurring stream | `merchant_id` |
+| `update_merchant` | Update merchant name/recurring stream | `merchant_id`, `name`, `is_recurring`, `frequency`, `base_date`, `amount`, `is_active` |
+| `review_recurring_stream` | Set recurring stream review status | `stream_id`, `review_status` |
 | `get_transaction_splits` | Get splits for a transaction | `transaction_id` |
 | `split_transaction` | Split a transaction into parts | `transaction_id`, `splits` (JSON array) |
 | `get_transactions_summary` | Get high-level transaction statistics | None |
@@ -371,6 +379,16 @@ Give me a quick summary of my transactions using get_transactions_summary
 Show my spending breakdown by category for last month using get_spending_summary
 ```
 
+### Update a Recurring Bill Amount
+```
+Update PennyMac's recurring stream to $1,460.93 monthly using update_merchant
+```
+
+### Review Recurring Streams
+```
+Approve the Netflix recurring stream using review_recurring_stream
+```
+
 ## 📅 Date Formats
 
 - All dates should be in `YYYY-MM-DD` format (e.g., "2024-01-15")
@@ -432,7 +450,7 @@ monarch-mcp-server/
 
 ### Recommended: require approval for mutating tools
 
-Several tools mutate your Monarch ledger (`create_transaction`, `update_transaction`, `delete_transaction`, `bulk_categorize_transactions`, `upload_account_balance_history`, `set_transaction_tags`, `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`, `split_transaction`, `set_budget_amount`).
+Several tools mutate your Monarch ledger (`create_transaction`, `update_transaction`, `delete_transaction`, `bulk_categorize_transactions`, `upload_account_balance_history`, `set_transaction_tags`, `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`, `split_transaction`, `set_budget_amount`, `update_merchant`, `review_recurring_stream`).
 
 Because the LLM can be influenced by data it reads back (a malicious-looking memo or merchant name in a transaction), the safest setup is to configure your MCP client to require manual approval before any mutating tool runs. In Claude Desktop and Claude Code this is the default behavior for unknown tools; keep it that way for the tools listed above rather than allow-listing them.
 

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -74,6 +74,11 @@ from monarch_mcp_server.tools.financial import (  # noqa: F401
     get_net_worth,
     get_net_worth_by_account_type,
 )
+from monarch_mcp_server.tools.merchants import (  # noqa: F401
+    get_merchant,
+    update_merchant,
+    review_recurring_stream,
+)
 
 if __name__ == "__main__":
     main()

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -64,6 +64,9 @@ from monarch_mcp_server.tools.categories import (  # noqa: F401
     get_transaction_categories,
     get_transaction_category_groups,
     create_transaction_category,
+    update_category,
+    get_category_details,
+    get_cashflow_by_month,
 )
 from monarch_mcp_server.tools.budgets import (  # noqa: F401
     get_budgets,

--- a/src/monarch_mcp_server/tools/__init__.py
+++ b/src/monarch_mcp_server/tools/__init__.py
@@ -11,4 +11,5 @@ from monarch_mcp_server.tools import (  # noqa: F401
     categories,
     budgets,
     financial,
+    merchants,
 )

--- a/src/monarch_mcp_server/tools/categories.py
+++ b/src/monarch_mcp_server/tools/categories.py
@@ -283,7 +283,10 @@ async def update_category(
             )
     """
     try:
-        if budget_variability and budget_variability not in _VALID_BUDGET_VARIABILITY:
+        if (
+            budget_variability is not None
+            and budget_variability not in _VALID_BUDGET_VARIABILITY
+        ):
             return json_success(
                 {
                     "success": False,
@@ -294,7 +297,10 @@ async def update_category(
                 }
             )
 
-        if rollover_frequency and rollover_frequency not in _VALID_ROLLOVER_FREQUENCY:
+        if (
+            rollover_frequency is not None
+            and rollover_frequency not in _VALID_ROLLOVER_FREQUENCY
+        ):
             return json_success(
                 {
                     "success": False,
@@ -305,22 +311,31 @@ async def update_category(
                 }
             )
 
-        field_map: Dict[str, Any] = {
-            "name": name,
-            "icon": icon,
-            "group": group_id,
-            "type": category_type,
-            "excludeFromBudget": exclude_from_budget,
-            "budgetVariability": budget_variability,
-            "rolloverEnabled": rollover_enabled,
-            "rolloverStartMonth": rollover_start_month,
-            "rolloverStartingBalance": rollover_starting_balance,
-            "rolloverFrequency": rollover_frequency,
-            "rolloverTargetAmount": rollover_target_amount,
-            "rolloverType": rollover_type,
-        }
-
-        provided = {k: v for k, v in field_map.items() if v is not None}
+        provided: Dict[str, Any] = {}
+        if name is not None:
+            provided["name"] = name
+        if icon is not None:
+            provided["icon"] = icon
+        if group_id is not None:
+            provided["group"] = group_id
+        if category_type is not None:
+            provided["type"] = category_type
+        if exclude_from_budget is not None:
+            provided["excludeFromBudget"] = exclude_from_budget
+        if budget_variability is not None:
+            provided["budgetVariability"] = budget_variability
+        if rollover_enabled is not None:
+            provided["rolloverEnabled"] = rollover_enabled
+        if rollover_start_month is not None:
+            provided["rolloverStartMonth"] = rollover_start_month
+        if rollover_starting_balance is not None:
+            provided["rolloverStartingBalance"] = rollover_starting_balance
+        if rollover_frequency is not None:
+            provided["rolloverFrequency"] = rollover_frequency
+        if rollover_target_amount is not None:
+            provided["rolloverTargetAmount"] = rollover_target_amount
+        if rollover_type is not None:
+            provided["rolloverType"] = rollover_type
 
         if not provided:
             return json_success(
@@ -570,17 +585,17 @@ async def get_cashflow_by_month(
             categories_list.append(
                 {
                     "category_id": cat_id,
-                    "total_absolute": abs_total,
+                    "_sort_key": abs_total,
                     "monthly_totals": sorted(
                         monthly_totals, key=lambda m: m.get("month") or ""
                     ),
                 }
             )
 
-        categories_list.sort(key=lambda c: c["total_absolute"], reverse=True)
+        categories_list.sort(key=lambda c: c["_sort_key"], reverse=True)
 
         for cat in categories_list:
-            del cat["total_absolute"]
+            del cat["_sort_key"]
 
         return json_success(
             {

--- a/src/monarch_mcp_server/tools/categories.py
+++ b/src/monarch_mcp_server/tools/categories.py
@@ -209,6 +209,10 @@ query GetAggregatesGraph($startDate: Date, $endDate: Date) {
 # ---------------------------------------------------------------------------
 
 
+_VALID_BUDGET_VARIABILITY = {"fixed", "flexible", "non_monthly"}
+_VALID_ROLLOVER_FREQUENCY = {"monthly", "variable"}
+
+
 @mcp.tool()
 async def update_category(
     category_id: str,
@@ -224,6 +228,7 @@ async def update_category(
     rollover_frequency: Optional[str] = None,
     rollover_target_amount: Optional[float] = None,
     rollover_type: Optional[str] = None,
+    dry_run: bool = False,
 ) -> str:
     """
     Update an existing category's settings.
@@ -251,10 +256,13 @@ async def update_category(
             "variable".
         rollover_target_amount: Target amount for rollover savings goal.
         rollover_type: Rollover type. Values: "monthly".
+        dry_run: If True, return the planned changes without executing the
+            mutation. Shows current vs proposed values.
 
     Returns:
         Updated category details including budget variability and rollover
-        configuration.
+        configuration. In dry_run mode, returns current state and proposed
+        changes without applying them.
 
     Example:
         Change a category to non-monthly with rollover:
@@ -266,8 +274,37 @@ async def update_category(
                 rollover_starting_balance=0,
                 rollover_frequency="variable",
             )
+
+        Preview changes without applying:
+            update_category(
+                category_id="243338338825232741",
+                budget_variability="flexible",
+                dry_run=True,
+            )
     """
     try:
+        if budget_variability and budget_variability not in _VALID_BUDGET_VARIABILITY:
+            return json_success(
+                {
+                    "success": False,
+                    "message": (
+                        f"Invalid budget_variability: {budget_variability!r}. "
+                        f"Must be one of: {sorted(_VALID_BUDGET_VARIABILITY)}"
+                    ),
+                }
+            )
+
+        if rollover_frequency and rollover_frequency not in _VALID_ROLLOVER_FREQUENCY:
+            return json_success(
+                {
+                    "success": False,
+                    "message": (
+                        f"Invalid rollover_frequency: {rollover_frequency!r}. "
+                        f"Must be one of: {sorted(_VALID_ROLLOVER_FREQUENCY)}"
+                    ),
+                }
+            )
+
         field_map: Dict[str, Any] = {
             "name": name,
             "icon": icon,
@@ -290,6 +327,39 @@ async def update_category(
                 {
                     "success": False,
                     "message": "At least one field to update must be provided.",
+                }
+            )
+
+        if dry_run:
+            client = await get_monarch_client()
+            current = await client.gql_call(
+                operation="GetCategoryDetails",
+                graphql_query=GET_CATEGORY_DETAILS_QUERY,
+                variables={
+                    "id": category_id,
+                    "month": datetime.now().strftime("%Y-%m-01"),
+                    "includeBudgetAmounts": False,
+                },
+            )
+            cat = current.get("category")
+            if not cat:
+                return json_success(
+                    {
+                        "success": False,
+                        "message": "No category found with the given ID.",
+                    }
+                )
+            return json_success(
+                {
+                    "dry_run": True,
+                    "category_id": category_id,
+                    "current": {
+                        "name": cat.get("name"),
+                        "icon": cat.get("icon"),
+                        "exclude_from_budget": cat.get("excludeFromBudget"),
+                        "is_disabled": cat.get("isDisabled"),
+                    },
+                    "proposed_changes": provided,
                 }
             )
 

--- a/src/monarch_mcp_server/tools/categories.py
+++ b/src/monarch_mcp_server/tools/categories.py
@@ -1,7 +1,10 @@
 """Category tools."""
 
 import logging
-from typing import Any, Dict, Optional
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from gql import gql
 
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
@@ -82,5 +85,440 @@ async def create_transaction_category(
         return json_success(result)
     except Exception as e:
         return json_error("create_transaction_category", e)
+
+
+# ---------------------------------------------------------------------------
+# GraphQL constants (custom queries not in monarchmoney library)
+# ---------------------------------------------------------------------------
+
+UPDATE_CATEGORY_MUTATION = gql(
+    """
+mutation Web_UpdateCategory($input: UpdateCategoryInput!) {
+  updateCategory(input: $input) {
+    errors {
+      fieldErrors {
+        field
+        messages
+        __typename
+      }
+      message
+      code
+      __typename
+    }
+    category {
+      id
+      name
+      icon
+      systemCategory
+      systemCategoryDisplayName
+      budgetVariability
+      excludeFromBudget
+      isSystemCategory
+      isDisabled
+      isProtected
+      group {
+        id
+        type
+        groupLevelBudgetingEnabled
+        __typename
+      }
+      rolloverPeriod {
+        id
+        startMonth
+        startingBalance
+        type
+        frequency
+        targetAmount
+        __typename
+      }
+      __typename
+    }
+    __typename
+  }
+}
+"""
+)
+
+GET_CATEGORY_DETAILS_QUERY = gql(
+    """
+query GetCategoryDetails($id: UUID, $month: Date!, $includeBudgetAmounts: Boolean!) {
+  category(id: $id) {
+    id
+    order
+    name
+    icon
+    isSystemCategory
+    systemCategory
+    excludeFromBudget
+    isDisabled
+    group {
+      id
+      name
+      type
+      __typename
+    }
+    rolloverPeriod {
+      id
+      startingBalance
+      __typename
+    }
+    budgetAmountsForMonth(month: $month) @include(if: $includeBudgetAmounts) {
+      month
+      plannedAmount
+      actualAmount
+      remainingAmount
+      previousMonthRolloverAmount
+      rolloverType
+      __typename
+    }
+    __typename
+  }
+}
+"""
+)
+
+GET_AGGREGATES_BY_MONTH_QUERY = gql(
+    """
+query GetAggregatesGraph($startDate: Date, $endDate: Date) {
+  aggregates(
+    filters: {startDate: $startDate, endDate: $endDate}
+    groupBy: ["category", "month"]
+    fillEmptyValues: true
+  ) {
+    groupBy {
+      category {
+        id
+        __typename
+      }
+      month
+      __typename
+    }
+    summary {
+      sum
+      __typename
+    }
+    __typename
+  }
+}
+"""
+)
+
+
+# ---------------------------------------------------------------------------
+# GraphQL-backed tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def update_category(
+    category_id: str,
+    name: Optional[str] = None,
+    icon: Optional[str] = None,
+    group_id: Optional[str] = None,
+    category_type: Optional[str] = None,
+    exclude_from_budget: Optional[bool] = None,
+    budget_variability: Optional[str] = None,
+    rollover_enabled: Optional[bool] = None,
+    rollover_start_month: Optional[str] = None,
+    rollover_starting_balance: Optional[float] = None,
+    rollover_frequency: Optional[str] = None,
+    rollover_target_amount: Optional[float] = None,
+    rollover_type: Optional[str] = None,
+) -> str:
+    """
+    Update an existing category's settings.
+
+    Modify a category's name, icon, group, budget variability, and rollover
+    configuration. Use get_transaction_categories to find category IDs, and
+    get_category_details to see current settings before updating.
+
+    Args:
+        category_id: The category ID to update.
+        name: New display name.
+        icon: New emoji icon.
+        group_id: Move to a different category group (use
+            get_transaction_category_groups to find group IDs).
+        category_type: Category type, typically "expense" or "income".
+        exclude_from_budget: Whether to exclude this category from budgets.
+        budget_variability: Budget variability mode. Values: "fixed" (same
+            every month), "flexible" (pooled into flex bucket), "non_monthly"
+            (annual/irregular with rollover).
+        rollover_enabled: Whether budget rollover is enabled.
+        rollover_start_month: When rollover tracking begins (YYYY-MM-DD,
+            first of month).
+        rollover_starting_balance: Starting rollover balance in dollars.
+        rollover_frequency: Rollover frequency. Values: "monthly",
+            "variable".
+        rollover_target_amount: Target amount for rollover savings goal.
+        rollover_type: Rollover type. Values: "monthly".
+
+    Returns:
+        Updated category details including budget variability and rollover
+        configuration.
+
+    Example:
+        Change a category to non-monthly with rollover:
+            update_category(
+                category_id="243338338825232741",
+                budget_variability="non_monthly",
+                rollover_enabled=True,
+                rollover_start_month="2026-05-01",
+                rollover_starting_balance=0,
+                rollover_frequency="variable",
+            )
+    """
+    try:
+        field_map: Dict[str, Any] = {
+            "name": name,
+            "icon": icon,
+            "group": group_id,
+            "type": category_type,
+            "excludeFromBudget": exclude_from_budget,
+            "budgetVariability": budget_variability,
+            "rolloverEnabled": rollover_enabled,
+            "rolloverStartMonth": rollover_start_month,
+            "rolloverStartingBalance": rollover_starting_balance,
+            "rolloverFrequency": rollover_frequency,
+            "rolloverTargetAmount": rollover_target_amount,
+            "rolloverType": rollover_type,
+        }
+
+        provided = {k: v for k, v in field_map.items() if v is not None}
+
+        if not provided:
+            return json_success(
+                {
+                    "success": False,
+                    "message": "At least one field to update must be provided.",
+                }
+            )
+
+        category_input: Dict[str, Any] = {"id": category_id, **provided}
+
+        client = await get_monarch_client()
+        result = await client.gql_call(
+            operation="Web_UpdateCategory",
+            graphql_query=UPDATE_CATEGORY_MUTATION,
+            variables={"input": category_input},
+        )
+
+        errors = result.get("updateCategory", {}).get("errors")
+        if errors:
+            return json_success({"success": False, "errors": errors})
+
+        cat = result.get("updateCategory", {}).get("category", {})
+        group = cat.get("group") or {}
+        rollover = cat.get("rolloverPeriod")
+
+        return json_success(
+            {
+                "success": True,
+                "category": {
+                    "id": cat.get("id"),
+                    "name": cat.get("name"),
+                    "icon": cat.get("icon"),
+                    "budget_variability": cat.get("budgetVariability"),
+                    "exclude_from_budget": cat.get("excludeFromBudget"),
+                    "is_system_category": cat.get("isSystemCategory"),
+                    "is_disabled": cat.get("isDisabled"),
+                    "group": {
+                        "id": group.get("id"),
+                        "type": group.get("type"),
+                        "group_level_budgeting_enabled": group.get(
+                            "groupLevelBudgetingEnabled"
+                        ),
+                    },
+                    "rollover_period": (
+                        {
+                            "id": rollover.get("id"),
+                            "start_month": rollover.get("startMonth"),
+                            "starting_balance": rollover.get("startingBalance"),
+                            "type": rollover.get("type"),
+                            "frequency": rollover.get("frequency"),
+                            "target_amount": rollover.get("targetAmount"),
+                        }
+                        if rollover
+                        else None
+                    ),
+                },
+            }
+        )
+    except Exception as e:
+        return json_error("update_category", e)
+
+
+@mcp.tool()
+async def get_category_details(
+    category_id: str,
+    month: Optional[str] = None,
+) -> str:
+    """
+    Get a single category's details including budget amounts for a month.
+
+    Returns the category's configuration (group, rollover settings) plus
+    budget performance for the specified month: planned amount, actual
+    spending, remaining budget, and any rollover from the previous month.
+
+    Args:
+        category_id: The category ID to look up.
+        month: Month to get budget amounts for, in YYYY-MM-DD format (first
+            of month). Defaults to the current month.
+
+    Returns:
+        Category details with budget amounts (planned, actual, remaining,
+        rollover).
+
+    Example:
+        Check how Groceries is tracking this month:
+            get_category_details(category_id="46433339325375401")
+    """
+    try:
+        if not month:
+            month = datetime.now().strftime("%Y-%m-01")
+
+        client = await get_monarch_client()
+        result = await client.gql_call(
+            operation="GetCategoryDetails",
+            graphql_query=GET_CATEGORY_DETAILS_QUERY,
+            variables={
+                "id": category_id,
+                "month": month,
+                "includeBudgetAmounts": True,
+            },
+        )
+
+        cat = result.get("category")
+        if not cat:
+            return json_success(
+                {
+                    "category": None,
+                    "message": "No category found with the given ID.",
+                }
+            )
+
+        group = cat.get("group") or {}
+        rollover = cat.get("rolloverPeriod")
+        budget = cat.get("budgetAmountsForMonth")
+
+        return json_success(
+            {
+                "id": cat.get("id"),
+                "name": cat.get("name"),
+                "icon": cat.get("icon"),
+                "order": cat.get("order"),
+                "is_system_category": cat.get("isSystemCategory"),
+                "exclude_from_budget": cat.get("excludeFromBudget"),
+                "is_disabled": cat.get("isDisabled"),
+                "group": {
+                    "id": group.get("id"),
+                    "name": group.get("name"),
+                    "type": group.get("type"),
+                },
+                "rollover_period": (
+                    {
+                        "id": rollover.get("id"),
+                        "starting_balance": rollover.get("startingBalance"),
+                    }
+                    if rollover
+                    else None
+                ),
+                "budget_amounts": (
+                    {
+                        "month": budget.get("month"),
+                        "planned_amount": budget.get("plannedAmount"),
+                        "actual_amount": budget.get("actualAmount"),
+                        "remaining_amount": budget.get("remainingAmount"),
+                        "previous_month_rollover_amount": budget.get(
+                            "previousMonthRolloverAmount"
+                        ),
+                        "rollover_type": budget.get("rolloverType"),
+                    }
+                    if budget
+                    else None
+                ),
+            }
+        )
+    except Exception as e:
+        return json_error("get_category_details", e)
+
+
+@mcp.tool()
+async def get_cashflow_by_month(
+    start_date: str,
+    end_date: str,
+) -> str:
+    """
+    Get spending trends over time, broken down by category and month.
+
+    Use this for month-over-month comparisons and trend analysis. Returns
+    each category's spending for every month in the date range, sorted by
+    total magnitude.
+
+    For single-period totals by category, use get_spending_summary instead.
+
+    Args:
+        start_date: Start date in YYYY-MM-DD format (first of month).
+        end_date: End date in YYYY-MM-DD format (last day or first of next
+            month).
+
+    Returns:
+        List of categories with monthly spending totals, sorted by total
+        absolute spending (largest first).
+
+    Example:
+        See how spending changed over the last 6 months:
+            get_cashflow_by_month(
+                start_date="2025-12-01",
+                end_date="2026-05-31",
+            )
+    """
+    try:
+        client = await get_monarch_client()
+        result = await client.gql_call(
+            operation="GetAggregatesGraph",
+            graphql_query=GET_AGGREGATES_BY_MONTH_QUERY,
+            variables={"startDate": start_date, "endDate": end_date},
+        )
+
+        aggregates = result.get("aggregates", [])
+
+        categories_map: Dict[str, List[Dict[str, Any]]] = {}
+        for item in aggregates:
+            group_by = item.get("groupBy", {})
+            cat = group_by.get("category") or {}
+            cat_id = cat.get("id") or "uncategorized"
+            month_val = group_by.get("month")
+            total = item.get("summary", {}).get("sum", 0)
+
+            if cat_id not in categories_map:
+                categories_map[cat_id] = []
+            categories_map[cat_id].append({"month": month_val, "sum": total})
+
+        categories_list: List[Dict[str, Any]] = []
+        for cat_id, monthly_totals in categories_map.items():
+            abs_total = sum(abs(m.get("sum", 0) or 0) for m in monthly_totals)
+            categories_list.append(
+                {
+                    "category_id": cat_id,
+                    "total_absolute": abs_total,
+                    "monthly_totals": sorted(
+                        monthly_totals, key=lambda m: m.get("month") or ""
+                    ),
+                }
+            )
+
+        categories_list.sort(key=lambda c: c["total_absolute"], reverse=True)
+
+        for cat in categories_list:
+            del cat["total_absolute"]
+
+        return json_success(
+            {
+                "period": {"start_date": start_date, "end_date": end_date},
+                "categories": categories_list,
+            }
+        )
+    except Exception as e:
+        return json_error("get_cashflow_by_month", e)
 
 

--- a/src/monarch_mcp_server/tools/merchants.py
+++ b/src/monarch_mcp_server/tools/merchants.py
@@ -1,0 +1,335 @@
+"""Merchant and recurring stream management tools with GraphQL queries."""
+
+import logging
+from typing import Any, Dict, Optional
+
+from gql import gql
+
+from monarch_mcp_server.app import mcp
+from monarch_mcp_server.client import get_monarch_client
+from monarch_mcp_server.helpers import json_error, json_success
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# GraphQL constants
+# ---------------------------------------------------------------------------
+
+GET_MERCHANT_QUERY = gql(
+    """
+query Common_GetEditMerchant($merchantId: ID!) {
+  merchant(id: $merchantId) {
+    id
+    name
+    logoUrl
+    transactionCount
+    ruleCount
+    canBeDeleted
+    hasActiveRecurringStreams
+    recurringTransactionStream {
+      id
+      frequency
+      amount
+      baseDate
+      isActive
+      __typename
+    }
+    __typename
+  }
+}
+"""
+)
+
+UPDATE_MERCHANT_MUTATION = gql(
+    """
+mutation Common_UpdateMerchant($input: UpdateMerchantInput!) {
+  updateMerchant(input: $input) {
+    merchant {
+      id
+      name
+      recurringTransactionStream {
+        id
+        frequency
+        amount
+        baseDate
+        isActive
+        __typename
+      }
+      __typename
+    }
+    errors {
+      fieldErrors {
+        field
+        messages
+        __typename
+      }
+      message
+      code
+      __typename
+    }
+    __typename
+  }
+}
+"""
+)
+
+REVIEW_STREAM_MUTATION = gql(
+    """
+mutation Web_ReviewStream($input: ReviewRecurringStreamInput!) {
+  reviewRecurringStream(input: $input) {
+    stream {
+      id
+      reviewStatus
+      __typename
+    }
+    errors {
+      fieldErrors {
+        field
+        messages
+        __typename
+      }
+      message
+      code
+      __typename
+    }
+    __typename
+  }
+}
+"""
+)
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def get_merchant(merchant_id: str) -> str:
+    """
+    Get a merchant's details including recurring transaction stream configuration.
+
+    Use this to look up a merchant's current recurring stream settings before
+    updating them with update_merchant.
+
+    Args:
+        merchant_id: The Monarch merchant ID (find via get_transactions or
+            get_recurring_transactions, which include merchant IDs in their
+            responses).
+
+    Returns:
+        Merchant details with name, transaction count, rule count, and
+        recurring stream configuration (frequency, amount, base date).
+
+    Example:
+        Look up PennyMac merchant details:
+            get_merchant(merchant_id="160319777541808781")
+    """
+    try:
+        client = await get_monarch_client()
+        result = await client.gql_call(
+            operation="Common_GetEditMerchant",
+            graphql_query=GET_MERCHANT_QUERY,
+            variables={"merchantId": merchant_id},
+        )
+
+        merchant = result.get("merchant")
+        if not merchant:
+            return json_success(
+                {
+                    "merchant": None,
+                    "message": "No merchant found with the given ID",
+                }
+            )
+
+        stream = merchant.get("recurringTransactionStream")
+        merchant_info: Dict[str, Any] = {
+            "id": merchant.get("id"),
+            "name": merchant.get("name"),
+            "logo_url": merchant.get("logoUrl"),
+            "transaction_count": merchant.get("transactionCount"),
+            "rule_count": merchant.get("ruleCount"),
+            "can_be_deleted": merchant.get("canBeDeleted"),
+            "has_active_recurring_streams": merchant.get("hasActiveRecurringStreams"),
+            "recurring_stream": (
+                {
+                    "id": stream.get("id"),
+                    "frequency": stream.get("frequency"),
+                    "amount": stream.get("amount"),
+                    "base_date": stream.get("baseDate"),
+                    "is_active": stream.get("isActive"),
+                }
+                if stream
+                else None
+            ),
+        }
+
+        return json_success({"merchant": merchant_info})
+    except Exception as e:
+        return json_error("get_merchant", e)
+
+
+@mcp.tool()
+async def update_merchant(
+    merchant_id: str,
+    name: Optional[str] = None,
+    is_recurring: Optional[bool] = None,
+    frequency: Optional[str] = None,
+    base_date: Optional[str] = None,
+    amount: Optional[float] = None,
+    is_active: Optional[bool] = None,
+) -> str:
+    """
+    Update a merchant's name and/or recurring transaction stream settings.
+
+    This is the only way to modify recurring stream configurations (frequency,
+    amount, base date, active status). Use get_merchant first to see current
+    settings, then update_merchant to change them.
+
+    Args:
+        merchant_id: The Monarch merchant ID.
+        name: New merchant display name.
+        is_recurring: Whether this merchant has a recurring stream.
+        frequency: Recurrence frequency. Known values: "weekly", "biweekly",
+            "twice_a_month", "monthly", "quarterly", "semiannually",
+            "annually".
+        base_date: Anchor date for recurrence in YYYY-MM-DD format.
+        amount: Expected recurring amount (negative for expenses, positive
+            for income).
+        is_active: Whether the recurring stream is actively tracked.
+
+    Returns:
+        Updated merchant details with recurring stream configuration.
+
+    Example:
+        Fix PennyMac mortgage to $1,460.93 monthly:
+            update_merchant(
+                merchant_id="160319777541808781",
+                is_recurring=True,
+                frequency="monthly",
+                base_date="2026-05-06",
+                amount=-1460.93,
+                is_active=True,
+            )
+    """
+    try:
+        recurrence_fields: Dict[str, Any] = {
+            k: v
+            for k, v in {
+                "isRecurring": is_recurring,
+                "frequency": frequency,
+                "baseDate": base_date,
+                "amount": amount,
+                "isActive": is_active,
+            }.items()
+            if v is not None
+        }
+
+        if name is None and not recurrence_fields:
+            return json_success(
+                {
+                    "success": False,
+                    "message": "At least one field (name or recurrence) "
+                    "must be provided",
+                }
+            )
+
+        merchant_input: Dict[str, Any] = {"merchantId": merchant_id}
+
+        if name is not None:
+            merchant_input["name"] = name
+
+        if recurrence_fields:
+            merchant_input["recurrence"] = recurrence_fields
+
+        client = await get_monarch_client()
+        result = await client.gql_call(
+            operation="Common_UpdateMerchant",
+            graphql_query=UPDATE_MERCHANT_MUTATION,
+            variables={"input": merchant_input},
+        )
+
+        errors = result.get("updateMerchant", {}).get("errors")
+        if errors:
+            return json_success({"success": False, "errors": errors})
+
+        merchant = result.get("updateMerchant", {}).get("merchant", {})
+        stream = merchant.get("recurringTransactionStream")
+        return json_success(
+            {
+                "success": True,
+                "merchant": {
+                    "id": merchant.get("id"),
+                    "name": merchant.get("name"),
+                    "recurring_stream": (
+                        {
+                            "id": stream.get("id"),
+                            "frequency": stream.get("frequency"),
+                            "amount": stream.get("amount"),
+                            "base_date": stream.get("baseDate"),
+                            "is_active": stream.get("isActive"),
+                        }
+                        if stream
+                        else None
+                    ),
+                },
+            }
+        )
+    except Exception as e:
+        return json_error("update_merchant", e)
+
+
+@mcp.tool()
+async def review_recurring_stream(
+    stream_id: str,
+    review_status: str,
+) -> str:
+    """
+    Set the review status of a recurring transaction stream.
+
+    When Monarch detects new recurring patterns, they appear as pending review.
+    Use this to accept, dismiss, or reset them.
+
+    Args:
+        stream_id: The recurring stream ID (find via get_recurring_transactions
+            or get_merchant, which include stream IDs).
+        review_status: The review status to set. Known values: "approved"
+            (accept the detected pattern), "ignored" (dismiss it), "pending"
+            (reset to pending review).
+
+    Returns:
+        Updated stream ID and review status.
+
+    Example:
+        Approve a detected Netflix recurring stream:
+            review_recurring_stream(
+                stream_id="235281502498808806",
+                review_status="approved",
+            )
+    """
+    try:
+        client = await get_monarch_client()
+        result = await client.gql_call(
+            operation="Web_ReviewStream",
+            graphql_query=REVIEW_STREAM_MUTATION,
+            variables={
+                "input": {
+                    "streamId": stream_id,
+                    "reviewStatus": review_status,
+                }
+            },
+        )
+
+        errors = result.get("reviewRecurringStream", {}).get("errors")
+        if errors:
+            return json_success({"success": False, "errors": errors})
+
+        stream = result.get("reviewRecurringStream", {}).get("stream", {})
+        return json_success(
+            {
+                "success": True,
+                "stream_id": stream.get("id"),
+                "review_status": stream.get("reviewStatus"),
+            }
+        )
+    except Exception as e:
+        return json_error("review_recurring_stream", e)

--- a/src/monarch_mcp_server/tools/summaries.py
+++ b/src/monarch_mcp_server/tools/summaries.py
@@ -1,13 +1,94 @@
 """Transaction summary tools."""
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
+
+from gql import gql
 
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
-from monarch_mcp_server.helpers import json_success, json_error
+from monarch_mcp_server.helpers import json_error, json_success
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# GraphQL constants
+# ---------------------------------------------------------------------------
+
+GET_CASHFLOW_ENTITY_AGGREGATES_QUERY = gql(
+    """
+query Common_GetCashFlowEntityAggregates($filters: TransactionFilterInput) {
+  byCategory: aggregates(filters: $filters, groupBy: ["category"]) {
+    groupBy {
+      category {
+        id
+        name
+        icon
+        group {
+          id
+          type
+          __typename
+        }
+        __typename
+      }
+      __typename
+    }
+    summary {
+      sum
+      __typename
+    }
+    __typename
+  }
+  byCategoryGroup: aggregates(filters: $filters, groupBy: ["categoryGroup"]) {
+    groupBy {
+      categoryGroup {
+        id
+        name
+        type
+        __typename
+      }
+      __typename
+    }
+    summary {
+      sum
+      __typename
+    }
+    __typename
+  }
+  byMerchant: aggregates(filters: $filters, groupBy: ["merchant"]) {
+    groupBy {
+      merchant {
+        id
+        name
+        logoUrl
+        __typename
+      }
+      __typename
+    }
+    summary {
+      sumIncome
+      sumExpense
+      __typename
+    }
+    __typename
+  }
+  summary: aggregates(filters: $filters, fillEmptyValues: true) {
+    summary {
+      sumIncome
+      sumExpense
+      savings
+      savingsRate
+      __typename
+    }
+    __typename
+  }
+}
+"""
+)
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
 
 
 @mcp.tool()
@@ -33,72 +114,106 @@ async def get_transactions_summary() -> str:
 async def get_spending_summary(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
-    limit: int = 100,
 ) -> str:
     """
-    Get a spending summary broken down by category.
+    Get a spending summary broken down by category, category group, and merchant.
 
-    Shows how much you've spent in each category over a time period.
-    Great for understanding where your money is going.
+    Shows how much you've spent in each category over a time period, plus
+    overall income, expenses, and savings rate.
 
     Args:
-        start_date: Start date in YYYY-MM-DD format
-        end_date: End date in YYYY-MM-DD format
-        limit: Maximum number of categories to return (default: 100)
+        start_date: Start date in YYYY-MM-DD format.
+        end_date: End date in YYYY-MM-DD format.
 
     Returns:
-        Spending breakdown by category with totals.
+        Spending breakdown with by_category, by_category_group, by_merchant,
+        and overall totals (income, expenses, savings, savings_rate).
 
     Examples:
         Get spending summary for current month:
-            get_spending_summary(start_date="2024-02-01", end_date="2024-02-29")
+            get_spending_summary(start_date="2026-05-01", end_date="2026-05-31")
 
         Get spending summary for the year:
-            get_spending_summary(start_date="2024-01-01")
+            get_spending_summary(start_date="2026-01-01", end_date="2026-12-31")
     """
     try:
         client = await get_monarch_client()
 
-        params: Dict[str, Any] = {"limit": limit}
+        filters: Dict[str, Any] = {}
         if start_date:
-            params["start_date"] = start_date
+            filters["startDate"] = start_date
         if end_date:
-            params["end_date"] = end_date
+            filters["endDate"] = end_date
 
-        result = await client.get_cashflow_summary(**params)
+        result = await client.gql_call(
+            operation="Common_GetCashFlowEntityAggregates",
+            graphql_query=GET_CASHFLOW_ENTITY_AGGREGATES_QUERY,
+            variables={"filters": filters},
+        )
 
-        summary = result.get("summary", [])
+        by_category: List[Dict[str, Any]] = []
+        for item in result.get("byCategory", []):
+            cat = item.get("groupBy", {}).get("category") or {}
+            group = cat.get("group") or {}
+            by_category.append(
+                {
+                    "category": cat.get("name"),
+                    "category_id": cat.get("id"),
+                    "icon": cat.get("icon"),
+                    "group_id": group.get("id"),
+                    "group_type": group.get("type"),
+                    "sum": item.get("summary", {}).get("sum", 0),
+                }
+            )
+        by_category.sort(key=lambda x: abs(x.get("sum", 0)), reverse=True)
+
+        by_category_group: List[Dict[str, Any]] = []
+        for item in result.get("byCategoryGroup", []):
+            grp = item.get("groupBy", {}).get("categoryGroup") or {}
+            by_category_group.append(
+                {
+                    "group": grp.get("name"),
+                    "group_id": grp.get("id"),
+                    "group_type": grp.get("type"),
+                    "sum": item.get("summary", {}).get("sum", 0),
+                }
+            )
+        by_category_group.sort(key=lambda x: abs(x.get("sum", 0)), reverse=True)
+
+        by_merchant: List[Dict[str, Any]] = []
+        for item in result.get("byMerchant", []):
+            merch = item.get("groupBy", {}).get("merchant") or {}
+            by_merchant.append(
+                {
+                    "merchant": merch.get("name"),
+                    "merchant_id": merch.get("id"),
+                    "income": item.get("summary", {}).get("sumIncome", 0),
+                    "expense": item.get("summary", {}).get("sumExpense", 0),
+                }
+            )
+        by_merchant.sort(key=lambda x: abs(x.get("expense", 0)), reverse=True)
+
+        overall = {}
+        summary_items = result.get("summary", [])
+        if summary_items:
+            s = summary_items[0].get("summary", {})
+            overall = {
+                "total_income": s.get("sumIncome", 0),
+                "total_expenses": s.get("sumExpense", 0),
+                "savings": s.get("savings", 0),
+                "savings_rate": s.get("savingsRate", 0),
+            }
 
         formatted: Dict[str, Any] = {
             "period": {
                 "start_date": start_date,
                 "end_date": end_date,
             },
-            "total_income": 0,
-            "total_expenses": 0,
-            "net": 0,
-            "by_category": []
+            **overall,
+            "by_category": by_category,
+            "by_category_group": by_category_group,
+            "by_merchant": by_merchant,
         }
-
-        for item in summary:
-            category_info = {
-                "category": item.get("category", {}).get("name") if item.get("category") else "Uncategorized",
-                "category_id": item.get("category", {}).get("id") if item.get("category") else None,
-                "group": item.get("categoryGroup", {}).get("name") if item.get("categoryGroup") else None,
-                "sum": item.get("sum", 0),
-                "avg": item.get("avg", 0),
-            }
-            formatted["by_category"].append(category_info)
-
-            amount = item.get("sum", 0)
-            if amount > 0:
-                formatted["total_income"] += amount
-            else:
-                formatted["total_expenses"] += abs(amount)
-
-        formatted["net"] = formatted["total_income"] - formatted["total_expenses"]
-
-        formatted["by_category"].sort(key=lambda x: abs(x.get("sum", 0)), reverse=True)
 
         return json_success(formatted)
     except Exception as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,6 +239,7 @@ _TOOL_MODULES = [
     "monarch_mcp_server.tools.categories",
     "monarch_mcp_server.tools.budgets",
     "monarch_mcp_server.tools.financial",
+    "monarch_mcp_server.tools.merchants",
 ]
 
 

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -193,6 +193,40 @@ class TestUpdateCategory:
         assert call_vars["input"]["rolloverStartMonth"] == "2026-05-01"
 
     @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_falsy_values_not_dropped(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateCategory": {
+                "errors": None,
+                "category": {
+                    "id": "cat-123",
+                    "name": "Test",
+                    "icon": "X",
+                    "budgetVariability": "fixed",
+                    "excludeFromBudget": False,
+                    "isSystemCategory": False,
+                    "isDisabled": False,
+                    "isProtected": False,
+                    "group": {"id": "grp-1", "type": "expense", "groupLevelBudgetingEnabled": False},
+                    "rolloverPeriod": None,
+                },
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        await update_category(
+            category_id="cat-123",
+            exclude_from_budget=False,
+            rollover_enabled=False,
+            rollover_starting_balance=0,
+        )
+
+        call_vars = mock_client.gql_call.call_args.kwargs["variables"]
+        assert call_vars["input"]["excludeFromBudget"] is False
+        assert call_vars["input"]["rolloverEnabled"] is False
+        assert call_vars["input"]["rolloverStartingBalance"] == 0
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
     async def test_invalid_budget_variability(self, mock_get_client):
         result = json.loads(
             await update_category(category_id="cat-123", budget_variability="bogus")

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -193,6 +193,78 @@ class TestUpdateCategory:
         assert call_vars["input"]["rolloverStartMonth"] == "2026-05-01"
 
     @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_invalid_budget_variability(self, mock_get_client):
+        result = json.loads(
+            await update_category(category_id="cat-123", budget_variability="bogus")
+        )
+
+        assert result["success"] is False
+        assert "Invalid budget_variability" in result["message"]
+        assert "bogus" in result["message"]
+        mock_get_client.assert_not_called()
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_invalid_rollover_frequency(self, mock_get_client):
+        result = json.loads(
+            await update_category(category_id="cat-123", rollover_frequency="weekly")
+        )
+
+        assert result["success"] is False
+        assert "Invalid rollover_frequency" in result["message"]
+        mock_get_client.assert_not_called()
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_dry_run_returns_current_and_proposed(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "category": {
+                "id": "cat-123",
+                "order": 1,
+                "name": "Fitness Subscriptions",
+                "icon": "\U0001f3cb",
+                "isSystemCategory": False,
+                "systemCategory": None,
+                "excludeFromBudget": False,
+                "isDisabled": False,
+                "group": {"id": "grp-1", "name": "Bills", "type": "expense"},
+                "rolloverPeriod": None,
+                "budgetAmountsForMonth": None,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = json.loads(
+            await update_category(
+                category_id="cat-123",
+                budget_variability="non_monthly",
+                rollover_enabled=True,
+                dry_run=True,
+            )
+        )
+
+        assert result["dry_run"] is True
+        assert result["current"]["name"] == "Fitness Subscriptions"
+        assert result["proposed_changes"]["budgetVariability"] == "non_monthly"
+        assert result["proposed_changes"]["rolloverEnabled"] is True
+        # Mutation should NOT have been called
+        assert mock_client.gql_call.call_args.kwargs["operation"] == "GetCategoryDetails"
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_dry_run_category_not_found(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {"category": None}
+        mock_get_client.return_value = mock_client
+
+        result = json.loads(
+            await update_category(
+                category_id="nonexistent", name="Test", dry_run=True
+            )
+        )
+
+        assert result["success"] is False
+        assert "No category found" in result["message"]
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
     async def test_no_fields_provided(self, mock_get_client):
         result = json.loads(await update_category(category_id="cat-123"))
 

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -8,6 +8,9 @@ from monarch_mcp_server.tools.categories import (
     get_transaction_categories,
     get_transaction_category_groups,
     create_transaction_category,
+    update_category,
+    get_category_details,
+    get_cashflow_by_month,
 )
 
 
@@ -66,4 +69,319 @@ class TestCreateTransactionCategory:
         mock_monarch_client.create_transaction_category.side_effect = Exception("boom")
         result = await create_transaction_category("grp-1", "Coffee")
         assert "create_transaction_category" in result
+
+
+class TestUpdateCategory:
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_update_name_and_icon(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateCategory": {
+                "errors": None,
+                "category": {
+                    "id": "cat-123",
+                    "name": "Fitness",
+                    "icon": "\U0001f3cb",
+                    "budgetVariability": "fixed",
+                    "excludeFromBudget": False,
+                    "isSystemCategory": False,
+                    "isDisabled": False,
+                    "isProtected": False,
+                    "group": {
+                        "id": "grp-1",
+                        "type": "expense",
+                        "groupLevelBudgetingEnabled": False,
+                    },
+                    "rolloverPeriod": None,
+                },
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = json.loads(
+            await update_category(category_id="cat-123", name="Fitness", icon="\U0001f3cb")
+        )
+
+        assert result["success"] is True
+        assert result["category"]["name"] == "Fitness"
+        assert result["category"]["icon"] == "\U0001f3cb"
+
+        call_vars = mock_client.gql_call.call_args.kwargs["variables"]
+        assert call_vars["input"]["id"] == "cat-123"
+        assert call_vars["input"]["name"] == "Fitness"
+        assert call_vars["input"]["icon"] == "\U0001f3cb"
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_update_budget_variability(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateCategory": {
+                "errors": None,
+                "category": {
+                    "id": "cat-123",
+                    "name": "Medical",
+                    "icon": "\U0001f48a",
+                    "budgetVariability": "flexible",
+                    "excludeFromBudget": False,
+                    "isSystemCategory": True,
+                    "isDisabled": False,
+                    "isProtected": False,
+                    "group": {"id": "grp-2", "type": "expense", "groupLevelBudgetingEnabled": False},
+                    "rolloverPeriod": None,
+                },
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = json.loads(
+            await update_category(category_id="cat-123", budget_variability="flexible")
+        )
+
+        assert result["success"] is True
+        assert result["category"]["budget_variability"] == "flexible"
+
+        call_vars = mock_client.gql_call.call_args.kwargs["variables"]
+        assert call_vars["input"]["budgetVariability"] == "flexible"
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_enable_rollover(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateCategory": {
+                "errors": None,
+                "category": {
+                    "id": "cat-456",
+                    "name": "Harper's Birthday",
+                    "icon": "\U0001f382",
+                    "budgetVariability": "non_monthly",
+                    "excludeFromBudget": False,
+                    "isSystemCategory": False,
+                    "isDisabled": False,
+                    "isProtected": False,
+                    "group": {"id": "grp-3", "type": "expense", "groupLevelBudgetingEnabled": False},
+                    "rolloverPeriod": {
+                        "id": "rp-1",
+                        "startMonth": "2026-05-01",
+                        "startingBalance": 0,
+                        "type": "monthly",
+                        "frequency": "variable",
+                        "targetAmount": None,
+                    },
+                },
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = json.loads(
+            await update_category(
+                category_id="cat-456",
+                budget_variability="non_monthly",
+                rollover_enabled=True,
+                rollover_start_month="2026-05-01",
+                rollover_starting_balance=0,
+                rollover_frequency="variable",
+            )
+        )
+
+        assert result["success"] is True
+        assert result["category"]["rollover_period"] is not None
+        assert result["category"]["rollover_period"]["start_month"] == "2026-05-01"
+        assert result["category"]["rollover_period"]["frequency"] == "variable"
+
+        call_vars = mock_client.gql_call.call_args.kwargs["variables"]
+        assert call_vars["input"]["rolloverEnabled"] is True
+        assert call_vars["input"]["rolloverStartMonth"] == "2026-05-01"
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_no_fields_provided(self, mock_get_client):
+        result = json.loads(await update_category(category_id="cat-123"))
+
+        assert result["success"] is False
+        assert "At least one field" in result["message"]
+        mock_get_client.assert_not_called()
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_graphql_errors(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateCategory": {
+                "errors": {
+                    "fieldErrors": [{"field": "name", "messages": ["too long"]}],
+                    "message": "Validation failed",
+                    "code": "INVALID_INPUT",
+                },
+                "category": None,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = json.loads(await update_category(category_id="cat-123", name="x" * 500))
+
+        assert result["success"] is False
+        assert result["errors"]["code"] == "INVALID_INPUT"
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_auth_error(self, mock_get_client):
+        mock_get_client.side_effect = RuntimeError("Not authenticated")
+
+        result = await update_category(category_id="cat-123", name="Test")
+        assert "update_category" in result
+
+
+class TestGetCategoryDetails:
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_success_with_budget_amounts(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "category": {
+                "id": "cat-groceries",
+                "order": 0,
+                "name": "Groceries",
+                "icon": "\U0001f6d2",
+                "isSystemCategory": True,
+                "systemCategory": "groceries",
+                "excludeFromBudget": False,
+                "isDisabled": False,
+                "group": {"id": "grp-food", "name": "Food & Dining", "type": "expense"},
+                "rolloverPeriod": None,
+                "budgetAmountsForMonth": {
+                    "month": "2026-05-01",
+                    "plannedAmount": 600.0,
+                    "actualAmount": 425.50,
+                    "remainingAmount": 174.50,
+                    "previousMonthRolloverAmount": None,
+                    "rolloverType": None,
+                },
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = json.loads(
+            await get_category_details(category_id="cat-groceries", month="2026-05-01")
+        )
+
+        assert result["name"] == "Groceries"
+        assert result["budget_amounts"]["planned_amount"] == 600.0
+        assert result["budget_amounts"]["actual_amount"] == 425.50
+        assert result["budget_amounts"]["remaining_amount"] == 174.50
+        assert result["group"]["name"] == "Food & Dining"
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_default_month(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "category": {
+                "id": "cat-1",
+                "order": 0,
+                "name": "Test",
+                "icon": "X",
+                "isSystemCategory": False,
+                "systemCategory": None,
+                "excludeFromBudget": False,
+                "isDisabled": False,
+                "group": {"id": "grp-1", "name": "G", "type": "expense"},
+                "rolloverPeriod": None,
+                "budgetAmountsForMonth": None,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        await get_category_details(category_id="cat-1")
+
+        call_vars = mock_client.gql_call.call_args.kwargs["variables"]
+        assert call_vars["includeBudgetAmounts"] is True
+        # Month should be current month in YYYY-MM-01 format
+        from datetime import datetime
+
+        expected_month = datetime.now().strftime("%Y-%m-01")
+        assert call_vars["month"] == expected_month
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_category_not_found(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {"category": None}
+        mock_get_client.return_value = mock_client
+
+        result = json.loads(await get_category_details(category_id="nonexistent"))
+
+        assert result["category"] is None
+        assert "No category found" in result["message"]
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_auth_error(self, mock_get_client):
+        mock_get_client.side_effect = RuntimeError("Not authenticated")
+
+        result = await get_category_details(category_id="cat-1")
+        assert "get_category_details" in result
+
+
+class TestGetCashflowByMonth:
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_success_multiple_categories(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "aggregates": [
+                {
+                    "groupBy": {"category": {"id": "cat-A"}, "month": "2026-01-01"},
+                    "summary": {"sum": -200.0},
+                },
+                {
+                    "groupBy": {"category": {"id": "cat-A"}, "month": "2026-02-01"},
+                    "summary": {"sum": -180.0},
+                },
+                {
+                    "groupBy": {"category": {"id": "cat-B"}, "month": "2026-01-01"},
+                    "summary": {"sum": -50.0},
+                },
+                {
+                    "groupBy": {"category": {"id": "cat-B"}, "month": "2026-02-01"},
+                    "summary": {"sum": -75.0},
+                },
+            ]
+        }
+        mock_get_client.return_value = mock_client
+
+        result = json.loads(
+            await get_cashflow_by_month(start_date="2026-01-01", end_date="2026-02-28")
+        )
+
+        assert result["period"]["start_date"] == "2026-01-01"
+        assert len(result["categories"]) == 2
+        # cat-A has higher total absolute (380 vs 125), so comes first
+        assert result["categories"][0]["category_id"] == "cat-A"
+        assert len(result["categories"][0]["monthly_totals"]) == 2
+        assert result["categories"][0]["monthly_totals"][0]["sum"] == -200.0
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_empty_results(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {"aggregates": []}
+        mock_get_client.return_value = mock_client
+
+        result = json.loads(
+            await get_cashflow_by_month(start_date="2030-01-01", end_date="2030-01-31")
+        )
+
+        assert result["categories"] == []
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_passes_date_variables(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {"aggregates": []}
+        mock_get_client.return_value = mock_client
+
+        await get_cashflow_by_month(start_date="2025-12-01", end_date="2026-05-31")
+
+        call_vars = mock_client.gql_call.call_args.kwargs["variables"]
+        assert call_vars["startDate"] == "2025-12-01"
+        assert call_vars["endDate"] == "2026-05-31"
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_auth_error(self, mock_get_client):
+        mock_get_client.side_effect = RuntimeError("Not authenticated")
+
+        result = await get_cashflow_by_month(
+            start_date="2026-01-01", end_date="2026-01-31"
+        )
+        assert "get_cashflow_by_month" in result
 

--- a/tests/test_merchants.py
+++ b/tests/test_merchants.py
@@ -1,0 +1,365 @@
+"""Tests for merchant and recurring stream MCP tools."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from monarch_mcp_server.tools.merchants import (
+    get_merchant,
+    review_recurring_stream,
+    update_merchant,
+)
+
+
+class TestGetMerchant:
+    """Tests for get_merchant tool."""
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_get_merchant_success(self, mock_get_client):
+        """Test successful retrieval of merchant with recurring stream."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "merchant": {
+                "id": "160319777541808781",
+                "name": "PennyMac",
+                "logoUrl": "https://example.com/logo.png",
+                "transactionCount": 24,
+                "ruleCount": 1,
+                "canBeDeleted": False,
+                "hasActiveRecurringStreams": True,
+                "recurringTransactionStream": {
+                    "id": "stream_123",
+                    "frequency": "monthly",
+                    "amount": -1460.93,
+                    "baseDate": "2026-05-06",
+                    "isActive": True,
+                },
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_merchant(merchant_id="160319777541808781")
+
+        data = json.loads(result)
+        assert data["merchant"]["id"] == "160319777541808781"
+        assert data["merchant"]["name"] == "PennyMac"
+        assert data["merchant"]["transaction_count"] == 24
+        assert data["merchant"]["rule_count"] == 1
+        assert data["merchant"]["can_be_deleted"] is False
+        assert data["merchant"]["has_active_recurring_streams"] is True
+        assert data["merchant"]["recurring_stream"]["frequency"] == "monthly"
+        assert data["merchant"]["recurring_stream"]["amount"] == -1460.93
+        assert data["merchant"]["recurring_stream"]["base_date"] == "2026-05-06"
+        assert data["merchant"]["recurring_stream"]["is_active"] is True
+
+        call_args = mock_client.gql_call.call_args
+        assert call_args.kwargs["variables"]["merchantId"] == "160319777541808781"
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_get_merchant_no_recurring_stream(self, mock_get_client):
+        """Test merchant that exists but has no recurring stream."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "merchant": {
+                "id": "999",
+                "name": "One-Time Shop",
+                "logoUrl": None,
+                "transactionCount": 2,
+                "ruleCount": 0,
+                "canBeDeleted": True,
+                "hasActiveRecurringStreams": False,
+                "recurringTransactionStream": None,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_merchant(merchant_id="999")
+
+        data = json.loads(result)
+        assert data["merchant"]["id"] == "999"
+        assert data["merchant"]["name"] == "One-Time Shop"
+        assert data["merchant"]["recurring_stream"] is None
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_get_merchant_not_found(self, mock_get_client):
+        """Test when merchant ID does not exist."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {"merchant": None}
+        mock_get_client.return_value = mock_client
+
+        result = await get_merchant(merchant_id="nonexistent")
+
+        data = json.loads(result)
+        assert data["merchant"] is None
+        assert "message" in data
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_get_merchant_auth_error(self, mock_get_client):
+        """Test error handling when not authenticated."""
+        mock_get_client.side_effect = RuntimeError("Authentication needed")
+
+        result = await get_merchant(merchant_id="123")
+
+        data = json.loads(result)
+        assert data["error"] is True
+        assert "Authentication needed" in data["message"]
+
+
+class TestUpdateMerchant:
+    """Tests for update_merchant tool."""
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_update_name_only(self, mock_get_client):
+        """Test updating only the merchant name."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateMerchant": {
+                "merchant": {
+                    "id": "123",
+                    "name": "New Name",
+                    "recurringTransactionStream": None,
+                },
+                "errors": None,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await update_merchant(merchant_id="123", name="New Name")
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["merchant"]["name"] == "New Name"
+
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert variables["input"]["name"] == "New Name"
+        assert "recurrence" not in variables["input"]
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_update_recurrence_only(self, mock_get_client):
+        """Test updating only recurrence settings."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateMerchant": {
+                "merchant": {
+                    "id": "123",
+                    "name": "PennyMac",
+                    "recurringTransactionStream": {
+                        "id": "stream_123",
+                        "frequency": "monthly",
+                        "amount": -1460.93,
+                        "baseDate": "2026-06-01",
+                        "isActive": True,
+                    },
+                },
+                "errors": None,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await update_merchant(
+            merchant_id="123",
+            is_recurring=True,
+            frequency="monthly",
+            base_date="2026-06-01",
+            amount=-1460.93,
+            is_active=True,
+        )
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["merchant"]["recurring_stream"]["frequency"] == "monthly"
+        assert data["merchant"]["recurring_stream"]["amount"] == -1460.93
+
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert "name" not in variables["input"]
+        assert variables["input"]["recurrence"]["isRecurring"] is True
+        assert variables["input"]["recurrence"]["frequency"] == "monthly"
+        assert variables["input"]["recurrence"]["baseDate"] == "2026-06-01"
+        assert variables["input"]["recurrence"]["amount"] == -1460.93
+        assert variables["input"]["recurrence"]["isActive"] is True
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_update_both(self, mock_get_client):
+        """Test updating name and recurrence together."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateMerchant": {
+                "merchant": {
+                    "id": "123",
+                    "name": "Updated Name",
+                    "recurringTransactionStream": {
+                        "id": "stream_123",
+                        "frequency": "biweekly",
+                        "amount": 2038.37,
+                        "baseDate": "2025-07-04",
+                        "isActive": True,
+                    },
+                },
+                "errors": None,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await update_merchant(
+            merchant_id="123",
+            name="Updated Name",
+            frequency="biweekly",
+            amount=2038.37,
+        )
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["merchant"]["name"] == "Updated Name"
+
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert variables["input"]["name"] == "Updated Name"
+        assert "recurrence" in variables["input"]
+        assert variables["input"]["recurrence"]["frequency"] == "biweekly"
+
+    async def test_update_no_fields(self):
+        """Test that calling with no updatable fields returns an error."""
+        result = await update_merchant(merchant_id="123")
+
+        data = json.loads(result)
+        assert data["success"] is False
+        assert "At least one field" in data["message"]
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_update_graphql_error(self, mock_get_client):
+        """Test handling of GraphQL-level errors."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateMerchant": {
+                "merchant": None,
+                "errors": {
+                    "message": "Merchant not found",
+                    "code": "NOT_FOUND",
+                    "fieldErrors": [],
+                },
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await update_merchant(
+            merchant_id="invalid",
+            name="Test",
+        )
+
+        data = json.loads(result)
+        assert data["success"] is False
+        assert data["errors"]["message"] == "Merchant not found"
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_update_auth_error(self, mock_get_client):
+        """Test error handling when not authenticated."""
+        mock_get_client.side_effect = RuntimeError("Auth needed")
+
+        result = await update_merchant(
+            merchant_id="123",
+            name="Test",
+        )
+
+        data = json.loads(result)
+        assert data["error"] is True
+        assert "Auth needed" in data["message"]
+
+
+class TestReviewRecurringStream:
+    """Tests for review_recurring_stream tool."""
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_review_approve(self, mock_get_client):
+        """Test approving a recurring stream."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "reviewRecurringStream": {
+                "stream": {
+                    "id": "stream_456",
+                    "reviewStatus": "approved",
+                },
+                "errors": None,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await review_recurring_stream(
+            stream_id="stream_456",
+            review_status="approved",
+        )
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["stream_id"] == "stream_456"
+        assert data["review_status"] == "approved"
+
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert variables["input"]["streamId"] == "stream_456"
+        assert variables["input"]["reviewStatus"] == "approved"
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_review_ignore(self, mock_get_client):
+        """Test ignoring a recurring stream."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "reviewRecurringStream": {
+                "stream": {
+                    "id": "stream_789",
+                    "reviewStatus": "ignored",
+                },
+                "errors": None,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await review_recurring_stream(
+            stream_id="stream_789",
+            review_status="ignored",
+        )
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["review_status"] == "ignored"
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_review_graphql_error(self, mock_get_client):
+        """Test handling of GraphQL-level errors."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "reviewRecurringStream": {
+                "stream": None,
+                "errors": {
+                    "message": "Stream not found",
+                    "code": "NOT_FOUND",
+                    "fieldErrors": [],
+                },
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await review_recurring_stream(
+            stream_id="invalid",
+            review_status="approved",
+        )
+
+        data = json.loads(result)
+        assert data["success"] is False
+        assert data["errors"]["message"] == "Stream not found"
+
+    @patch("monarch_mcp_server.tools.merchants.get_monarch_client")
+    async def test_review_auth_error(self, mock_get_client):
+        """Test error handling when not authenticated."""
+        mock_get_client.side_effect = RuntimeError("Auth needed")
+
+        result = await review_recurring_stream(
+            stream_id="stream_123",
+            review_status="approved",
+        )
+
+        data = json.loads(result)
+        assert data["error"] is True
+        assert "Auth needed" in data["message"]

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -1,0 +1,269 @@
+"""Tests for transaction summary MCP tools."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from monarch_mcp_server.tools.summaries import (
+    get_spending_summary,
+    get_transactions_summary,
+)
+
+
+class TestGetTransactionsSummary:
+    """Tests for get_transactions_summary tool."""
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_returns_summary(self, mock_get_client):
+        """Test successful summary retrieval."""
+        mock_client = AsyncMock()
+        mock_client.get_transactions_summary.return_value = {
+            "transactionCount": 142,
+            "totalAmount": -3200.50,
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_transactions_summary()
+
+        data = json.loads(result)
+        assert data["transactionCount"] == 142
+        assert data["totalAmount"] == -3200.50
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_handles_error(self, mock_get_client):
+        """Test error handling."""
+        mock_get_client.side_effect = RuntimeError("Auth needed")
+
+        result = await get_transactions_summary()
+
+        data = json.loads(result)
+        assert data["error"] is True
+        assert "Auth needed" in data["message"]
+
+
+class TestGetSpendingSummary:
+    """Tests for get_spending_summary tool."""
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_full_response(self, mock_get_client):
+        """Test successful spending summary with all sections."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "byCategory": [
+                {
+                    "groupBy": {
+                        "category": {
+                            "id": "cat-1",
+                            "name": "Groceries",
+                            "icon": "cart",
+                            "group": {"id": "grp-1", "type": "expense"},
+                        }
+                    },
+                    "summary": {"sum": -450.0},
+                },
+                {
+                    "groupBy": {
+                        "category": {
+                            "id": "cat-2",
+                            "name": "Salary",
+                            "icon": "money",
+                            "group": {"id": "grp-2", "type": "income"},
+                        }
+                    },
+                    "summary": {"sum": 5000.0},
+                },
+            ],
+            "byCategoryGroup": [
+                {
+                    "groupBy": {
+                        "categoryGroup": {
+                            "id": "grp-1",
+                            "name": "Food",
+                            "type": "expense",
+                        }
+                    },
+                    "summary": {"sum": -450.0},
+                },
+            ],
+            "byMerchant": [
+                {
+                    "groupBy": {
+                        "merchant": {
+                            "id": "merch-1",
+                            "name": "Whole Foods",
+                            "logoUrl": "https://example.com/logo.png",
+                        }
+                    },
+                    "summary": {"sumIncome": 0, "sumExpense": -320.0},
+                },
+            ],
+            "summary": [
+                {
+                    "summary": {
+                        "sumIncome": 5000.0,
+                        "sumExpense": -450.0,
+                        "savings": 4550.0,
+                        "savingsRate": 0.91,
+                    }
+                }
+            ],
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_spending_summary(
+            start_date="2026-01-01", end_date="2026-01-31"
+        )
+
+        data = json.loads(result)
+        assert data["period"]["start_date"] == "2026-01-01"
+        assert data["period"]["end_date"] == "2026-01-31"
+        assert data["total_income"] == 5000.0
+        assert data["total_expenses"] == -450.0
+        assert data["savings"] == 4550.0
+        assert data["savings_rate"] == 0.91
+
+        assert len(data["by_category"]) == 2
+        assert data["by_category"][0]["category"] == "Salary"
+        assert data["by_category"][0]["sum"] == 5000.0
+        assert data["by_category"][1]["category"] == "Groceries"
+        assert data["by_category"][1]["category_id"] == "cat-1"
+        assert data["by_category"][1]["group_type"] == "expense"
+
+        assert len(data["by_category_group"]) == 1
+        assert data["by_category_group"][0]["group"] == "Food"
+
+        assert len(data["by_merchant"]) == 1
+        assert data["by_merchant"][0]["merchant"] == "Whole Foods"
+        assert data["by_merchant"][0]["expense"] == -320.0
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_passes_date_filters(self, mock_get_client):
+        """Test that date params are passed as filters to gql_call."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "byCategory": [],
+            "byCategoryGroup": [],
+            "byMerchant": [],
+            "summary": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        await get_spending_summary(start_date="2026-03-01", end_date="2026-03-31")
+
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert variables["filters"]["startDate"] == "2026-03-01"
+        assert variables["filters"]["endDate"] == "2026-03-31"
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_no_dates(self, mock_get_client):
+        """Test calling without date filters."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "byCategory": [],
+            "byCategoryGroup": [],
+            "byMerchant": [],
+            "summary": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        await get_spending_summary()
+
+        call_args = mock_client.gql_call.call_args
+        variables = call_args.kwargs["variables"]
+        assert "startDate" not in variables["filters"]
+        assert "endDate" not in variables["filters"]
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_empty_results(self, mock_get_client):
+        """Test handling of empty aggregate results."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "byCategory": [],
+            "byCategoryGroup": [],
+            "byMerchant": [],
+            "summary": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_spending_summary()
+
+        data = json.loads(result)
+        assert data["by_category"] == []
+        assert data["by_category_group"] == []
+        assert data["by_merchant"] == []
+        assert "total_income" not in data
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_sorts_by_absolute_value(self, mock_get_client):
+        """Test that categories are sorted by absolute sum descending."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "byCategory": [
+                {
+                    "groupBy": {
+                        "category": {
+                            "id": "c1",
+                            "name": "Small",
+                            "icon": None,
+                            "group": None,
+                        }
+                    },
+                    "summary": {"sum": -10.0},
+                },
+                {
+                    "groupBy": {
+                        "category": {
+                            "id": "c2",
+                            "name": "Large",
+                            "icon": None,
+                            "group": None,
+                        }
+                    },
+                    "summary": {"sum": -500.0},
+                },
+            ],
+            "byCategoryGroup": [],
+            "byMerchant": [],
+            "summary": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_spending_summary()
+
+        data = json.loads(result)
+        assert data["by_category"][0]["category"] == "Large"
+        assert data["by_category"][1]["category"] == "Small"
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_handles_null_category(self, mock_get_client):
+        """Test handling of null category in aggregates."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "byCategory": [
+                {
+                    "groupBy": {"category": None},
+                    "summary": {"sum": -25.0},
+                },
+            ],
+            "byCategoryGroup": [],
+            "byMerchant": [],
+            "summary": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_spending_summary()
+
+        data = json.loads(result)
+        assert data["by_category"][0]["category"] is None
+        assert data["by_category"][0]["sum"] == -25.0
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_handles_error(self, mock_get_client):
+        """Test error handling."""
+        mock_get_client.side_effect = RuntimeError("Auth needed")
+
+        result = await get_spending_summary()
+
+        data = json.loads(result)
+        assert data["error"] is True
+        assert "Auth needed" in data["message"]


### PR DESCRIPTION
## Summary

Three new tools for category management and budget trend analysis:

- **`update_category`**: Modify a category's name, icon, group, budget variability (`fixed`/`flexible`/`non_monthly`), and rollover settings. Uses the `Web_UpdateCategory` GraphQL mutation (not available in the monarchmoney library).
- **`get_category_details`**: Query a single category's full configuration plus budget amounts for a specific month (planned, actual, remaining, rollover carryover).
- **`get_cashflow_by_month`**: Spending by category broken down by month over a date range. Use for trend analysis; complements `get_spending_summary` which gives single-period totals.

All three use custom GraphQL via `gql_call`, following the same pattern as the merchant tools in PR #56.

## Motivation

The MCP server can create categories but cannot update them. Changing budget variability or enabling rollover currently requires using the Monarch web app directly. These GraphQL operations were identified by analyzing the Monarch web app's network traffic (HAR capture).

## Changes

- `src/monarch_mcp_server/tools/categories.py` — 3 new tools + GraphQL constants (+440 lines)
- `src/monarch_mcp_server/server.py` — re-export new functions in backward-compat shim
- `tests/test_categories.py` — 14 new tests across 3 test classes (+318 lines)

## Notes

- If #61 (read-only mode) merges, `update_category` should be added to the mutation guard list.
- `delete_transaction_category` is deferred — the library already has the method; a thin MCP wrapper is separate scope.

## Test plan

- [x] `pytest tests/test_categories.py -v` — 22 passed
- [x] `pytest` (full suite) — 176 passed, no regressions
- [ ] Manual smoke test against live Monarch account