### PR TITLE
Fix keyring detection on macOS storing token as plaintext

### DIFF
--- a/src/monarch_mcp_server/secure_session.py
+++ b/src/monarch_mcp_server/secure_session.py
@@ -23,36 +23,32 @@ _TOKEN_DIR = Path.home() / ".monarch-mcp-server"
 _TOKEN_FILE = _TOKEN_DIR / "token"
 
 
+_PROBE_USERNAME = "__keyring_probe__"
+
+
 def _keyring_available() -> bool:
-    """Check whether a usable keyring backend is available."""
+    """Probe whether the active keyring backend can actually round-trip a value.
+
+    Class-name sniffing is unreliable: the macOS Keychain backend
+    (`keyring.backends.macOS.Keyring`) and the no-op fail backend
+    (`keyring.backends.fail.Keyring`) share the class name `Keyring`, so a
+    name-based check rejects real macOS keyrings and silently falls back to
+    plaintext file storage. We instead set + get + delete a sentinel value
+    and trust the backend only if every step succeeds.
+    """
     try:
         import keyring
-        backend = keyring.get_keyring()
-        # The fail backend means no real backend was found
-        from keyrings.alt import file as _  # noqa: F401 – probe import
-        # If we get here, keyrings.alt is installed but may be the only option.
-        # Fall through and check the backend name.
     except ImportError:
-        pass
+        return False
 
     try:
-        import keyring
-        backend = keyring.get_keyring()
-        backend_name = type(backend).__name__
-        # These backends indicate no real keyring is available
-        if backend_name in ("Keyring", "NullKeyring", "FailKeyring", "ChainerBackend"):
-            # ChainerBackend may wrap a real backend — try a round-trip test
-            if backend_name == "ChainerBackend":
-                try:
-                    keyring.set_password(KEYRING_SERVICE, "__probe__", "1")
-                    keyring.delete_password(KEYRING_SERVICE, "__probe__")
-                    return True
-                except Exception:
-                    return False
-            return False
-        return True
+        keyring.set_password(KEYRING_SERVICE, _PROBE_USERNAME, "1")
+        stored = keyring.get_password(KEYRING_SERVICE, _PROBE_USERNAME)
+        keyring.delete_password(KEYRING_SERVICE, _PROBE_USERNAME)
     except Exception:
         return False
+
+    return stored == "1"
 
 
 class SecureMonarchSession:

--- a/tests/test_secure_session.py
+++ b/tests/test_secure_session.py
@@ -1,0 +1,137 @@
+"""Tests for keyring backend detection and secure session storage."""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from monarch_mcp_server import secure_session as ss_module
+from monarch_mcp_server.secure_session import _keyring_available
+
+
+class _FakeKeyring:
+    """Minimal stand-in for the `keyring` module used by detection tests."""
+
+    def __init__(
+        self,
+        *,
+        set_raises=None,
+        get_returns=None,
+        get_raises=None,
+        delete_raises=None,
+    ):
+        self._set_raises = set_raises
+        self._get_returns = get_returns
+        self._get_raises = get_raises
+        self._delete_raises = delete_raises
+        self.set_calls = []
+        self.get_calls = []
+        self.delete_calls = []
+
+    def set_password(self, service, username, value):
+        self.set_calls.append((service, username, value))
+        if self._set_raises:
+            raise self._set_raises
+
+    def get_password(self, service, username):
+        self.get_calls.append((service, username))
+        if self._get_raises:
+            raise self._get_raises
+        return self._get_returns
+
+    def delete_password(self, service, username):
+        self.delete_calls.append((service, username))
+        if self._delete_raises:
+            raise self._delete_raises
+
+
+@pytest.fixture
+def install_fake_keyring(monkeypatch):
+    """Replace the importable `keyring` module with a controllable fake."""
+
+    def _install(fake):
+        module = types.ModuleType("keyring")
+        module.set_password = fake.set_password
+        module.get_password = fake.get_password
+        module.delete_password = fake.delete_password
+        monkeypatch.setitem(sys.modules, "keyring", module)
+        return fake
+
+    return _install
+
+
+class TestKeyringAvailable:
+    def test_returns_true_when_probe_round_trips(self, install_fake_keyring):
+        """A real backend (set + get returns same value + delete) is accepted."""
+        fake = install_fake_keyring(_FakeKeyring(get_returns="1"))
+        assert _keyring_available() is True
+        assert len(fake.set_calls) == 1
+        assert len(fake.get_calls) == 1
+        assert len(fake.delete_calls) == 1
+
+    def test_macos_keychain_class_name_collision_is_handled(
+        self, install_fake_keyring
+    ):
+        """The macOS Keychain and fail backends share the class name `Keyring`.
+
+        Previously this caused real macOS keyrings to be rejected by name and
+        tokens to be written to a plaintext file. The probe roundtrip ignores
+        class names entirely and only trusts what the backend can actually do.
+        """
+        fake = install_fake_keyring(_FakeKeyring(get_returns="1"))
+        # Simulate the macOS Keychain class name to prove name has no effect.
+        fake.__class__.__name__ = "Keyring"
+        assert _keyring_available() is True
+
+    def test_returns_false_when_set_raises(self, install_fake_keyring):
+        """The fail backend raises on set_password — we must NOT trust it."""
+        install_fake_keyring(_FakeKeyring(set_raises=RuntimeError("no backend")))
+        assert _keyring_available() is False
+
+    def test_returns_false_when_get_returns_none(self, install_fake_keyring):
+        """A backend that silently drops writes is not safe to use."""
+        install_fake_keyring(_FakeKeyring(get_returns=None))
+        assert _keyring_available() is False
+
+    def test_returns_false_when_get_returns_wrong_value(self, install_fake_keyring):
+        """A backend that corrupts the round-trip is not safe to use."""
+        install_fake_keyring(_FakeKeyring(get_returns="not-the-probe-value"))
+        assert _keyring_available() is False
+
+    def test_returns_false_when_get_raises(self, install_fake_keyring):
+        install_fake_keyring(
+            _FakeKeyring(set_raises=None, get_raises=RuntimeError("read failed"))
+        )
+        assert _keyring_available() is False
+
+    def test_returns_false_when_delete_raises(self, install_fake_keyring):
+        """Delete failure means cleanup is broken; don't trust the backend."""
+        install_fake_keyring(
+            _FakeKeyring(get_returns="1", delete_raises=RuntimeError("rm failed"))
+        )
+        assert _keyring_available() is False
+
+    def test_returns_false_when_keyring_not_installed(self, monkeypatch):
+        """If the keyring package is absent, treat as unavailable, don't crash."""
+
+        real_import = __builtins__["__import__"] if isinstance(
+            __builtins__, dict
+        ) else __builtins__.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "keyring":
+                raise ImportError("no keyring installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", fake_import)
+        assert _keyring_available() is False
+
+    def test_probe_uses_dedicated_username(self, install_fake_keyring):
+        """The probe must not clobber the real token username."""
+        fake = install_fake_keyring(_FakeKeyring(get_returns="1"))
+        _keyring_available()
+        for _service, username, _value in fake.set_calls:
+            assert username != ss_module.KEYRING_USERNAME
+        for _service, username in fake.get_calls:
+            assert username != ss_module.KEYRING_USERNAME


### PR DESCRIPTION
## Summary

Fixes #70. `_keyring_available()` rejected backends by class name, but `keyring.backends.macOS.Keyring` (the real Keychain) and `keyring.backends.fail.Keyring` (the no-op fallback sentinel) share the class name `Keyring`. Result: every macOS install was misclassified, silently fell back to writing the session token to `~/.monarch-mcp-server/token` as plaintext (chmod 600), contradicting the README's claim that "session files are encrypted."

Replaces the brittle class-name sniffing with a probe roundtrip: `set_password` + `get_password` + `delete_password` against a dedicated `__keyring_probe__` username. Only trust the backend if every step succeeds and the value round-trips correctly.

## Security impact

- macOS users: tokens move from plaintext file to the system Keychain on next launch.
- No data migration. The existing file-based token (if present) is read on first call after upgrade and re-saved via the new keyring-aware path through `save_authenticated_session`.
- Probe writes a non-secret sentinel under a dedicated username so it can never collide with a real token.

## Test plan

- [x] `uv run pytest tests/test_secure_session.py -v` — 9/9 passing (new file).
- [x] `uv run pytest tests/` — 197/197 passing.
- [x] Live verified on macOS: `_keyring_available()` returns True against the real Keychain (was False before the fix).

Closes #70