### PR TITLE
Add save_token.py for non-interactive token-based authentication

### DIFF
--- a/save_token.py
+++ b/save_token.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Quick token-based login — pass your token as a command-line argument."""
+import asyncio, sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+from monarchmoney import MonarchMoney
+from monarch_mcp_server.secure_session import secure_session
+
+async def main():
+    if len(sys.argv) < 2:
+        print("Usage: uv run python save_token.py YOUR_TOKEN_HERE")
+        sys.exit(1)
+    token = sys.argv[1].strip()
+    mm = MonarchMoney(token=token)
+    print("Testing connection...")
+    accounts = await mm.get_accounts()
+    count = len(accounts.get("accounts", []))
+    print(f"✅ Connected! Found {count} accounts.")
+    secure_session.save_authenticated_session(mm)
+    print("✅ Session saved to keyring. You're all set!")
+
+asyncio.run(main())


### PR DESCRIPTION
## Summary

- Adds save_token.py, a lightweight CLI script that accepts a Monarch Money session token as a command-line argument and saves it to the system keyring
- Bypasses the getpass-based interactive prompts in login_setup.py that block paste in many terminal emulators
- Targets users who authenticate via Google/SSO and need to copy their token from the browser

## Motivation

login_setup.py uses getpass.getpass() for credential input, which disables paste in many terminal environments. Users signing in with Google/SSO have no fallback since they cannot type a long session token by hand. save_token.py sidesteps this entirely by accepting the token as a positional CLI argument so it can be pasted into the command before pressing enter.

## Usage

uv run python save_token.py YOUR_TOKEN_HERE

## Test plan
- Copy session token from app.monarchmoney.com Local Storage
- Run: uv run python save_token.py <token>
- Confirm Connected message with account count
- Confirm MCP get_accounts tool works after saving