### PR TITLE
Fix refresh_accounts crash and gql<4.0 dep conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 | `get_account_holdings` | Get investment holdings | `account_id` |
 | `create_transaction` | Create new transaction | `account_id`, `amount`, `description`, `date`, `category_id`, `merchant_name` |
 | `update_transaction` | Update existing transaction | `transaction_id`, `amount`, `description`, `category_id`, `date` |
-| `refresh_accounts` | Request account data refresh | None |
+| `refresh_accounts` | Request account data refresh | `account_ids` (optional — defaults to all active, visible accounts) |
 | `get_categories` | List all transaction categories | None |
 | `get_category_groups` | List category groups with categories | None |
 | `get_transactions_needing_review` | Get transactions needing review | `needs_review`, `days`, `uncategorized`, `no_notes` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.12,<3.14"
 dependencies = [
     "mcp[cli]>=1.10.0",
     "monarchmoneycommunity>=1.2.0",
-    "gql>=3.4,<4.0",
+    "gql>=3.4",
     "keyring>=24.0.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mcp[cli]>=1.10.0
 monarchmoneycommunity>=1.2.0
-gql>=3.4,<4.0
+gql>=3.4
 keyring>=24.0.0
 python-dotenv>=1.0.0
 pydantic>=2.0.0

--- a/src/monarch_mcp_server/tools/accounts.py
+++ b/src/monarch_mcp_server/tools/accounts.py
@@ -4,7 +4,7 @@ import json
 import logging
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from pydantic import RootModel, ValidationError
 
@@ -51,11 +51,30 @@ async def get_accounts() -> str:
 
 
 @mcp.tool()
-async def refresh_accounts() -> str:
-    """Request account data refresh from financial institutions."""
+async def refresh_accounts(account_ids: Optional[List[str]] = None) -> str:
+    """Request account data refresh from financial institutions.
+
+    Args:
+        account_ids: Specific account IDs to refresh. If omitted or empty,
+            refreshes all active, non-hidden accounts.
+    """
     try:
         client = await get_monarch_client()
-        result = await client.request_accounts_refresh()
+        if not account_ids:
+            accounts = await client.get_accounts()
+            account_ids = [
+                a["id"]
+                for a in accounts.get("accounts", [])
+                if (
+                    a.get("isActive", not a.get("deactivatedAt"))
+                    and not a.get("isHidden")
+                )
+            ]
+        if not account_ids:
+            return json_success(
+                {"refreshed": [], "message": "No active, visible accounts to refresh"}
+            )
+        result = await client.request_accounts_refresh(account_ids)
         return json_success(result)
     except Exception as e:
         return json_error("refresh_accounts", e)

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -74,13 +74,46 @@ class TestGetAccountHoldings:
 
 
 class TestRefreshAccounts:
-    async def test_refreshes_accounts(self):
+    async def test_auto_discovers_active_visible_accounts(self, mock_monarch_client):
+        """No args → fetch accounts, refresh only active+non-hidden ones."""
         result = json.loads(await refresh_accounts())
         assert result["requestAccountsRefresh"]["success"] is True
+        # Default fixture: acc-1 active+visible, acc-2 hidden. Only acc-1 refreshes.
+        mock_monarch_client.request_accounts_refresh.assert_awaited_once_with(["acc-1"])
+
+    async def test_passes_explicit_account_ids(self, mock_monarch_client):
+        """Explicit account_ids must be passed through unchanged."""
+        result = json.loads(await refresh_accounts(account_ids=["acc-9", "acc-42"]))
+        assert result["requestAccountsRefresh"]["success"] is True
+        mock_monarch_client.request_accounts_refresh.assert_awaited_once_with(
+            ["acc-9", "acc-42"]
+        )
+        # Must not have looked up accounts when caller specified the list.
+        mock_monarch_client.get_accounts.assert_not_called()
+
+    async def test_empty_list_falls_back_to_auto_discover(self, mock_monarch_client):
+        """An empty list is treated as 'refresh all visible', matching no-arg."""
+        await refresh_accounts(account_ids=[])
+        mock_monarch_client.request_accounts_refresh.assert_awaited_once_with(["acc-1"])
+
+    async def test_no_visible_accounts_returns_graceful_message(
+        self, mock_monarch_client
+    ):
+        """If every account is hidden or inactive, do not call the upstream API."""
+        mock_monarch_client.get_accounts.return_value = {
+            "accounts": [
+                {"id": "acc-h", "isHidden": True, "deactivatedAt": None},
+                {"id": "acc-d", "isHidden": False, "deactivatedAt": "2025-01-01"},
+            ]
+        }
+        result = json.loads(await refresh_accounts())
+        assert result["refreshed"] == []
+        assert "No active" in result["message"]
+        mock_monarch_client.request_accounts_refresh.assert_not_called()
 
     async def test_handles_api_error(self, mock_monarch_client):
         mock_monarch_client.request_accounts_refresh.side_effect = Exception("Timeout")
-        result = await refresh_accounts()
+        result = await refresh_accounts(account_ids=["acc-1"])
         assert "refresh_accounts" in result
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
-    { name = "gql", specifier = ">=3.4,<4.0" },
+    { name = "gql", specifier = ">=3.4" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "keyring", specifier = ">=24.0.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.10.0" },


### PR DESCRIPTION
## Summary

Two small, independent fixes addressing the two open bug reports.

- **#58** — `refresh_accounts` crashed with a `TypeError` because the upstream `request_accounts_refresh` requires an `account_ids` list. The tool now accepts an optional `account_ids` parameter; when omitted it auto-discovers active, non-hidden accounts via `get_accounts` and refreshes those. Graceful "no accounts to refresh" path when everything is hidden/inactive.
- **#60** — `monarchmoneycommunity` 1.3.2 pulls `gql>=4.0`, conflicting with the `<4.0` ceiling. Drops the upper bound. The codebase uses `gql` only via `from gql import gql` for query parsing, which is API-compatible across 3.x and 4.x.

## Test plan

- [x] `uv run pytest tests/` — 184/184 passing (was 181 + 3 new `refresh_accounts` tests)
- [x] No regressions in the rest of the suite
- [x] Two commits, one per issue, for clean bisect

Closes #58
Closes #60