### PR TITLE
feat(rules): support multiple merchant criteria values; fix delete false-error

### DIFF
--- a/src/monarch_mcp_server/tools/rules.py
+++ b/src/monarch_mcp_server/tools/rules.py
@@ -208,6 +208,7 @@ async def get_transaction_rules() -> str:
 async def create_transaction_rule(
     merchant_criteria_operator: Optional[str] = None,
     merchant_criteria_value: Optional[str] = None,
+    merchant_criteria_values: Optional[List[str]] = None,
     amount_operator: Optional[str] = None,
     amount_value: Optional[float] = None,
     amount_is_expense: bool = True,
@@ -256,11 +257,17 @@ async def create_transaction_rule(
             "applyToExistingTransactions": apply_to_existing,
         }
 
-        if merchant_criteria_operator and merchant_criteria_value:
-            rule_input["merchantNameCriteria"] = [{
-                "operator": merchant_criteria_operator,
-                "value": merchant_criteria_value,
-            }]
+        # Accept either a single merchant value or a list of values. When a
+        # list is given, build one criterion per value sharing the operator
+        # (defaults to "contains"). This lets one rule match many merchants.
+        _merchant_op = merchant_criteria_operator or "contains"
+        _merchant_values = [v for v in (merchant_criteria_values or []) if v]
+        if not _merchant_values and merchant_criteria_value:
+            _merchant_values = [merchant_criteria_value]
+        if _merchant_values:
+            rule_input["merchantNameCriteria"] = [
+                {"operator": _merchant_op, "value": v} for v in _merchant_values
+            ]
 
         if amount_operator and amount_value is not None:
             rule_input["amountCriteria"] = {
@@ -304,6 +311,7 @@ async def update_transaction_rule(
     rule_id: str,
     merchant_criteria_operator: Optional[str] = None,
     merchant_criteria_value: Optional[str] = None,
+    merchant_criteria_values: Optional[List[str]] = None,
     amount_operator: Optional[str] = None,
     amount_value: Optional[float] = None,
     amount_is_expense: bool = True,
@@ -344,11 +352,17 @@ async def update_transaction_rule(
             "applyToExistingTransactions": apply_to_existing,
         }
 
-        if merchant_criteria_operator and merchant_criteria_value:
-            rule_input["merchantNameCriteria"] = [{
-                "operator": merchant_criteria_operator,
-                "value": merchant_criteria_value,
-            }]
+        # Accept either a single merchant value or a list of values. When a
+        # list is given, build one criterion per value sharing the operator
+        # (defaults to "contains"). This lets one rule match many merchants.
+        _merchant_op = merchant_criteria_operator or "contains"
+        _merchant_values = [v for v in (merchant_criteria_values or []) if v]
+        if not _merchant_values and merchant_criteria_value:
+            _merchant_values = [merchant_criteria_value]
+        if _merchant_values:
+            rule_input["merchantNameCriteria"] = [
+                {"operator": _merchant_op, "value": v} for v in _merchant_values
+            ]
 
         if amount_operator and amount_value is not None:
             rule_input["amountCriteria"] = {
@@ -407,14 +421,20 @@ async def delete_transaction_rule(rule_id: str) -> str:
             variables={"id": rule_id},
         )
 
-        delete_result = result.get("deleteTransactionRule", {})
-        if delete_result.get("deleted"):
-            return json_success({"success": True, "message": "Rule deleted successfully"})
+        # Monarch's deleteTransactionRule can return a payload where the
+        # `deleted` flag is absent/null even when the deletion succeeded, which
+        # previously produced a false "Unknown error". Treat an explicit errors
+        # payload (or deleted == False) as failure; otherwise the mutation was
+        # accepted and the rule is gone.
+        delete_result = result.get("deleteTransactionRule") or {}
 
         errors = delete_result.get("errors")
         if errors:
             return json_success({"success": False, "errors": errors})
 
-        return json_success({"success": False, "message": "Unknown error"})
+        if delete_result.get("deleted") is False:
+            return json_success({"success": False, "message": "Rule was not deleted"})
+
+        return json_success({"success": True, "message": "Rule deleted successfully"})
     except Exception as e:
         return json_error("delete_transaction_rule", e)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -185,6 +185,51 @@ class TestCreateTransactionRule:
         assert data["success"] is False
         assert data["errors"] is not None
 
+    @patch('monarch_mcp_server.tools.rules.get_monarch_client')
+    async def test_create_rule_with_multiple_merchant_values(self, mock_get_client):
+        """Test creating a rule that matches multiple merchants in one rule."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "createTransactionRuleV2": {"errors": None}
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await create_transaction_rule(
+            merchant_criteria_operator="contains",
+            merchant_criteria_values=["american education services", "origin aes"],
+            set_category_id="cat_student_loans"
+        )
+
+        data = json.loads(result)
+        assert data["success"] is True
+
+        call_args = mock_client.gql_call.call_args
+        criteria = call_args.kwargs["variables"]["input"]["merchantNameCriteria"]
+        assert len(criteria) == 2
+        assert criteria[0] == {"operator": "contains", "value": "american education services"}
+        assert criteria[1] == {"operator": "contains", "value": "origin aes"}
+
+    @patch('monarch_mcp_server.tools.rules.get_monarch_client')
+    async def test_create_rule_multiple_values_default_operator(self, mock_get_client):
+        """merchant_criteria_values should default to the 'contains' operator."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "createTransactionRuleV2": {"errors": None}
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await create_transaction_rule(
+            merchant_criteria_values=["fnbo", "slice"]
+        )
+
+        data = json.loads(result)
+        assert data["success"] is True
+
+        call_args = mock_client.gql_call.call_args
+        criteria = call_args.kwargs["variables"]["input"]["merchantNameCriteria"]
+        assert [c["value"] for c in criteria] == ["fnbo", "slice"]
+        assert all(c["operator"] == "contains" for c in criteria)
+
 
 class TestUpdateTransactionRule:
     """Tests for update_transaction_rule tool."""
@@ -231,6 +276,29 @@ class TestUpdateTransactionRule:
 
         data = json.loads(result)
         assert data["success"] is False
+
+    @patch('monarch_mcp_server.tools.rules.get_monarch_client')
+    async def test_update_rule_with_multiple_merchant_values(self, mock_get_client):
+        """Test updating a rule to match multiple merchants in one rule."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateTransactionRuleV2": {"errors": None}
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await update_transaction_rule(
+            rule_id="rule_123",
+            merchant_criteria_operator="contains",
+            merchant_criteria_values=["courtyard", "hotel"],
+            set_category_id="cat_hotel"
+        )
+
+        data = json.loads(result)
+        assert data["success"] is True
+
+        call_args = mock_client.gql_call.call_args
+        criteria = call_args.kwargs["variables"]["input"]["merchantNameCriteria"]
+        assert [c["value"] for c in criteria] == ["courtyard", "hotel"]
 
 
 class TestDeleteTransactionRule:
@@ -281,3 +349,19 @@ class TestDeleteTransactionRule:
         data = json.loads(result)
         assert data["error"] is True
         assert "API error" in data["message"]
+
+    @patch('monarch_mcp_server.tools.rules.get_monarch_client')
+    async def test_delete_rule_success_without_deleted_flag(self, mock_get_client):
+        """Monarch omits the `deleted` flag on success; absence of errors
+        should be treated as a successful deletion, not 'Unknown error'."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "deleteTransactionRule": {"errors": None}
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await delete_transaction_rule(rule_id="rule_123")
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert "deleted" in data["message"].lower()


### PR DESCRIPTION
## Summary

Two improvements to the transaction-rule tools in `tools/rules.py`:

### 1. Multiple merchant criteria per rule
`create_transaction_rule` and `update_transaction_rule` now accept an optional `merchant_criteria_values` (list of strings). When provided, the tool builds one `merchantNameCriteria` entry per value, all sharing `merchant_criteria_operator` (defaults to `contains`). Monarch rules already support multiple merchant criteria — the tools just hardcoded a single entry — so this lets a single rule match many merchants (e.g. `netflix`, `paramount+`, `peacock`) instead of needing one rule per merchant.

The existing single-value `merchant_criteria_value` parameter is unchanged and fully backward compatible.

```python
create_transaction_rule(
    merchant_criteria_operator="contains",
    merchant_criteria_values=["american education services", "origin aes"],
    set_category_id="<student-loans-id>",
)
```

### 2. Fix `delete_transaction_rule` false "Unknown error"
`deleteTransactionRule` deletes the rule successfully but its payload can omit/null the `deleted` flag, which previously caused the tool to return `{"success": false, "message": "Unknown error"}` on every successful delete. Now only an explicit `errors` payload (or `deleted == False`) is treated as a failure; otherwise the delete is reported as success.

## Testing
- Verified backward compatibility: single-value rules still create/update correctly.
- Verified `merchant_criteria_values` produces multi-criteria rules (confirmed via `get_transaction_rules`).
- Verified deletes now report success and the rules are actually removed.
- `import monarch_mcp_server.tools.rules` passes.