### PR TITLE
Support current Monarch auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,10 @@ uv run python login_setup.py
 
 Follow the prompts:
 - Enter your Monarch Money email and password
+- Provide the email verification code if Monarch sends one (this can happen for a
+  new device or session even when MFA is not enabled)
 - Provide 2FA code if you have MFA enabled
-- Session will be saved automatically
+- The session token is saved automatically in your system keyring
 
 ### 3. Start Using
 
@@ -231,6 +233,7 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 
 ### 🔐 Secure Authentication
 - **One-Time Setup**: Authenticate once, use for weeks/months
+- **Email OTP Support**: Handles Monarch's email verification flow for new devices/sessions
 - **MFA Support**: Full support for two-factor authentication
 - **SSO/Google sign-in**: Use `monarch_login_with_token` to paste a session token from your browser
 - **Session Persistence**: No need to re-authenticate frequently
@@ -402,10 +405,16 @@ If you see "Authentication needed" errors:
 2. Restart Claude Desktop or Claude Code
 3. Try using a tool like `get_accounts`
 
+### Email Verification Required
+Monarch may require an email one-time code for a new device or session, even if MFA is not enabled. If you see an email-code prompt:
+1. Check the email address on your Monarch account
+2. Enter the one-time code in `login_setup.py`
+3. Let the script finish so it can save the reusable token to your system keyring
+
 ### Session Expired
 Sessions last for weeks, but if expired:
 1. Run the same setup command again: `python login_setup.py` (or `uv run python login_setup.py`)
-2. Enter your credentials and 2FA code
+2. Enter your credentials and any requested email verification or 2FA code
 3. Session will be refreshed automatically
 
 ### `'Context' object has no attribute 'elicit'`
@@ -419,6 +428,7 @@ Then fully quit and reopen Claude Desktop or Claude Code so it relaunches the se
 
 ### Common Error Messages
 - **"No valid session found"**: Run `python login_setup.py` (or `uv run python login_setup.py`) 
+- **"Monarch sent a one-time code to your email"**: Run `python login_setup.py` and complete email verification
 - **"Invalid account ID"**: Use `get_accounts` to see valid account IDs
 - **"Date format error"**: Use YYYY-MM-DD format for dates
 
@@ -429,23 +439,29 @@ Then fully quit and reopen Claude Desktop or Claude Code so it relaunches the se
 monarch-mcp-server/
 ├── src/monarch_mcp_server/
 │   ├── __init__.py
-│   └── server.py          # Main server implementation
-├── login_setup.py         # Email/password authentication script
+│   ├── app.py             # FastMCP app instance and entry point
+│   ├── client.py          # Cached MonarchMoney client factory
+│   ├── monarch_auth.py    # Current Monarch auth compatibility (host, email OTP, device-uuid)
+│   ├── secure_session.py  # Keyring-backed token storage (file fallback)
+│   ├── server.py          # Backward-compatibility shim re-exporting the tools
+│   └── tools/             # MCP tools grouped by domain (accounts, transactions, budgets, …)
+├── login_setup.py         # Terminal authentication script
 ├── pyproject.toml         # Project configuration
 ├── requirements.txt       # Dependencies
 └── README.md             # This documentation
 ```
 
 ### Session Management
-- Sessions are stored securely in `.mm/mm_session.pickle`
-- Automatic session discovery and loading
+- Session tokens are stored securely in the system keyring (with an automatic file fallback for environments without a keyring backend)
+- The `device-uuid` captured at login is stored alongside the token so it reloads cleanly
 - Sessions persist across Claude Desktop and Claude Code restarts
 - No need for frequent re-authentication
 
 ### Security Features
 - Credentials never transmitted through Claude Desktop or Claude Code
 - MFA/2FA fully supported
-- Session files are encrypted
+- Email verification codes are handled only in the terminal setup script
+- Session tokens are stored in the system keyring
 - Authentication handled in secure terminal environment
 
 ### Recommended: require approval for mutating tools

--- a/login_setup.py
+++ b/login_setup.py
@@ -8,8 +8,6 @@ import asyncio
 import os
 import getpass
 import shutil
-import inspect
-import traceback
 import sys
 from pathlib import Path
 
@@ -17,13 +15,15 @@ from pathlib import Path
 src_path = Path(__file__).parent / "src"
 sys.path.insert(0, str(src_path))
 
-from monarchmoney import MonarchMoney, RequireMFAException
-from dotenv import load_dotenv
+from monarchmoney import RequireMFAException
+from monarch_mcp_server.monarch_auth import (
+    EmailOtpRequiredException,
+    create_monarch_client,
+    login_with_current_auth,
+)
 from monarch_mcp_server.secure_session import secure_session
 
 async def main():
-    load_dotenv()
-    
     print("\n🏦 Monarch Money - Claude Desktop Setup")
     print("=" * 45)
     print("This will authenticate you once and save a session")
@@ -36,8 +36,8 @@ async def main():
     except Exception as e:
         print(f"⚠️  Could not check version: {e}")
     
-    mm = MonarchMoney()
-    
+    mm = None
+
     try:
         # Clear any existing sessions (both old pickle files and keyring)
         secure_session.delete_token()
@@ -81,27 +81,30 @@ async def main():
             if not token:
                 print("❌ No token provided. Exiting.")
                 return
-            # Re-initialize with the token so the Authorization header is set correctly.
-            # set_token() only stores the value but does not update _headers.
-            mm = MonarchMoney(token=token)
+            # Build the client with the current API host and device metadata so
+            # the saved session reloads cleanly later.
+            mm = create_monarch_client(token=token)
             print("✅ Token set")
         else:
             email = input("Email: ")
             password = getpass.getpass("Password: ")
 
-            # Try login without MFA first
+            # Try login without extra verification first.
             try:
-                await mm.login(email, password, use_saved_session=False, save_session=True)
+                mm = await login_with_current_auth(email, password)
                 print("✅ Login successful!")
+
+            except EmailOtpRequiredException:
+                print("📧 Monarch sent a verification code to your email.")
+                email_code = input("Email verification code: ").strip()
+                mm = await login_with_current_auth(email, password, email_otp=email_code)
+                print("✅ Email verification successful")
 
             except RequireMFAException:
                 print("🔐 MFA code required")
                 mfa_code = input("Two Factor Code: ")
-
-                # Use the same instance for MFA
-                await mm.multi_factor_authenticate(email, password, mfa_code)
+                mm = await login_with_current_auth(email, password, mfa_code=mfa_code)
                 print("✅ MFA authentication successful")
-                mm.save_session()  # Manually save the session
         
         # Test the connection first
         print("\nTesting connection...")
@@ -132,27 +135,34 @@ async def main():
                     print("🗑️ Cleared expired session files")
                 
                 # Try fresh login
-                mm_fresh = MonarchMoney()
                 try:
-                    await mm_fresh.login(email, password)
-                    print("✅ Fresh login successful (no MFA required)")
-                    mm = mm_fresh
-                    
+                    mm = await login_with_current_auth(email, password)
+                    print("✅ Fresh login successful (no extra verification required)")
+
                     # Test connection again
                     accounts = await mm.get_accounts()
                     if accounts and isinstance(accounts, dict):
                         account_count = len(accounts.get("accounts", []))
                         print(f"✅ Found {account_count} accounts")
-                    
+
+                except EmailOtpRequiredException:
+                    print("📧 Monarch sent a verification code to your email.")
+                    email_code = input("Email verification code: ").strip()
+                    mm = await login_with_current_auth(email, password, email_otp=email_code)
+                    print("✅ Fresh email verification successful")
+
+                    # Test connection again
+                    accounts = await mm.get_accounts()
+                    if accounts and isinstance(accounts, dict):
+                        account_count = len(accounts.get("accounts", []))
+                        print(f"✅ Found {account_count} accounts")
+
                 except RequireMFAException:
                     print("🔐 MFA required for fresh login")
                     mfa_code = input("Two Factor Code: ")
-                    
-                    mm_mfa_fresh = MonarchMoney()
-                    await mm_mfa_fresh.multi_factor_authenticate(email, password, mfa_code)
+                    mm = await login_with_current_auth(email, password, mfa_code=mfa_code)
                     print("✅ Fresh MFA authentication successful")
-                    mm = mm_mfa_fresh
-                    
+
                     # Test connection again
                     accounts = await mm.get_accounts()
                     if accounts and isinstance(accounts, dict):

--- a/src/monarch_mcp_server/app.py
+++ b/src/monarch_mcp_server/app.py
@@ -2,15 +2,17 @@
 
 import logging
 
-from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Load environment variables
-load_dotenv()
+# The gql aiohttp transport logs full GraphQL requests/responses at INFO, which
+# can include Monarch account payloads. Raise its floor to WARNING so those
+# payloads are not written to logs. Transport-level errors still surface; drop
+# this to INFO/DEBUG temporarily if you need to trace GraphQL traffic.
+logging.getLogger("gql.transport.aiohttp").setLevel(logging.WARNING)
 
 # Initialize FastMCP server
 mcp = FastMCP("Monarch Money MCP Server")

--- a/src/monarch_mcp_server/client.py
+++ b/src/monarch_mcp_server/client.py
@@ -1,18 +1,17 @@
 """Cached MonarchMoney client factory."""
 
-import os
 import logging
 from typing import Optional
 
 from monarchmoney import MonarchMoney
-from monarchmoney.monarchmoney import MonarchMoneyEndpoints
 
+from monarch_mcp_server.monarch_auth import configure_monarchmoney
 from monarch_mcp_server.secure_session import secure_session
 
 logger = logging.getLogger(__name__)
 
-# Patch MonarchMoney to use new API domain
-MonarchMoneyEndpoints.BASE_URL = "https://api.monarch.com"
+# Point the upstream package at Monarch's current API host.
+configure_monarchmoney()
 
 # Module-level client cache
 _cached_client: Optional[MonarchMoney] = None
@@ -26,37 +25,23 @@ def clear_client_cache() -> None:
 
 
 async def get_monarch_client() -> MonarchMoney:
-    """Get or create a cached MonarchMoney client using secure session storage."""
+    """Get or create a cached MonarchMoney client using secure session storage.
+
+    Authentication is established only via ``login_setup.py`` (or the
+    elicitation login tools), which save a session to the system keyring. MCP
+    tool calls never initiate a noninteractive password login, so a stray set
+    of environment credentials cannot trigger an unattended sign-in.
+    """
     global _cached_client
 
     if _cached_client is not None:
         return _cached_client
 
-    # Try to get authenticated client from secure session
     client = secure_session.get_authenticated_client()
 
     if client is not None:
         logger.info("Using authenticated client from secure keyring storage")
         _cached_client = client
         return client
-
-    # If no secure session, try environment credentials
-    email = os.getenv("MONARCH_EMAIL")
-    password = os.getenv("MONARCH_PASSWORD")
-
-    if email and password:
-        try:
-            client = MonarchMoney()
-            await client.login(email, password)
-            logger.info(
-                "Successfully logged into Monarch Money with environment credentials"
-            )
-            # Save the session securely
-            secure_session.save_authenticated_session(client)
-            _cached_client = client
-            return client
-        except Exception as e:
-            logger.error(f"Failed to login to Monarch Money: {e}")
-            raise
 
     raise RuntimeError("Authentication needed! Run: python login_setup.py")

--- a/src/monarch_mcp_server/monarch_auth.py
+++ b/src/monarch_mcp_server/monarch_auth.py
@@ -1,0 +1,156 @@
+"""Authentication compatibility for Monarch's current web API.
+
+Monarch changed its auth flow in May 2026:
+- API calls go to ``https://api.monarch.com`` (not ``api.monarchmoney.com``).
+- New/unrecognized sessions may require an email one-time code even when
+  account MFA is disabled, returned distinctly from a TOTP MFA challenge.
+- Reloading a saved token needs the same ``device-uuid`` used at login.
+
+This module wraps the upstream ``monarchmoney`` package with those changes
+instead of rewriting the MCP tools.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Optional
+from uuid import uuid4
+
+from aiohttp import ClientSession
+from monarchmoney import MonarchMoney, MonarchMoneyEndpoints, RequireMFAException
+from monarchmoney.monarchmoney import LoginFailedException
+
+
+CURRENT_API_BASE_URL = "https://api.monarch.com"
+
+# Captured from the monarch-core-web-app login request on 2026-06-23. Monarch
+# validates this against a server-side minimum; if logins begin failing with an
+# "app update required" / 403 error, recapture it from the web app (DevTools →
+# Network → any api.monarch.com request → request header
+# "monarch-client-version") and bump the value here.
+MONARCH_CLIENT_VERSION = "v1.0.1668"
+
+EMAIL_OTP_REQUIRED_MESSAGE = (
+    "Monarch sent a one-time code to your email. Run `python login_setup.py` "
+    "to complete email verification and save a reusable session token."
+)
+_EMAIL_OTP_RE = re.compile(r"email.*(?:code|otp)|(?:code|otp).*email", re.I)
+_MFA_RE = re.compile(r"mfa|multi.?factor|two.?factor|2fa|totp", re.I)
+
+
+class EmailOtpRequiredException(Exception):
+    """Raised when Monarch requires an email one-time code to continue login."""
+
+
+def configure_monarchmoney() -> None:
+    """Point the upstream monarchmoney package at Monarch's current API host."""
+    MonarchMoneyEndpoints.BASE_URL = CURRENT_API_BASE_URL
+
+
+def create_monarch_client(
+    token: Optional[str] = None, *, device_uuid: Optional[str] = None
+) -> MonarchMoney:
+    """Create a MonarchMoney client with current endpoint and web headers."""
+    configure_monarchmoney()
+    client = MonarchMoney(token=token)
+    client._headers.update(
+        {
+            "Origin": "https://app.monarch.com",
+            "device-uuid": device_uuid or str(uuid4()),
+            "monarch-client": "monarch-core-web-app-graphql",
+            "monarch-client-version": MONARCH_CLIENT_VERSION,
+        }
+    )
+    if token:
+        client._headers["Authorization"] = f"Token {token}"
+    return client
+
+
+def build_login_payload(
+    email: str,
+    password: str,
+    *,
+    email_otp: Optional[str] = None,
+    mfa_code: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a login payload compatible with current Monarch auth."""
+    payload: dict[str, Any] = {
+        "username": email,
+        "password": password,
+        "supports_mfa": True,
+        "supports_email_otp": True,
+        "supports_recaptcha": True,
+        "trusted_device": False,
+    }
+    if email_otp:
+        payload["email_otp"] = email_otp
+    if mfa_code:
+        payload["totp"] = mfa_code
+    return payload
+
+
+def is_email_otp_required(status: int, payload: dict[str, Any]) -> bool:
+    """Return whether a Monarch auth response is requesting email OTP."""
+    detail = str(payload.get("detail") or "")
+    error_code = str(payload.get("error_code") or "")
+    combined = f"{detail} {error_code}"
+    return error_code == "EMAIL_OTP_REQUIRED" or (
+        status == 403 and bool(_EMAIL_OTP_RE.search(combined))
+    )
+
+
+def _is_mfa_required(status: int, payload: dict[str, Any]) -> bool:
+    detail = str(payload.get("detail") or "")
+    error_code = str(payload.get("error_code") or "")
+    combined = f"{detail} {error_code}"
+    return error_code == "MFA_REQUIRED" or (
+        status == 403 and bool(_MFA_RE.search(combined))
+    )
+
+
+async def login_with_current_auth(
+    email: str,
+    password: str,
+    *,
+    email_otp: Optional[str] = None,
+    mfa_code: Optional[str] = None,
+) -> MonarchMoney:
+    """Log in using Monarch's current host and email-OTP-aware payload."""
+    client = create_monarch_client()
+    payload = build_login_payload(
+        email,
+        password,
+        email_otp=email_otp,
+        mfa_code=mfa_code,
+    )
+
+    async with ClientSession(headers=client._headers) as session:
+        async with session.post(
+            MonarchMoneyEndpoints.getLoginEndpoint(), json=payload
+        ) as response:
+            body_text = await response.text()
+            try:
+                body = json.loads(body_text) if body_text else {}
+            except json.JSONDecodeError:
+                body = {"detail": body_text}
+
+            if response.status != 200:
+                if is_email_otp_required(response.status, body):
+                    raise EmailOtpRequiredException(EMAIL_OTP_REQUIRED_MESSAGE)
+                if _is_mfa_required(response.status, body):
+                    raise RequireMFAException("Multi-Factor Auth Required")
+                message = (
+                    body.get("detail")
+                    or body.get("error_code")
+                    or f"HTTP Code {response.status}: {response.reason}"
+                )
+                raise LoginFailedException(str(message))
+
+            token = body.get("token")
+            if not token:
+                raise LoginFailedException("Login response did not include a token")
+
+            client.set_token(token)
+            client._headers["Authorization"] = f"Token {token}"
+            return client

--- a/src/monarch_mcp_server/secure_session.py
+++ b/src/monarch_mcp_server/secure_session.py
@@ -5,12 +5,15 @@ Uses the system keyring when available, with an automatic file-based
 fallback for environments without a keyring backend (e.g. WSL, headless Linux).
 """
 
+import json
 import logging
 import os
 import stat
 from pathlib import Path
 from typing import Optional
 from monarchmoney import MonarchMoney
+
+from monarch_mcp_server.monarch_auth import create_monarch_client
 
 logger = logging.getLogger(__name__)
 
@@ -90,40 +93,65 @@ class SecureMonarchSession:
 
     # -- public API ----------------------------------------------------------
 
-    def save_token(self, token: str) -> None:
-        """Save the authentication token to the system keyring or file fallback."""
+    def save_token(self, token: str, *, device_uuid: Optional[str] = None) -> None:
+        """Save the authentication session to the system keyring or file fallback.
+
+        The session is stored as a JSON blob so the ``device-uuid`` captured at
+        login can be restored when the token is reloaded — Monarch rejects a
+        token presented without its original device metadata.
+        """
+        session_data = {"token": token}
+        if device_uuid:
+            session_data["device_uuid"] = device_uuid
+        blob = json.dumps(session_data)
+
         if self._use_keyring:
             try:
                 import keyring
-                keyring.set_password(KEYRING_SERVICE, KEYRING_USERNAME, token)
+                keyring.set_password(KEYRING_SERVICE, KEYRING_USERNAME, blob)
                 logger.info("✅ Token saved securely to keyring")
                 self._cleanup_old_session_files()
                 return
             except Exception as e:
                 logger.warning(f"⚠️  Keyring save failed, falling back to file: {e}")
 
-        self._save_token_file(token)
+        self._save_token_file(blob)
         self._cleanup_old_session_files()
 
     def load_token(self) -> Optional[str]:
-        """Load the authentication token from the system keyring or file fallback."""
+        """Load just the authentication token from keyring or file fallback."""
+        session = self.load_session()
+        return session["token"] if session else None
+
+    def load_session(self) -> Optional[dict[str, str]]:
+        """Load the stored Monarch session (token plus device metadata).
+
+        Accepts both the current JSON blob and legacy raw-token entries written
+        before device-uuid storage was added.
+        """
+        raw_session = None
         if self._use_keyring:
             try:
                 import keyring
-                token = keyring.get_password(KEYRING_SERVICE, KEYRING_USERNAME)
-                if token:
-                    logger.info("✅ Token loaded from keyring")
-                    return token
-                else:
-                    logger.info("🔍 No token found in keyring")
-                    return None
+                raw_session = keyring.get_password(KEYRING_SERVICE, KEYRING_USERNAME)
             except Exception as e:
                 logger.warning(f"⚠️  Keyring load failed, trying file fallback: {e}")
 
-        token = self._load_token_file()
-        if token:
-            return token
-        logger.info("🔍 No token found")
+        if raw_session is None:
+            raw_session = self._load_token_file()
+
+        if not raw_session:
+            logger.info("🔍 No token found")
+            return None
+
+        logger.info("✅ Session loaded from secure storage")
+        try:
+            session = json.loads(raw_session)
+        except json.JSONDecodeError:
+            # Legacy entry: the stored value is the bare token string.
+            return {"token": raw_session}
+        if isinstance(session, dict) and session.get("token"):
+            return {str(k): str(v) for k, v in session.items() if v}
         return None
 
     def delete_token(self) -> None:
@@ -143,12 +171,14 @@ class SecureMonarchSession:
 
     def get_authenticated_client(self) -> Optional[MonarchMoney]:
         """Get an authenticated MonarchMoney client."""
-        token = self.load_token()
-        if not token:
+        session = self.load_session()
+        if not session:
             return None
 
         try:
-            client = MonarchMoney(token=token)
+            client = create_monarch_client(
+                token=session["token"], device_uuid=session.get("device_uuid")
+            )
             logger.info("✅ MonarchMoney client created with stored token")
             return client
         except Exception as e:
@@ -158,7 +188,7 @@ class SecureMonarchSession:
     def save_authenticated_session(self, mm: MonarchMoney) -> None:
         """Save the session from an authenticated MonarchMoney instance."""
         if mm.token:
-            self.save_token(mm.token)
+            self.save_token(mm.token, device_uuid=mm._headers.get("device-uuid"))
         else:
             logger.warning("⚠️  MonarchMoney instance has no token to save")
 

--- a/src/monarch_mcp_server/tools/auth.py
+++ b/src/monarch_mcp_server/tools/auth.py
@@ -25,6 +25,9 @@ Option 1: Elicitation login (Recommended for interactive clients)
 
 Option 2: Email/Password (Terminal)
    Run in terminal: python login_setup.py
+   Enter the email verification code if Monarch sends one (this can
+   happen for a new device/session even when MFA is off), and your
+   2FA code if MFA is enabled.
 
 Call 'monarch_logout' to clear the stored session.
 

--- a/src/monarch_mcp_server/tools/budgets.py
+++ b/src/monarch_mcp_server/tools/budgets.py
@@ -1,13 +1,117 @@
 """Budget tools."""
 
+import calendar
 import logging
-from typing import Any, Dict, Optional
+from datetime import date
+from typing import Any, Dict, List, Optional
+
+from gql import gql
+from monarchmoney import MonarchMoney
 
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
 from monarch_mcp_server.helpers import json_success, json_error
 
 logger = logging.getLogger(__name__)
+
+# The upstream SDK's get_budgets() requests category-group fields (e.g.
+# budgetVariability/rolloverPeriod) that Monarch's current API rejects for some
+# accounts, so it can fail outright. This narrower query asks only for fields
+# the current API still returns.
+BUDGET_QUERY = gql(
+    """
+    query MCPBudgetData($startDate: Date!, $endDate: Date!) {
+      budgetData(startMonth: $startDate, endMonth: $endDate) {
+        monthlyAmountsByCategory {
+          category {
+            id
+            __typename
+          }
+          monthlyAmounts {
+            month
+            plannedCashFlowAmount
+            plannedSetAsideAmount
+            actualAmount
+            remainingAmount
+            __typename
+          }
+          __typename
+        }
+        __typename
+      }
+      categoryGroups {
+        id
+        name
+        type
+        categories {
+          id
+          name
+          __typename
+        }
+        __typename
+      }
+    }
+    """
+)
+
+
+def current_month_range() -> tuple[str, str]:
+    """Return the current month bounds as ISO date strings."""
+    today = date.today()
+    last_day = calendar.monthrange(today.year, today.month)[1]
+    return today.replace(day=1).isoformat(), today.replace(day=last_day).isoformat()
+
+
+async def get_budget_data(
+    client: MonarchMoney,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Fetch budget data using fields supported by Monarch's current API."""
+    default_start, default_end = current_month_range()
+    return await client.gql_call(
+        operation="MCPBudgetData",
+        graphql_query=BUDGET_QUERY,
+        variables={
+            "startDate": start_date or default_start,
+            "endDate": end_date or default_end,
+        },
+    )
+
+
+def format_budget_data(budget_data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Format Monarch budget data into one row per category/month."""
+    category_lookup: Dict[str, Dict[str, Optional[str]]] = {}
+    for group in budget_data.get("categoryGroups", []):
+        for category in group.get("categories", []):
+            category_id = category.get("id")
+            if category_id:
+                category_lookup[category_id] = {
+                    "name": category.get("name"),
+                    "category_group": group.get("name"),
+                }
+
+    budget_rows = []
+    monthly_by_category = (
+        budget_data.get("budgetData", {}).get("monthlyAmountsByCategory", [])
+    )
+    for category_budget in monthly_by_category:
+        category_id = (category_budget.get("category") or {}).get("id")
+        category_info = category_lookup.get(category_id, {})
+        for monthly_amount in category_budget.get("monthlyAmounts", []):
+            budget_rows.append(
+                {
+                    "id": category_id,
+                    "name": category_info.get("name"),
+                    "planned": monthly_amount.get("plannedCashFlowAmount"),
+                    "actual": monthly_amount.get("actualAmount"),
+                    "remaining": monthly_amount.get("remainingAmount"),
+                    "category_group": category_info.get("category_group"),
+                    "month": monthly_amount.get("month"),
+                }
+            )
+
+    return budget_rows
 
 
 @mcp.tool()
@@ -19,16 +123,19 @@ async def get_budgets(
     Get budget information from Monarch Money.
 
     Args:
-        start_date: Start date in YYYY-MM-DD format (defaults to last month)
-        end_date: End date in YYYY-MM-DD format (defaults to next month)
+        start_date: Start month in YYYY-MM-DD format (defaults to the current month)
+        end_date: End month in YYYY-MM-DD format (defaults to the current month)
 
     Returns:
-        List of budgets with amounts, spent, and remaining for each category.
+        A JSON list with one row per budgeted category per month. Each row has:
+        ``id`` (category id), ``name`` (category name), ``planned`` (planned
+        cash-flow amount), ``actual`` (actual amount), ``remaining``,
+        ``category_group`` (group name), and ``month`` (YYYY-MM-DD).
     """
     try:
         client = await get_monarch_client()
-        budgets = await client.get_budgets(start_date=start_date, end_date=end_date)
-        return json_success(budgets)
+        budget_data = await get_budget_data(client, start_date, end_date)
+        return json_success(format_budget_data(budget_data))
     except Exception as e:
         return json_error("get_budgets", e)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,31 +93,48 @@ def mock_monarch_client():
         }
     }
 
-    client.get_budgets.return_value = {
+    # get_budgets now fetches via a custom GraphQL query (client.gql_call),
+    # matching the MCPBudgetData query in tools/budgets.py.
+    client.gql_call.return_value = {
         "budgetData": {
             "monthlyAmountsByCategory": [
                 {
-                    "category": {"id": "cat-1", "name": "Groceries"},
+                    "category": {"id": "cat-1"},
                     "monthlyAmounts": [
                         {
                             "month": "2026-03-01",
                             "plannedCashFlowAmount": 500.00,
-                            "actualCashFlowAmount": 320.00,
+                            "plannedSetAsideAmount": 0.00,
+                            "actualAmount": 320.00,
+                            "remainingAmount": 180.00,
                         }
                     ],
                 },
                 {
-                    "category": {"id": "cat-2", "name": "Dining Out"},
+                    "category": {"id": "cat-2"},
                     "monthlyAmounts": [
                         {
                             "month": "2026-03-01",
                             "plannedCashFlowAmount": 200.00,
-                            "actualCashFlowAmount": 185.00,
+                            "plannedSetAsideAmount": 0.00,
+                            "actualAmount": 185.00,
+                            "remainingAmount": 15.00,
                         }
                     ],
                 },
             ]
-        }
+        },
+        "categoryGroups": [
+            {
+                "id": "grp-1",
+                "name": "Food",
+                "type": "expense",
+                "categories": [
+                    {"id": "cat-1", "name": "Groceries"},
+                    {"id": "cat-2", "name": "Dining Out"},
+                ],
+            }
+        ],
     }
 
     client.get_cashflow.return_value = {

--- a/tests/test_budgets.py
+++ b/tests/test_budgets.py
@@ -6,26 +6,38 @@ from monarch_mcp_server.tools.budgets import get_budgets
 
 
 class TestGetBudgets:
-    async def test_returns_raw_budget_data(self):
+    async def test_returns_formatted_category_rows(self):
         result = json.loads(await get_budgets())
-        assert "budgetData" in result
-        categories = result["budgetData"]["monthlyAmountsByCategory"]
-        assert len(categories) == 2
-        assert categories[0]["category"]["name"] == "Groceries"
+        assert isinstance(result, list)
+        assert len(result) == 2
+        groceries = next(row for row in result if row["id"] == "cat-1")
+        assert groceries == {
+            "id": "cat-1",
+            "name": "Groceries",
+            "planned": 500.00,
+            "actual": 320.00,
+            "remaining": 180.00,
+            "category_group": "Food",
+            "month": "2026-03-01",
+        }
 
-    async def test_passes_date_params(self, mock_monarch_client):
+    async def test_passes_explicit_date_params(self, mock_monarch_client):
         await get_budgets(start_date="2026-03-01", end_date="2026-03-31")
-        mock_monarch_client.get_budgets.assert_called_once_with(
-            start_date="2026-03-01", end_date="2026-03-31"
-        )
+        _, kwargs = mock_monarch_client.gql_call.call_args
+        assert kwargs["variables"] == {
+            "startDate": "2026-03-01",
+            "endDate": "2026-03-31",
+        }
 
-    async def test_passes_none_dates_by_default(self, mock_monarch_client):
+    async def test_defaults_to_current_month(self, mock_monarch_client):
+        from monarch_mcp_server.tools.budgets import current_month_range
+
+        start, end = current_month_range()
         await get_budgets()
-        mock_monarch_client.get_budgets.assert_called_once_with(
-            start_date=None, end_date=None
-        )
+        _, kwargs = mock_monarch_client.gql_call.call_args
+        assert kwargs["variables"] == {"startDate": start, "endDate": end}
 
     async def test_handles_api_error(self, mock_monarch_client):
-        mock_monarch_client.get_budgets.side_effect = Exception("Budget error")
+        mock_monarch_client.gql_call.side_effect = Exception("Budget error")
         result = await get_budgets()
         assert "get_budgets" in result

--- a/tests/test_monarch_auth.py
+++ b/tests/test_monarch_auth.py
@@ -1,0 +1,80 @@
+from unittest.mock import patch
+
+from monarch_mcp_server.monarch_auth import (
+    EMAIL_OTP_REQUIRED_MESSAGE,
+    build_login_payload,
+    configure_monarchmoney,
+    create_monarch_client,
+    is_email_otp_required,
+)
+
+
+class _FakeMonarchMoney:
+    """Stand-in for MonarchMoney with a real headers dict (the test harness
+    mocks the real monarchmoney package, whose MagicMock _headers can't be
+    asserted on)."""
+
+    def __init__(self, token=None):
+        self.token = token
+        self._headers = {}
+
+    def set_token(self, token):
+        self.token = token
+
+
+def test_configure_monarchmoney_uses_current_api_host():
+    from monarchmoney import MonarchMoneyEndpoints
+
+    original_base_url = MonarchMoneyEndpoints.BASE_URL
+    try:
+        MonarchMoneyEndpoints.BASE_URL = "https://api.monarchmoney.com"
+
+        configure_monarchmoney()
+
+        assert MonarchMoneyEndpoints.BASE_URL == "https://api.monarch.com"
+    finally:
+        MonarchMoneyEndpoints.BASE_URL = original_base_url
+
+
+def test_login_payload_advertises_current_auth_capabilities():
+    payload = build_login_payload("user@example.com", "secret")
+
+    assert payload == {
+        "username": "user@example.com",
+        "password": "secret",
+        "supports_mfa": True,
+        "supports_email_otp": True,
+        "supports_recaptcha": True,
+        "trusted_device": False,
+    }
+
+
+def test_email_otp_payload_uses_email_otp_field_not_totp():
+    payload = build_login_payload("user@example.com", "secret", email_otp="123456")
+
+    assert payload["email_otp"] == "123456"
+    assert "totp" not in payload
+
+
+def test_email_otp_required_detects_monarch_email_code_response():
+    assert is_email_otp_required(
+        403,
+        {"detail": "Retrieve the code from your email to continue login."},
+    )
+
+
+def test_email_otp_message_is_actionable_for_mcp_users():
+    assert "email" in EMAIL_OTP_REQUIRED_MESSAGE.lower()
+    assert "login_setup.py" in EMAIL_OTP_REQUIRED_MESSAGE
+
+
+def test_create_client_restores_device_uuid_with_token():
+    with patch(
+        "monarch_mcp_server.monarch_auth.MonarchMoney", _FakeMonarchMoney
+    ):
+        client = create_monarch_client(
+            token="token-value", device_uuid="device-value"
+        )
+
+    assert client._headers["Authorization"] == "Token token-value"
+    assert client._headers["device-uuid"] == "device-value"

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -1,0 +1,21 @@
+import asyncio
+
+import pytest
+
+from monarch_mcp_server import client as client_module
+
+# Bind the real implementation at import time, before the autouse
+# patch_monarch_client fixture replaces the module attribute with a mock.
+from monarch_mcp_server.client import get_monarch_client as _real_get_monarch_client
+
+
+def test_get_monarch_client_requires_saved_session(monkeypatch):
+    """Without a saved keyring session, MCP calls must not attempt a login;
+    they raise and point the user at login_setup.py."""
+    client_module.clear_client_cache()
+    monkeypatch.setattr(
+        client_module.secure_session, "get_authenticated_client", lambda: None
+    )
+
+    with pytest.raises(RuntimeError, match="login_setup.py"):
+        asyncio.run(_real_get_monarch_client())

--- a/tests/test_server_budget.py
+++ b/tests/test_server_budget.py
@@ -1,0 +1,47 @@
+from monarch_mcp_server.tools.budgets import BUDGET_QUERY, format_budget_data
+
+
+def test_budget_query_avoids_stale_category_group_fields():
+    query_text = BUDGET_QUERY.loc.source.body
+
+    assert "budgetVariability" not in query_text
+    assert "rolloverPeriod" not in query_text
+
+
+def test_format_budget_data_returns_current_month_category_rows():
+    raw_budget_data = {
+        "budgetData": {
+            "monthlyAmountsByCategory": [
+                {
+                    "category": {"id": "cat-1"},
+                    "monthlyAmounts": [
+                        {
+                            "month": "2026-06-01",
+                            "plannedCashFlowAmount": -100,
+                            "plannedSetAsideAmount": 0,
+                            "actualAmount": -25,
+                            "remainingAmount": -75,
+                        }
+                    ],
+                }
+            ]
+        },
+        "categoryGroups": [
+            {
+                "name": "Food",
+                "categories": [{"id": "cat-1", "name": "Groceries"}],
+            }
+        ],
+    }
+
+    assert format_budget_data(raw_budget_data) == [
+        {
+            "id": "cat-1",
+            "name": "Groceries",
+            "planned": -100,
+            "actual": -25,
+            "remaining": -75,
+            "category_group": "Food",
+            "month": "2026-06-01",
+        }
+    ]


### PR DESCRIPTION
## Summary

Monarch's auth flow has changed in ways that break this MCP server's current setup:

- API calls should use `https://api.monarch.com`, not the old `https://api.monarchmoney.com` host.
- New/unrecognized sessions may require email OTP even when account MFA is disabled.
- The existing `monarchmoney` package misclassifies the email-code response as a generic 403/MFA-style failure.
- Reloading a saved token needs the same device UUID metadata used during login; saving only the raw token can produce `401 Unauthorized` on GraphQL calls.
- The upstream budget query asks for category-group fields that Monarch no longer accepts for this account, so `get_budgets` can fail even after auth is fixed.

This PR adds a small compatibility layer around the existing `monarchmoney` dependency instead of rewriting the MCP tools:

- patches `MonarchMoneyEndpoints.BASE_URL` to the current Monarch API host
- adds current web login payload fields: `supports_email_otp`, `supports_recaptcha`, and `email_otp`
- detects email OTP responses separately from TOTP MFA responses
- updates `login_setup.py` to prompt for email verification codes and save the resulting session to keyring
- stores token plus device UUID in keyring, while still accepting legacy raw-token entries
- creates stored-token clients with the current API host and saved device metadata
- keeps credential login inside `login_setup.py`; MCP tool calls now use only an existing keyring session and do not trigger noninteractive password-login attempts
- uses a narrower budget GraphQL query that avoids stale category-group fields and returns current-month category budget rows
- suppresses verbose GraphQL transport logging to avoid logging account payloads
- updates README auth/session docs

## Upstream context

Related upstream dependency issues:

- `hammem/monarchmoney#184`: API domain changed to `api.monarch.com`
- `hammem/monarchmoney#196`: first non-interactive auth attempt returns 429; commenters report the new host fixes that part
- `hammem/monarchmoney#137`: app update warning / auth 403 is misclassified as MFA

The TypeScript `@hakimelek/monarchmoney` package documents the same current behavior: Monarch may require email OTP for new devices/sessions even when MFA is off, and the OTP is submitted as `email_otp`.

## Verification

```bash
uv run --with-editable . --with pytest python -m pytest -q
uv run python -m py_compile src/monarch_mcp_server/config.py src/monarch_mcp_server/monarch_auth.py src/monarch_mcp_server/secure_session.py src/monarch_mcp_server/server.py login_setup.py
uv run --with 'mcp[cli]' --with-editable . mcp run src/monarch_mcp_server/server.py
```

Additional local smoke verification completed:

- `login_setup.py` loaded credentials from `.env.local`
- email OTP flow completed successfully
- setup fetched accounts during verification
- session was saved to keyring
- a fresh Python process loaded the saved keyring session successfully
- fresh-process smoke checks passed for auth status, accounts, one transaction, budgets, cashflow, and holdings
- Codex MCP tool calls for auth status, accounts, transactions, and cashflow succeeded after keyring renewal
