### PR TITLE
Add browser cookie auth and fix short-lived token bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,28 +135,40 @@ My MonarchMoney referral: https://www.monarchmoney.com/referral/ufmn0r83yf?r_sou
 
 **Important**: For security and MFA support, authentication is done outside of Claude.
 
-#### Option A: Email/Password Login
+Open a terminal and run:
 
-Open Terminal and run:
-
-**Using `python`**:
 ```bash
 cd /path/to/your/monarch-mcp-server
-python login_setup.py
+uv run python login_setup.py        # or: python login_setup.py
 ```
 
-**Using `uv`**:
-```bash
-cd /path/to/your/monarch-mcp-server
-uv run python login_setup.py
-```
+The script offers three login paths:
 
-Follow the prompts:
-- Enter your Monarch Money email and password
-- Provide the email verification code if Monarch sends one (this can happen for a
-  new device or session even when MFA is not enabled)
-- Provide 2FA code if you have MFA enabled
-- The session token is saved automatically in your system keyring
+#### Option 1 (recommended): Session cookies from your browser
+
+Long-lived sessions, supports SSO accounts, and sidesteps Cloudflare CAPTCHA gates on programmatic login. Steps:
+
+1. Log in to https://app.monarch.com in Chrome or Firefox.
+2. Open DevTools (F12) → Network tab.
+3. Click any request whose Name starts with `graphql` (or any request to `api.monarch.com`).
+4. Scroll to Request Headers, find the `cookie:` header, and copy the full value.
+5. Paste it into the prompt.
+
+The script verifies the cookies against the live API before saving them to your system keyring.
+
+#### Option 2: Email and password
+
+Standard interactive login. The script handles:
+
+- Email verification codes (Monarch may send one for a new device session even when MFA is off).
+- TOTP MFA codes if you have MFA enabled.
+- Cloudflare CAPTCHA detection: if Monarch blocks programmatic login, the script tells you to switch to option 1.
+
+The resulting long-lived session token is saved to your system keyring.
+
+#### Option 3: Legacy session token paste
+
+Kept for users with an existing token captured before the May 2026 API change. Monarch may no longer accept token-only auth on the GraphQL endpoint; if the verification call returns 401, fall back to option 1.
 
 ### 3. Start Using
 
@@ -411,11 +423,11 @@ Monarch may require an email one-time code for a new device or session, even if 
 2. Enter the one-time code in `login_setup.py`
 3. Let the script finish so it can save the reusable token to your system keyring
 
-### Session Expired
-Sessions last for weeks, but if expired:
-1. Run the same setup command again: `python login_setup.py` (or `uv run python login_setup.py`)
-2. Enter your credentials and any requested email verification or 2FA code
-3. Session will be refreshed automatically
+### Session Expired or 401 within an hour
+If your session dies quickly (under a couple of hours), the most common cause is that Monarch returned a short-lived token. The login script now requests `trusted_device=True` and rejects any short-lived token, so a fresh login produces a long-lived session. If you re-run `login_setup.py` and the issue persists, switch to option 1 (browser cookies); cookie sessions track the lifetime of the underlying browser login.
+
+### Cloudflare CAPTCHA on login
+If `login_setup.py` reports "Programmatic login is blocked by Cloudflare CAPTCHA", choose option 1 (browser cookies) instead. Email/password POSTs to Monarch's login endpoint are sometimes gated by Cloudflare for unfamiliar IPs or rapid retries; cookie-based auth bypasses that endpoint entirely.
 
 ### `'Context' object has no attribute 'elicit'`
 The `monarch_login` and `monarch_login_with_token` tools require the MCP Python SDK 1.10.0 or newer (released June 2025). If your environment cached an older `mcp` install, refresh it:

--- a/login_setup.py
+++ b/login_setup.py
@@ -1,200 +1,193 @@
 #!/usr/bin/env python3
 """
-Standalone script to perform interactive Monarch Money login with MFA support.
-Run this script to authenticate and save a session file that the MCP server can use.
+Standalone script to perform interactive Monarch Money login.
+
+Supports three auth paths in order of recommendation:
+
+1. Session cookies pasted from a logged-in browser. Long-lived, works
+   for all account types including SSO, sidesteps Cloudflare CAPTCHA.
+2. Email and password (with optional email OTP and MFA prompts). Now
+   requests a long-lived session token from Monarch.
+3. Legacy session token paste. Kept for users with a working token
+   captured under the old auth model.
 """
 
 import asyncio
-import os
 import getpass
-import shutil
 import sys
 from pathlib import Path
 
-# Add the src directory to the Python path for imports
 src_path = Path(__file__).parent / "src"
 sys.path.insert(0, str(src_path))
 
-from monarchmoney import RequireMFAException
+from monarchmoney import CaptchaRequiredException, RequireMFAException
 from monarch_mcp_server.monarch_auth import (
     EmailOtpRequiredException,
     create_monarch_client,
+    login_with_browser_cookies,
     login_with_current_auth,
 )
 from monarch_mcp_server.secure_session import secure_session
+
+
+async def _login_with_cookies():
+    print("\n📋 To copy the right cookie string:")
+    print("  1. Log in to https://app.monarch.com in Chrome or Firefox")
+    print("  2. Open DevTools (F12) → Network tab")
+    print("  3. Click any request whose Name starts with 'graphql'")
+    print("     (or any request to api.monarch.com)")
+    print("  4. Scroll to 'Request Headers' and find the 'cookie:' header")
+    print("  5. Copy the full value (a long string of key=value; pairs)")
+    print()
+    cookie_string = getpass.getpass("Paste the Cookie header value: ").strip()
+    if not cookie_string:
+        print("❌ No cookie string provided. Exiting.")
+        return None
+    try:
+        mm = await login_with_browser_cookies(cookie_string)
+        print("✅ Cookie login successful")
+        return mm
+    except Exception as e:
+        print(f"❌ Cookie login failed: {e}")
+        return None
+
+
+async def _login_with_password():
+    email = input("Email: ").strip()
+    password = getpass.getpass("Password: ")
+    try:
+        mm = await login_with_current_auth(email, password)
+        print("✅ Login successful")
+        return mm
+    except CaptchaRequiredException as e:
+        print(f"❌ {e}")
+        print("Re-run this script and choose option 1 (session cookies).")
+        return None
+    except EmailOtpRequiredException:
+        print("📧 Monarch sent a verification code to your email.")
+        code = input("Email verification code: ").strip()
+        if not code:
+            print("❌ No code provided. Exiting.")
+            return None
+        try:
+            mm = await login_with_current_auth(email, password, email_otp=code)
+        except RequireMFAException:
+            mfa_code = input("Two Factor Code: ").strip()
+            mm = await login_with_current_auth(
+                email, password, email_otp=code, mfa_code=mfa_code
+            )
+        print("✅ Email verification successful")
+        return mm
+    except RequireMFAException:
+        mfa_code = input("Two Factor Code: ").strip()
+        if not mfa_code:
+            print("❌ No MFA code provided. Exiting.")
+            return None
+        mm = await login_with_current_auth(email, password, mfa_code=mfa_code)
+        print("✅ MFA authentication successful")
+        return mm
+
+
+def _login_with_legacy_token():
+    print("\n📋 To get a legacy session token:")
+    print("  1. Log in to https://app.monarch.com in Chrome or Firefox")
+    print("  2. DevTools (F12) → Application tab → Local Storage")
+    print("     → https://app.monarch.com → key 'token'")
+    print("  3. Copy the value")
+    print()
+    print(
+        "⚠️  Monarch may no longer accept Authorization: Token auth on the "
+        "GraphQL endpoint. If the test call below fails with 401, re-run "
+        "this script and choose option 1 (cookies) instead."
+    )
+    token = getpass.getpass("Paste your session token: ").strip()
+    if not token:
+        print("❌ No token provided. Exiting.")
+        return None
+    mm = create_monarch_client(token=token)
+    print("✅ Token configured")
+    return mm
+
 
 async def main():
     print("\n🏦 Monarch Money - Claude Desktop Setup")
     print("=" * 45)
     print("This will authenticate you once and save a session")
     print("for seamless access through Claude Desktop.\n")
-    
-    # Check the version first
+
     try:
         import monarchmoney
-        print(f"📦 MonarchMoney version: {getattr(monarchmoney, '__version__', 'unknown')}")
+        print(
+            f"📦 MonarchMoney version: "
+            f"{getattr(monarchmoney, '__version__', 'unknown')}"
+        )
     except Exception as e:
         print(f"⚠️  Could not check version: {e}")
-    
-    mm = None
 
     try:
-        # Clear any existing sessions (both old pickle files and keyring)
         secure_session.delete_token()
         print("🗑️ Cleared existing secure sessions")
-        
-        # Ask about MFA setup
-        print("\n🔐 Security Check:")
-        has_mfa = input("Do you have MFA (Multi-Factor Authentication) enabled on your Monarch Money account? (y/n): ").strip().lower()
-        
-        if has_mfa not in ['y', 'yes']:
-            print("\n⚠️  SECURITY RECOMMENDATION:")
-            print("=" * 50)
-            print("You should enable MFA for your Monarch Money account.")
-            print("MFA adds an extra layer of security to protect your financial data.")
-            print("\nTo enable MFA:")
-            print("1. Log into Monarch Money at https://monarchmoney.com")
-            print("2. Go to Settings → Security")
-            print("3. Enable Two-Factor Authentication")
-            print("4. Follow the setup instructions\n")
-            
-            proceed = input("Continue with login anyway? (y/n): ").strip().lower()
-            if proceed not in ['y', 'yes']:
-                print("Login cancelled. Please set up MFA and try again.")
-                return
-        
-        print("\nStarting login...")
+
         print("\nHow do you sign in to Monarch Money?")
-        print("  1) Email and password")
-        print("  2) Google / SSO (single sign-on)")
-        login_method = input("Choice (1 or 2): ").strip()
+        print(
+            "  1) Session cookies from browser   "
+            "(recommended: long-lived, supports SSO)"
+        )
+        print("  2) Email and password")
+        print("  3) Legacy session token paste")
+        choice = input("Choice [1]: ").strip() or "1"
 
-        if login_method == "2":
-            print("\n📋 To get your session token from the browser:")
-            print("  1. Log in to https://app.monarchmoney.com in Chrome/Firefox")
-            print("  2. Open DevTools (F12) → Application tab → Local Storage")
-            print("     → https://app.monarchmoney.com")
-            print("  3. Copy the value for the key 'token'")
-            print("     (Alternatively: DevTools → Network tab, filter any request,")
-            print("      look for 'Authorization: Token <value>' in request headers)")
-            token = getpass.getpass("\nPaste your session token: ").strip()
-            if not token:
-                print("❌ No token provided. Exiting.")
-                return
-            # Build the client with the current API host and device metadata so
-            # the saved session reloads cleanly later.
-            mm = create_monarch_client(token=token)
-            print("✅ Token set")
+        mm = None
+        if choice == "1":
+            mm = await _login_with_cookies()
+        elif choice == "2":
+            mm = await _login_with_password()
+        elif choice == "3":
+            mm = _login_with_legacy_token()
         else:
-            email = input("Email: ")
-            password = getpass.getpass("Password: ")
+            print(f"❌ Unrecognized choice: {choice!r}. Exiting.")
+            return
 
-            # Try login without extra verification first.
-            try:
-                mm = await login_with_current_auth(email, password)
-                print("✅ Login successful!")
+        if mm is None:
+            return
 
-            except EmailOtpRequiredException:
-                print("📧 Monarch sent a verification code to your email.")
-                email_code = input("Email verification code: ").strip()
-                mm = await login_with_current_auth(email, password, email_otp=email_code)
-                print("✅ Email verification successful")
-
-            except RequireMFAException:
-                print("🔐 MFA code required")
-                mfa_code = input("Two Factor Code: ")
-                mm = await login_with_current_auth(email, password, mfa_code=mfa_code)
-                print("✅ MFA authentication successful")
-        
-        # Test the connection first
         print("\nTesting connection...")
         try:
-            # Try a simple test call that should work
-            print("Calling get_accounts()...")
             accounts = await mm.get_accounts()
-            print(f"Response received: {type(accounts)}")
             if accounts and isinstance(accounts, dict):
                 account_count = len(accounts.get("accounts", []))
                 print(f"✅ Found {account_count} accounts")
             else:
-                print("❌ No accounts data returned or unexpected format")
-                print(f"Response type: {type(accounts)}")
-                print(f"Response content: {accounts}")
+                print(f"❌ Unexpected accounts response: {type(accounts)}")
                 return
         except Exception as test_error:
             print(f"❌ Connection test failed: {test_error}")
-            print(f"Error type: {type(test_error)}")
-            
-            # Check if it's a session issue
-            if "session" in str(test_error).lower() or "expired" in str(test_error).lower():
-                print("Session may be expired. Clearing old session and trying fresh login...")
-                
-                # Clear old session and try fresh login
-                if os.path.exists(".mm"):
-                    shutil.rmtree(".mm")
-                    print("🗑️ Cleared expired session files")
-                
-                # Try fresh login
-                try:
-                    mm = await login_with_current_auth(email, password)
-                    print("✅ Fresh login successful (no extra verification required)")
+            print(f"Error type: {type(test_error).__name__}")
+            print(
+                "\nIf this looks like 401 Unauthorized, the cookie or token "
+                "is invalid. Re-run this script."
+            )
+            return
 
-                    # Test connection again
-                    accounts = await mm.get_accounts()
-                    if accounts and isinstance(accounts, dict):
-                        account_count = len(accounts.get("accounts", []))
-                        print(f"✅ Found {account_count} accounts")
-
-                except EmailOtpRequiredException:
-                    print("📧 Monarch sent a verification code to your email.")
-                    email_code = input("Email verification code: ").strip()
-                    mm = await login_with_current_auth(email, password, email_otp=email_code)
-                    print("✅ Fresh email verification successful")
-
-                    # Test connection again
-                    accounts = await mm.get_accounts()
-                    if accounts and isinstance(accounts, dict):
-                        account_count = len(accounts.get("accounts", []))
-                        print(f"✅ Found {account_count} accounts")
-
-                except RequireMFAException:
-                    print("🔐 MFA required for fresh login")
-                    mfa_code = input("Two Factor Code: ")
-                    mm = await login_with_current_auth(email, password, mfa_code=mfa_code)
-                    print("✅ Fresh MFA authentication successful")
-
-                    # Test connection again
-                    accounts = await mm.get_accounts()
-                    if accounts and isinstance(accounts, dict):
-                        account_count = len(accounts.get("accounts", []))
-                        print(f"✅ Found {account_count} accounts")
-            else:
-                print("This appears to be an API compatibility issue.")
-                print("The MonarchMoney library API may have changed.")
-                print("Try updating the library: pip install --upgrade monarchmoneycommunity")
-                return
-        
-        # Save session securely to keyring
         try:
-            print(f"\n🔐 Saving session securely to system keyring...")
+            print("\n🔐 Saving session securely to system keyring...")
             secure_session.save_authenticated_session(mm)
-            print(f"✅ Session saved securely to keyring!")
-                
+            print("✅ Session saved")
         except Exception as save_error:
-            print(f"❌ Could not save session to keyring: {save_error}")
-            print("You may need to run the login again.")
-        
-        print("\n🎉 Setup complete! You can now use these tools in Claude Desktop:")
-        print("   • get_accounts - View all your accounts")  
+            print(f"❌ Could not save session: {save_error}")
+            return
+
+        print("\n🎉 Setup complete. Restart Claude Desktop to pick up the session.")
+        print("\n💡 Useful tools in Claude:")
+        print("   • get_accounts - View all your accounts")
         print("   • get_transactions - Recent transactions")
         print("   • get_budgets - Budget information")
         print("   • get_cashflow - Income/expense analysis")
-        print("\n💡 Session will persist across Claude restarts!")
-        
+
     except Exception as e:
         print(f"\n❌ Login failed: {e}")
-        print("\nPlease check your credentials and try again.")
-        print(f"Error type: {type(e)}")
+        print(f"Error type: {type(e).__name__}")
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "mcp[cli]>=1.10.0",
-    "monarchmoneycommunity>=1.2.0",
+    "monarchmoneycommunity>=1.4.0",
     "gql>=3.4",
     "keyring>=24.0.0",
     "python-dotenv>=1.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mcp[cli]>=1.10.0
-monarchmoneycommunity>=1.2.0
+monarchmoneycommunity>=1.4.0
 gql>=3.4
 keyring>=24.0.0
 python-dotenv>=1.0.0

--- a/src/monarch_mcp_server/monarch_auth.py
+++ b/src/monarch_mcp_server/monarch_auth.py
@@ -5,6 +5,14 @@ Monarch changed its auth flow in May 2026:
 - New/unrecognized sessions may require an email one-time code even when
   account MFA is disabled, returned distinctly from a TOTP MFA challenge.
 - Reloading a saved token needs the same ``device-uuid`` used at login.
+- Programmatic login attempts may be gated by Cloudflare CAPTCHA, in which
+  case authentication has to fall through to cookie-based auth (cookies
+  captured from a real browser session).
+
+Token auth note: pass ``trusted_device=True`` in the login payload so
+Monarch returns a long-lived token (``tokenExpiration: null``). Passing
+``False`` yields a 1-hour token that expires mid-session, which is the
+exact behavior tracked in hammem/monarchmoney#139.
 
 This module wraps the upstream ``monarchmoney`` package with those changes
 instead of rewriting the MCP tools.
@@ -14,11 +22,16 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 from uuid import uuid4
 
 from aiohttp import ClientSession
-from monarchmoney import MonarchMoney, MonarchMoneyEndpoints, RequireMFAException
+from monarchmoney import (
+    CaptchaRequiredException,
+    MonarchMoney,
+    MonarchMoneyEndpoints,
+    RequireMFAException,
+)
 from monarchmoney.monarchmoney import LoginFailedException
 
 
@@ -74,20 +87,41 @@ def build_login_payload(
     email_otp: Optional[str] = None,
     mfa_code: Optional[str] = None,
 ) -> dict[str, Any]:
-    """Build a login payload compatible with current Monarch auth."""
+    """Build a login payload compatible with current Monarch auth.
+
+    ``trusted_device=True`` is critical: Monarch returns a long-lived
+    token (``tokenExpiration: null``) only when this flag is set. With
+    ``False`` we get a 1-hour token that expires mid-session.
+    """
     payload: dict[str, Any] = {
         "username": email,
         "password": password,
         "supports_mfa": True,
         "supports_email_otp": True,
         "supports_recaptcha": True,
-        "trusted_device": False,
+        "trusted_device": True,
     }
     if email_otp:
         payload["email_otp"] = email_otp
     if mfa_code:
         payload["totp"] = mfa_code
     return payload
+
+
+def _looks_like_jwt(value: str) -> bool:
+    """JWT features tokens are header.payload.signature (two dots).
+
+    Monarch returns 1-hour JWT-style tokens for features endpoints; the
+    long-lived login token is opaque without dots.
+    """
+    return isinstance(value, str) and value.count(".") == 2
+
+
+def _is_captcha_required(status: int, payload: dict[str, Any]) -> bool:
+    return (
+        status == 403
+        and str(payload.get("error_code") or "") == "CAPTCHA_REQUIRED"
+    )
 
 
 def is_email_otp_required(status: int, payload: dict[str, Any]) -> bool:
@@ -116,7 +150,19 @@ async def login_with_current_auth(
     email_otp: Optional[str] = None,
     mfa_code: Optional[str] = None,
 ) -> MonarchMoney:
-    """Log in using Monarch's current host and email-OTP-aware payload."""
+    """Log in using Monarch's current host and email-OTP-aware payload.
+
+    Raises:
+        CaptchaRequiredException: programmatic login is blocked by
+            Cloudflare. Caller should fall through to cookie-based auth
+            via ``login_with_browser_cookies``.
+        EmailOtpRequiredException: Monarch sent a code to the account
+            email. Caller should prompt for it and retry with ``email_otp``.
+        RequireMFAException: account has TOTP/MFA enabled. Caller should
+            prompt and retry with ``mfa_code``.
+        LoginFailedException: any other failure including short-lived
+            token rejection.
+    """
     client = create_monarch_client()
     payload = build_login_payload(
         email,
@@ -136,6 +182,12 @@ async def login_with_current_auth(
                 body = {"detail": body_text}
 
             if response.status != 200:
+                if _is_captcha_required(response.status, body):
+                    raise CaptchaRequiredException(
+                        "Programmatic login is blocked by Cloudflare CAPTCHA. "
+                        "Re-run `python login_setup.py` and choose the "
+                        "browser cookie option instead."
+                    )
                 if is_email_otp_required(response.status, body):
                     raise EmailOtpRequiredException(EMAIL_OTP_REQUIRED_MESSAGE)
                 if _is_mfa_required(response.status, body):
@@ -148,9 +200,49 @@ async def login_with_current_auth(
                 raise LoginFailedException(str(message))
 
             token = body.get("token")
+            token_expiration = body.get("tokenExpiration")
             if not token:
                 raise LoginFailedException("Login response did not include a token")
+            if _looks_like_jwt(token):
+                raise LoginFailedException(
+                    "Received a JWT-style (1-hour features) token. "
+                    "Refusing to save."
+                )
+            if token_expiration not in (None, "null"):
+                raise LoginFailedException(
+                    f"Short-lived token returned (tokenExpiration="
+                    f"{token_expiration!r}). Refusing to save; expected "
+                    "tokenExpiration=null. This typically means trusted_device "
+                    "was not honored by the server."
+                )
 
             client.set_token(token)
             client._headers["Authorization"] = f"Token {token}"
             return client
+
+
+async def login_with_browser_cookies(cookie_string: str) -> MonarchMoney:
+    """Log in by pasting a browser ``Cookie`` header string.
+
+    Uses the upstream library's cookie-auth path (added in
+    monarchmoneycommunity 1.4.0): parses the cookie string, validates the
+    required cookies, sets the cookie auth headers, and verifies by
+    calling ``get_accounts``. Caller is responsible for persisting the
+    resulting session via ``secure_session.save_authenticated_session``.
+
+    Returns:
+        A MonarchMoney client in cookie auth mode, verified against the API.
+    """
+    client = create_monarch_client()
+    await client.login_with_cookies(
+        cookie_string, save_session=False, verify=True
+    )
+    return client
+
+
+def cookies_from_client(client: MonarchMoney) -> Optional[Dict[str, str]]:
+    """Return the cookies on a cookie-auth client, or None for token mode."""
+    if getattr(client, "_auth_mode", "token") != "cookie":
+        return None
+    cookies = getattr(client, "_cookies", None)
+    return dict(cookies) if cookies else None

--- a/src/monarch_mcp_server/secure_session.py
+++ b/src/monarch_mcp_server/secure_session.py
@@ -10,10 +10,13 @@ import logging
 import os
 import stat
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
 from monarchmoney import MonarchMoney
 
-from monarch_mcp_server.monarch_auth import create_monarch_client
+from monarch_mcp_server.monarch_auth import (
+    cookies_from_client,
+    create_monarch_client,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -93,23 +96,46 @@ class SecureMonarchSession:
 
     # -- public API ----------------------------------------------------------
 
-    def save_token(self, token: str, *, device_uuid: Optional[str] = None) -> None:
-        """Save the authentication session to the system keyring or file fallback.
+    def save_session_blob(
+        self,
+        *,
+        token: Optional[str] = None,
+        device_uuid: Optional[str] = None,
+        cookies: Optional[Dict[str, str]] = None,
+        auth_mode: str = "token",
+    ) -> None:
+        """Persist a Monarch session (token + device_uuid, or cookies).
 
-        The session is stored as a JSON blob so the ``device-uuid`` captured at
-        login can be restored when the token is reloaded — Monarch rejects a
-        token presented without its original device metadata.
+        Stored as a JSON blob so we can represent either auth mode:
+
+        - Token mode: ``{"token": "...", "device_uuid": "...",
+          "auth_mode": "token"}``. The device_uuid must be the same UUID
+          presented during login or Monarch rejects the token.
+        - Cookie mode: ``{"cookies": {"session_id": "...",
+          "csrftoken": "..."}, "auth_mode": "cookie"}``. May also carry
+          ``token`` and ``device_uuid`` from the same session, which the
+          upstream library preserves as a fallback.
         """
-        session_data = {"token": token}
+        if not token and not cookies:
+            raise ValueError("save_session_blob requires either a token or cookies")
+
+        session_data: Dict[str, Any] = {"auth_mode": auth_mode}
+        if token:
+            session_data["token"] = token
         if device_uuid:
             session_data["device_uuid"] = device_uuid
+        if cookies:
+            session_data["cookies"] = dict(cookies)
         blob = json.dumps(session_data)
 
         if self._use_keyring:
             try:
                 import keyring
                 keyring.set_password(KEYRING_SERVICE, KEYRING_USERNAME, blob)
-                logger.info("✅ Token saved securely to keyring")
+                logger.info(
+                    "✅ Session saved securely to keyring (auth_mode=%s)",
+                    auth_mode,
+                )
                 self._cleanup_old_session_files()
                 return
             except Exception as e:
@@ -118,16 +144,34 @@ class SecureMonarchSession:
         self._save_token_file(blob)
         self._cleanup_old_session_files()
 
+    def save_token(self, token: str, *, device_uuid: Optional[str] = None) -> None:
+        """Save a token-mode session. Kept for backward compatibility."""
+        self.save_session_blob(
+            token=token, device_uuid=device_uuid, auth_mode="token"
+        )
+
     def load_token(self) -> Optional[str]:
         """Load just the authentication token from keyring or file fallback."""
         session = self.load_session()
-        return session["token"] if session else None
+        if not session:
+            return None
+        token = session.get("token")
+        return token if isinstance(token, str) else None
 
-    def load_session(self) -> Optional[dict[str, str]]:
-        """Load the stored Monarch session (token plus device metadata).
+    def load_session(self) -> Optional[Dict[str, Any]]:
+        """Load the stored Monarch session as a dict.
 
-        Accepts both the current JSON blob and legacy raw-token entries written
-        before device-uuid storage was added.
+        Returns a dict that may carry any of ``token``, ``device_uuid``,
+        ``cookies`` (a nested dict), and ``auth_mode``. Accepts three
+        legacy formats:
+
+        1. Bare token string (very old installs).
+        2. JSON blob with token and optional device_uuid, no auth_mode.
+        3. Current JSON blob with explicit auth_mode and optional cookies.
+
+        Cookies are returned as a nested ``dict`` to preserve their
+        original key/value pairs (legacy ``load_session`` flattened
+        everything to ``str(value)`` which corrupted nested dicts).
         """
         raw_session = None
         if self._use_keyring:
@@ -141,18 +185,35 @@ class SecureMonarchSession:
             raw_session = self._load_token_file()
 
         if not raw_session:
-            logger.info("🔍 No token found")
+            logger.info("🔍 No session found")
             return None
 
         logger.info("✅ Session loaded from secure storage")
         try:
-            session = json.loads(raw_session)
+            parsed = json.loads(raw_session)
         except json.JSONDecodeError:
             # Legacy entry: the stored value is the bare token string.
-            return {"token": raw_session}
-        if isinstance(session, dict) and session.get("token"):
-            return {str(k): str(v) for k, v in session.items() if v}
-        return None
+            return {"token": raw_session, "auth_mode": "token"}
+
+        if not isinstance(parsed, dict):
+            return None
+        if not parsed.get("token") and not parsed.get("cookies"):
+            return None
+
+        result: Dict[str, Any] = {}
+        if isinstance(parsed.get("token"), str):
+            result["token"] = parsed["token"]
+        if isinstance(parsed.get("device_uuid"), str):
+            result["device_uuid"] = parsed["device_uuid"]
+        cookies = parsed.get("cookies")
+        if isinstance(cookies, dict) and cookies:
+            result["cookies"] = {str(k): str(v) for k, v in cookies.items()}
+        # Default to "cookie" only when cookies are present and no explicit
+        # auth_mode says otherwise; otherwise default to "token".
+        result["auth_mode"] = parsed.get(
+            "auth_mode", "cookie" if result.get("cookies") else "token"
+        )
+        return result
 
     def delete_token(self) -> None:
         """Delete the authentication token from all storage backends."""
@@ -170,14 +231,39 @@ class SecureMonarchSession:
         self._cleanup_old_session_files()
 
     def get_authenticated_client(self) -> Optional[MonarchMoney]:
-        """Get an authenticated MonarchMoney client."""
+        """Get an authenticated MonarchMoney client.
+
+        Prefers cookie auth when cookies are present, falling back to the
+        token + device_uuid path otherwise. Returns None if no usable
+        session is stored.
+        """
         session = self.load_session()
         if not session:
             return None
 
+        auth_mode = session.get("auth_mode", "token")
+        cookies = session.get("cookies")
+        token = session.get("token")
+
         try:
+            if auth_mode == "cookie" and isinstance(cookies, dict) and cookies:
+                client = create_monarch_client(
+                    token=token, device_uuid=session.get("device_uuid")
+                )
+                # set_cookies pops Authorization and sets the cookie-mode
+                # web headers (Origin, Referer, monarch-client, X-Csrftoken).
+                client.set_cookies(cookies)
+                logger.info("✅ MonarchMoney client created with stored cookies")
+                return client
+
+            if not token:
+                logger.warning(
+                    "⚠️  Session has no token and no cookies; treating as missing"
+                )
+                return None
+
             client = create_monarch_client(
-                token=session["token"], device_uuid=session.get("device_uuid")
+                token=token, device_uuid=session.get("device_uuid")
             )
             logger.info("✅ MonarchMoney client created with stored token")
             return client
@@ -186,11 +272,33 @@ class SecureMonarchSession:
             return None
 
     def save_authenticated_session(self, mm: MonarchMoney) -> None:
-        """Save the session from an authenticated MonarchMoney instance."""
+        """Save the session from an authenticated MonarchMoney instance.
+
+        Inspects ``mm._auth_mode`` to decide whether to persist cookies or
+        the token + device_uuid pair. The upstream library exposes both as
+        documented internals (``_auth_mode``, ``_cookies``, ``token``).
+        """
+        cookies = cookies_from_client(mm)
+        device_uuid = mm._headers.get("device-uuid")
+
+        if cookies:
+            self.save_session_blob(
+                token=mm.token,
+                device_uuid=device_uuid,
+                cookies=cookies,
+                auth_mode="cookie",
+            )
+            return
+
         if mm.token:
-            self.save_token(mm.token, device_uuid=mm._headers.get("device-uuid"))
-        else:
-            logger.warning("⚠️  MonarchMoney instance has no token to save")
+            self.save_session_blob(
+                token=mm.token,
+                device_uuid=device_uuid,
+                auth_mode="token",
+            )
+            return
+
+        logger.warning("⚠️  MonarchMoney instance has no token or cookies to save")
 
     def _cleanup_old_session_files(self) -> None:
         """Clean up old insecure session files."""

--- a/tests/test_monarch_auth.py
+++ b/tests/test_monarch_auth.py
@@ -2,8 +2,11 @@ from unittest.mock import patch
 
 from monarch_mcp_server.monarch_auth import (
     EMAIL_OTP_REQUIRED_MESSAGE,
+    _is_captcha_required,
+    _looks_like_jwt,
     build_login_payload,
     configure_monarchmoney,
+    cookies_from_client,
     create_monarch_client,
     is_email_otp_required,
 )
@@ -45,7 +48,10 @@ def test_login_payload_advertises_current_auth_capabilities():
         "supports_mfa": True,
         "supports_email_otp": True,
         "supports_recaptcha": True,
-        "trusted_device": False,
+        # trusted_device=True is required for Monarch to return a long-lived
+        # token (tokenExpiration=null). False yields a 1-hour token that
+        # expires mid-session per hammem/monarchmoney#139.
+        "trusted_device": True,
     }
 
 
@@ -78,3 +84,45 @@ def test_create_client_restores_device_uuid_with_token():
 
     assert client._headers["Authorization"] == "Token token-value"
     assert client._headers["device-uuid"] == "device-value"
+
+
+def test_looks_like_jwt_detects_three_part_tokens():
+    assert _looks_like_jwt("eyJhbGciOi.eyJzdWIiOi.abc123") is True
+    assert _looks_like_jwt("opaque-long-token-with-no-dots") is False
+    # Two dots in a row should be rejected too (still matches header.payload.sig shape)
+    assert _looks_like_jwt("a.b.c") is True
+    # Edge: must be a string
+    assert _looks_like_jwt(None) is False  # type: ignore[arg-type]
+
+
+def test_captcha_required_detection():
+    assert _is_captcha_required(403, {"error_code": "CAPTCHA_REQUIRED"}) is True
+    # Same error_code at a different status should not be classified as captcha
+    assert _is_captcha_required(429, {"error_code": "CAPTCHA_REQUIRED"}) is False
+    # 403 alone is not enough — could be MFA or generic
+    assert _is_captcha_required(403, {"detail": "something else"}) is False
+
+
+def test_cookies_from_client_returns_none_for_token_mode():
+    client = _FakeMonarchMoney()
+    client._auth_mode = "token"
+    client._cookies = None
+    assert cookies_from_client(client) is None
+
+
+def test_cookies_from_client_returns_dict_for_cookie_mode():
+    client = _FakeMonarchMoney()
+    client._auth_mode = "cookie"
+    client._cookies = {"session_id": "s", "csrftoken": "c"}
+    result = cookies_from_client(client)
+    assert result == {"session_id": "s", "csrftoken": "c"}
+    # Must return a copy so callers cannot mutate the client's internal state
+    result["session_id"] = "mutated"
+    assert client._cookies["session_id"] == "s"
+
+
+def test_cookies_from_client_handles_missing_attributes():
+    """A bare MonarchMoney without auth_mode set should look token-like."""
+    client = _FakeMonarchMoney()
+    # _auth_mode not set at all
+    assert cookies_from_client(client) is None

--- a/tests/test_secure_session.py
+++ b/tests/test_secure_session.py
@@ -135,3 +135,202 @@ class TestKeyringAvailable:
             assert username != ss_module.KEYRING_USERNAME
         for _service, username in fake.get_calls:
             assert username != ss_module.KEYRING_USERNAME
+
+
+class _StorageFakeKeyring:
+    """In-memory keyring fake that round-trips set/get/delete.
+
+    Lets save_session_blob/load_session roundtrip without touching the
+    real Keychain or the host filesystem.
+    """
+
+    def __init__(self):
+        self._store = {}
+
+    def set_password(self, service, username, value):
+        self._store[(service, username)] = value
+
+    def get_password(self, service, username):
+        return self._store.get((service, username))
+
+    def delete_password(self, service, username):
+        self._store.pop((service, username), None)
+
+
+@pytest.fixture
+def storage_keyring(monkeypatch):
+    """Install a roundtrip-capable fake keyring and return a fresh session."""
+    fake = _StorageFakeKeyring()
+    module = types.ModuleType("keyring")
+    module.set_password = fake.set_password
+    module.get_password = fake.get_password
+    module.delete_password = fake.delete_password
+    monkeypatch.setitem(sys.modules, "keyring", module)
+
+    session = ss_module.SecureMonarchSession()
+    # __init__ ran the probe and set _use_keyring=True via the fake.
+    assert session._use_keyring is True
+    return session, fake
+
+
+class TestSessionStorageRoundTrip:
+    """save_session_blob → load_session must round-trip every supported shape."""
+
+    def test_token_mode_roundtrip(self, storage_keyring):
+        session, _ = storage_keyring
+        session.save_session_blob(
+            token="tok-abc",
+            device_uuid="dev-xyz",
+            auth_mode="token",
+        )
+
+        loaded = session.load_session()
+        assert loaded == {
+            "token": "tok-abc",
+            "device_uuid": "dev-xyz",
+            "auth_mode": "token",
+        }
+
+    def test_cookie_mode_roundtrip_preserves_nested_dict(self, storage_keyring):
+        """Cookies must come back as a nested dict, not flattened to strings."""
+        session, _ = storage_keyring
+        cookies = {
+            "session_id": "session-value",
+            "csrftoken": "csrf-value",
+            "cf_clearance": "cf-value",
+        }
+        session.save_session_blob(
+            cookies=cookies,
+            device_uuid="dev-xyz",
+            auth_mode="cookie",
+        )
+
+        loaded = session.load_session()
+        assert loaded is not None
+        assert loaded["auth_mode"] == "cookie"
+        assert loaded["cookies"] == cookies
+        assert loaded["device_uuid"] == "dev-xyz"
+
+    def test_cookie_mode_with_token_fallback(self, storage_keyring):
+        """When cookies and a token coexist, both must round-trip."""
+        session, _ = storage_keyring
+        session.save_session_blob(
+            token="tok-abc",
+            cookies={"session_id": "s", "csrftoken": "c"},
+            device_uuid="dev",
+            auth_mode="cookie",
+        )
+
+        loaded = session.load_session()
+        assert loaded["auth_mode"] == "cookie"
+        assert loaded["token"] == "tok-abc"
+        assert loaded["cookies"] == {"session_id": "s", "csrftoken": "c"}
+
+    def test_requires_token_or_cookies(self, storage_keyring):
+        session, _ = storage_keyring
+        with pytest.raises(ValueError):
+            session.save_session_blob(auth_mode="token")
+
+
+class TestBackwardCompatLoading:
+    """Existing keyring entries must keep working after the cookie upgrade."""
+
+    def test_legacy_bare_token_string(self, storage_keyring):
+        """Very old installs stored the raw token as the keyring value."""
+        session, fake = storage_keyring
+        fake.set_password(
+            ss_module.KEYRING_SERVICE,
+            ss_module.KEYRING_USERNAME,
+            "legacy-bare-token",
+        )
+
+        loaded = session.load_session()
+        assert loaded == {"token": "legacy-bare-token", "auth_mode": "token"}
+
+    def test_pre_cookie_json_blob(self, storage_keyring):
+        """Pre-cookie entries had token + device_uuid but no auth_mode key."""
+        session, fake = storage_keyring
+        fake.set_password(
+            ss_module.KEYRING_SERVICE,
+            ss_module.KEYRING_USERNAME,
+            '{"token": "t", "device_uuid": "d"}',
+        )
+
+        loaded = session.load_session()
+        assert loaded["token"] == "t"
+        assert loaded["device_uuid"] == "d"
+        # Without an explicit auth_mode and no cookies, default to "token".
+        assert loaded["auth_mode"] == "token"
+
+    def test_blob_with_cookies_defaults_to_cookie_mode(self, storage_keyring):
+        """If a blob has cookies but no auth_mode, infer cookie mode."""
+        session, fake = storage_keyring
+        fake.set_password(
+            ss_module.KEYRING_SERVICE,
+            ss_module.KEYRING_USERNAME,
+            '{"cookies": {"session_id": "s", "csrftoken": "c"}}',
+        )
+
+        loaded = session.load_session()
+        assert loaded["cookies"] == {"session_id": "s", "csrftoken": "c"}
+        assert loaded["auth_mode"] == "cookie"
+
+    def test_missing_token_and_cookies_returns_none(self, storage_keyring):
+        """A blob with neither credential type is unusable."""
+        session, fake = storage_keyring
+        fake.set_password(
+            ss_module.KEYRING_SERVICE,
+            ss_module.KEYRING_USERNAME,
+            '{"auth_mode": "token", "device_uuid": "d"}',
+        )
+
+        assert session.load_session() is None
+
+
+class TestGetAuthenticatedClient:
+    """get_authenticated_client must dispatch on the stored auth_mode."""
+
+    def test_cookie_mode_calls_set_cookies_on_client(self, storage_keyring, monkeypatch):
+        session, _ = storage_keyring
+        session.save_session_blob(
+            cookies={"session_id": "s", "csrftoken": "c"},
+            auth_mode="cookie",
+        )
+
+        # Capture what set_cookies is invoked with.
+        fake_client = MagicMock()
+        monkeypatch.setattr(
+            ss_module, "create_monarch_client", lambda **kwargs: fake_client
+        )
+
+        client = session.get_authenticated_client()
+        assert client is fake_client
+        fake_client.set_cookies.assert_called_once_with(
+            {"session_id": "s", "csrftoken": "c"}
+        )
+
+    def test_token_mode_does_not_call_set_cookies(self, storage_keyring, monkeypatch):
+        session, _ = storage_keyring
+        session.save_session_blob(
+            token="tok",
+            device_uuid="dev",
+            auth_mode="token",
+        )
+
+        fake_client = MagicMock()
+        captured = {}
+
+        def fake_create(**kwargs):
+            captured.update(kwargs)
+            return fake_client
+
+        monkeypatch.setattr(ss_module, "create_monarch_client", fake_create)
+
+        client = session.get_authenticated_client()
+        assert client is fake_client
+        assert captured == {"token": "tok", "device_uuid": "dev"}
+        fake_client.set_cookies.assert_not_called()
+
+    def test_no_session_returns_none(self, storage_keyring):
+        session, _ = storage_keyring
+        assert session.get_authenticated_client() is None

--- a/tests/test_server_budget.py
+++ b/tests/test_server_budget.py
@@ -2,7 +2,10 @@ from monarch_mcp_server.tools.budgets import BUDGET_QUERY, format_budget_data
 
 
 def test_budget_query_avoids_stale_category_group_fields():
-    query_text = BUDGET_QUERY.loc.source.body
+    # gql 4.0 returns a GraphQLRequest wrapping the parsed DocumentNode;
+    # the source string lives on document.loc.source.body. Earlier gql 3.x
+    # exposed .loc directly on the gql() return value.
+    query_text = BUDGET_QUERY.document.loc.source.body
 
     assert "budgetVariability" not in query_text
     assert "rolloverPeriod" not in query_text

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.12.15"
+version = "3.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -22,44 +22,52 @@ dependencies = [
     { name = "frozenlist" },
     { name = "multidict" },
     { name = "propcache" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/e7/d92a237d8802ca88483906c388f7c201bbe96cd80a165ffd0ac2f6a8d59f/aiohttp-3.12.15.tar.gz", hash = "sha256:4fc61385e9c98d72fcdf47e6dd81833f47b2f77c114c29cd64a361be57a763a2", size = 7823716, upload-time = "2025-07-29T05:52:32.215Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/97/77cb2450d9b35f517d6cf506256bf4f5bda3f93a66b4ad64ba7fc917899c/aiohttp-3.12.15-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:802d3868f5776e28f7bf69d349c26fc0efadb81676d0afa88ed00d98a26340b7", size = 702333, upload-time = "2025-07-29T05:50:46.507Z" },
-    { url = "https://files.pythonhosted.org/packages/83/6d/0544e6b08b748682c30b9f65640d006e51f90763b41d7c546693bc22900d/aiohttp-3.12.15-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f2800614cd560287be05e33a679638e586a2d7401f4ddf99e304d98878c29444", size = 476948, upload-time = "2025-07-29T05:50:48.067Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/1d/c8c40e611e5094330284b1aea8a4b02ca0858f8458614fa35754cab42b9c/aiohttp-3.12.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8466151554b593909d30a0a125d638b4e5f3836e5aecde85b66b80ded1cb5b0d", size = 469787, upload-time = "2025-07-29T05:50:49.669Z" },
-    { url = "https://files.pythonhosted.org/packages/38/7d/b76438e70319796bfff717f325d97ce2e9310f752a267bfdf5192ac6082b/aiohttp-3.12.15-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e5a495cb1be69dae4b08f35a6c4579c539e9b5706f606632102c0f855bcba7c", size = 1716590, upload-time = "2025-07-29T05:50:51.368Z" },
-    { url = "https://files.pythonhosted.org/packages/79/b1/60370d70cdf8b269ee1444b390cbd72ce514f0d1cd1a715821c784d272c9/aiohttp-3.12.15-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6404dfc8cdde35c69aaa489bb3542fb86ef215fc70277c892be8af540e5e21c0", size = 1699241, upload-time = "2025-07-29T05:50:53.628Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/2b/4968a7b8792437ebc12186db31523f541943e99bda8f30335c482bea6879/aiohttp-3.12.15-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3ead1c00f8521a5c9070fcb88f02967b1d8a0544e6d85c253f6968b785e1a2ab", size = 1754335, upload-time = "2025-07-29T05:50:55.394Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/c1/49524ed553f9a0bec1a11fac09e790f49ff669bcd14164f9fab608831c4d/aiohttp-3.12.15-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6990ef617f14450bc6b34941dba4f12d5613cbf4e33805932f853fbd1cf18bfb", size = 1800491, upload-time = "2025-07-29T05:50:57.202Z" },
-    { url = "https://files.pythonhosted.org/packages/de/5e/3bf5acea47a96a28c121b167f5ef659cf71208b19e52a88cdfa5c37f1fcc/aiohttp-3.12.15-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd736ed420f4db2b8148b52b46b88ed038d0354255f9a73196b7bbce3ea97545", size = 1719929, upload-time = "2025-07-29T05:50:59.192Z" },
-    { url = "https://files.pythonhosted.org/packages/39/94/8ae30b806835bcd1cba799ba35347dee6961a11bd507db634516210e91d8/aiohttp-3.12.15-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c5092ce14361a73086b90c6efb3948ffa5be2f5b6fbcf52e8d8c8b8848bb97c", size = 1635733, upload-time = "2025-07-29T05:51:01.394Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/46/06cdef71dd03acd9da7f51ab3a9107318aee12ad38d273f654e4f981583a/aiohttp-3.12.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:aaa2234bb60c4dbf82893e934d8ee8dea30446f0647e024074237a56a08c01bd", size = 1696790, upload-time = "2025-07-29T05:51:03.657Z" },
-    { url = "https://files.pythonhosted.org/packages/02/90/6b4cfaaf92ed98d0ec4d173e78b99b4b1a7551250be8937d9d67ecb356b4/aiohttp-3.12.15-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6d86a2fbdd14192e2f234a92d3b494dd4457e683ba07e5905a0b3ee25389ac9f", size = 1718245, upload-time = "2025-07-29T05:51:05.911Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/e6/2593751670fa06f080a846f37f112cbe6f873ba510d070136a6ed46117c6/aiohttp-3.12.15-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a041e7e2612041a6ddf1c6a33b883be6a421247c7afd47e885969ee4cc58bd8d", size = 1658899, upload-time = "2025-07-29T05:51:07.753Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/28/c15bacbdb8b8eb5bf39b10680d129ea7410b859e379b03190f02fa104ffd/aiohttp-3.12.15-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5015082477abeafad7203757ae44299a610e89ee82a1503e3d4184e6bafdd519", size = 1738459, upload-time = "2025-07-29T05:51:09.56Z" },
-    { url = "https://files.pythonhosted.org/packages/00/de/c269cbc4faa01fb10f143b1670633a8ddd5b2e1ffd0548f7aa49cb5c70e2/aiohttp-3.12.15-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:56822ff5ddfd1b745534e658faba944012346184fbfe732e0d6134b744516eea", size = 1766434, upload-time = "2025-07-29T05:51:11.423Z" },
-    { url = "https://files.pythonhosted.org/packages/52/b0/4ff3abd81aa7d929b27d2e1403722a65fc87b763e3a97b3a2a494bfc63bc/aiohttp-3.12.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b2acbbfff69019d9014508c4ba0401822e8bae5a5fdc3b6814285b71231b60f3", size = 1726045, upload-time = "2025-07-29T05:51:13.689Z" },
-    { url = "https://files.pythonhosted.org/packages/71/16/949225a6a2dd6efcbd855fbd90cf476052e648fb011aa538e3b15b89a57a/aiohttp-3.12.15-cp312-cp312-win32.whl", hash = "sha256:d849b0901b50f2185874b9a232f38e26b9b3d4810095a7572eacea939132d4e1", size = 423591, upload-time = "2025-07-29T05:51:15.452Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/d8/fa65d2a349fe938b76d309db1a56a75c4fb8cc7b17a398b698488a939903/aiohttp-3.12.15-cp312-cp312-win_amd64.whl", hash = "sha256:b390ef5f62bb508a9d67cb3bba9b8356e23b3996da7062f1a57ce1a79d2b3d34", size = 450266, upload-time = "2025-07-29T05:51:17.239Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/33/918091abcf102e39d15aba2476ad9e7bd35ddb190dcdd43a854000d3da0d/aiohttp-3.12.15-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9f922ffd05034d439dde1c77a20461cf4a1b0831e6caa26151fe7aa8aaebc315", size = 696741, upload-time = "2025-07-29T05:51:19.021Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/2a/7495a81e39a998e400f3ecdd44a62107254803d1681d9189be5c2e4530cd/aiohttp-3.12.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2ee8a8ac39ce45f3e55663891d4b1d15598c157b4d494a4613e704c8b43112cd", size = 474407, upload-time = "2025-07-29T05:51:21.165Z" },
-    { url = "https://files.pythonhosted.org/packages/49/fc/a9576ab4be2dcbd0f73ee8675d16c707cfc12d5ee80ccf4015ba543480c9/aiohttp-3.12.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3eae49032c29d356b94eee45a3f39fdf4b0814b397638c2f718e96cfadf4c4e4", size = 466703, upload-time = "2025-07-29T05:51:22.948Z" },
-    { url = "https://files.pythonhosted.org/packages/09/2f/d4bcc8448cf536b2b54eed48f19682031ad182faa3a3fee54ebe5b156387/aiohttp-3.12.15-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b97752ff12cc12f46a9b20327104448042fce5c33a624f88c18f66f9368091c7", size = 1705532, upload-time = "2025-07-29T05:51:25.211Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/f3/59406396083f8b489261e3c011aa8aee9df360a96ac8fa5c2e7e1b8f0466/aiohttp-3.12.15-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:894261472691d6fe76ebb7fcf2e5870a2ac284c7406ddc95823c8598a1390f0d", size = 1686794, upload-time = "2025-07-29T05:51:27.145Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/71/164d194993a8d114ee5656c3b7ae9c12ceee7040d076bf7b32fb98a8c5c6/aiohttp-3.12.15-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5fa5d9eb82ce98959fc1031c28198b431b4d9396894f385cb63f1e2f3f20ca6b", size = 1738865, upload-time = "2025-07-29T05:51:29.366Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/00/d198461b699188a93ead39cb458554d9f0f69879b95078dce416d3209b54/aiohttp-3.12.15-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f0fa751efb11a541f57db59c1dd821bec09031e01452b2b6217319b3a1f34f3d", size = 1788238, upload-time = "2025-07-29T05:51:31.285Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b8/9e7175e1fa0ac8e56baa83bf3c214823ce250d0028955dfb23f43d5e61fd/aiohttp-3.12.15-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5346b93e62ab51ee2a9d68e8f73c7cf96ffb73568a23e683f931e52450e4148d", size = 1710566, upload-time = "2025-07-29T05:51:33.219Z" },
-    { url = "https://files.pythonhosted.org/packages/59/e4/16a8eac9df39b48ae102ec030fa9f726d3570732e46ba0c592aeeb507b93/aiohttp-3.12.15-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:049ec0360f939cd164ecbfd2873eaa432613d5e77d6b04535e3d1fbae5a9e645", size = 1624270, upload-time = "2025-07-29T05:51:35.195Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f8/cd84dee7b6ace0740908fd0af170f9fab50c2a41ccbc3806aabcb1050141/aiohttp-3.12.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b52dcf013b57464b6d1e51b627adfd69a8053e84b7103a7cd49c030f9ca44461", size = 1677294, upload-time = "2025-07-29T05:51:37.215Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/42/d0f1f85e50d401eccd12bf85c46ba84f947a84839c8a1c2c5f6e8ab1eb50/aiohttp-3.12.15-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:9b2af240143dd2765e0fb661fd0361a1b469cab235039ea57663cda087250ea9", size = 1708958, upload-time = "2025-07-29T05:51:39.328Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/6b/f6fa6c5790fb602538483aa5a1b86fcbad66244997e5230d88f9412ef24c/aiohttp-3.12.15-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ac77f709a2cde2cc71257ab2d8c74dd157c67a0558a0d2799d5d571b4c63d44d", size = 1651553, upload-time = "2025-07-29T05:51:41.356Z" },
-    { url = "https://files.pythonhosted.org/packages/04/36/a6d36ad545fa12e61d11d1932eef273928b0495e6a576eb2af04297fdd3c/aiohttp-3.12.15-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:47f6b962246f0a774fbd3b6b7be25d59b06fdb2f164cf2513097998fc6a29693", size = 1727688, upload-time = "2025-07-29T05:51:43.452Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/c8/f195e5e06608a97a4e52c5d41c7927301bf757a8e8bb5bbf8cef6c314961/aiohttp-3.12.15-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:760fb7db442f284996e39cf9915a94492e1896baac44f06ae551974907922b64", size = 1761157, upload-time = "2025-07-29T05:51:45.643Z" },
-    { url = "https://files.pythonhosted.org/packages/05/6a/ea199e61b67f25ba688d3ce93f63b49b0a4e3b3d380f03971b4646412fc6/aiohttp-3.12.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ad702e57dc385cae679c39d318def49aef754455f237499d5b99bea4ef582e51", size = 1710050, upload-time = "2025-07-29T05:51:48.203Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/2e/ffeb7f6256b33635c29dbed29a22a723ff2dd7401fff42ea60cf2060abfb/aiohttp-3.12.15-cp313-cp313-win32.whl", hash = "sha256:f813c3e9032331024de2eb2e32a88d86afb69291fbc37a3a3ae81cc9917fb3d0", size = 422647, upload-time = "2025-07-29T05:51:50.718Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/8e/78ee35774201f38d5e1ba079c9958f7629b1fd079459aea9467441dbfbf5/aiohttp-3.12.15-cp313-cp313-win_amd64.whl", hash = "sha256:1a649001580bdb37c6fdb1bebbd7e3bc688e8ec2b5c6f52edbb664662b17dc84", size = 449067, upload-time = "2025-07-29T05:51:52.549Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/21/151624b51cd92553d95424daf4bf19f19ce9be9002d19253e7e7ce67197b/aiohttp-3.14.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d35143e27778b4bb0fb189562d7f275bff79c62ab8e98459717c0ea617ff2480", size = 757402, upload-time = "2026-06-07T21:06:40.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/82/280619e0bd7bf2454987e19282616e84762255dd9c8468f62382e8c191f1/aiohttp-3.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bcfb80a2cc36fba2534e5e5b5264dc7ae6fcd9bf15256da3e53d2f499e6fa29d", size = 512310, upload-time = "2026-06-07T21:06:42.207Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b2/2aac325583aaa1353045f96dffa586d8a34e8322e14a7ba49cffeb103ab4/aiohttp-3.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:27fd7c91e51729b4f7e1577865fa6d34c9adccbc39aabe9000285b48af9f0ec2", size = 512448, upload-time = "2026-06-07T21:06:43.813Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/72/a60607cb849faa8af8a356c9329ea2eb6f395d49e82cc82ccba1fd8deb8f/aiohttp-3.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:64c567bf9eaf664280116a8688f63016e6b32db2505908e2bdaca1b6438142f2", size = 1766854, upload-time = "2026-06-07T21:06:45.391Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d3/d9fe1c9ec7557ab4d0d82bebaa728c6418f0b93295ec2f4ab015f7710cc7/aiohttp-3.14.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f5e6ff2bdbb8f4cd3fbe41f99e25bbcd58e3bf9f13d3dd31a11e7917251cc77a", size = 1740884, upload-time = "2026-06-07T21:06:47.413Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/dc/f2cecfaf9337ba3e63f181500814ff502aa3d00d9c7ec93a9d23d10a27b2/aiohttp-3.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2f73e01dc37122325caf079982621262f96d74823c179038a82fddfc50359264", size = 1810034, upload-time = "2026-06-07T21:06:50.165Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d7/2ff65c5e65c0d7476daf7e15c032e0805e36811185b9623e3238ad6c763e/aiohttp-3.14.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bb2c0c80d431c0d03f2c7dbf125150fedd4f0de17366a7ca33f7ccb822391842", size = 1904054, upload-time = "2026-06-07T21:06:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9c/d445818389df371f56d141d881153ba23183c4735a03f7356ffb43f7757d/aiohttp-3.14.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e6fc1a85fa7194a1a7d19f44e8609180f4a8eb5fa4c7ed8b4355f080fad235c", size = 1790278, upload-time = "2026-06-07T21:06:54.049Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/aa/bf04cb4d865fc6101c2229a294ad744973b72e513fdc5a6b791e6983d72a/aiohttp-3.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:686b6c0d3911ec387b444ddf5dc62fb7f7c0a7d5186a7861626496a5ab4aff95", size = 1591795, upload-time = "2026-06-07T21:06:55.911Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b4/4dac0038960427ba832f6609dfb4ea5437d7fd80c72001b9e48f834f428b/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c6fa4dc7ad6f8109c70bb1499e589f76b0b792baf39f9b017eb92c8a81d0a199", size = 1728397, upload-time = "2026-06-07T21:06:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/7cd4e8ad7aa3b75f17d56bb5498dd604a93d4e6eece822ba0568c413fff0/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:87a5eea1b2a5e21e1ebdbb33ad4165359189327e63fc4e4894693e7f821ac817", size = 1766504, upload-time = "2026-06-07T21:07:00.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/fc01d9fcad0f73fed3f3d361f1f94f975947b50dff82919f6dc2bf4316cc/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c1421eb01d4fd608d88cc8290211d177a58532b55ad94076fb349c5bf467f0a", size = 1777806, upload-time = "2026-06-07T21:07:02.064Z" },
+    { url = "https://files.pythonhosted.org/packages/41/09/47e2d090bddcc8fb4ccb4c314aadc32d7c5d9bb55f50f6ad1c92fc15d501/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:34b257ec41345c1e8f2df68fa908a7952f5de932723871eb633ecbbff396c9a4", size = 1580707, upload-time = "2026-06-07T21:07:03.942Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/36/f1a4ce904ae0b6930cfe9afc96d0896f7ec1a620c400405d63783bb95a9c/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:de538791a80e5d862addbc183f70f0158ac9b9bb872bb147f1fd2a683691e087", size = 1798121, upload-time = "2026-06-07T21:07:05.987Z" },
+    { url = "https://files.pythonhosted.org/packages/70/0a/e0075ce9ca0279ee1d4f0c0b85f54fea02ebc83c3007651a72bece658fec/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f71173be42d3241d428f760122febb748de0623f44308a6f120d0dd9ec572e3", size = 1767580, upload-time = "2026-06-07T21:07:07.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/a0c0a8f327a9c52095cdd8e312391b00d3ed64ab6c72bb5c33d8ec251cf7/aiohttp-3.14.1-cp312-cp312-win32.whl", hash = "sha256:ec8dc383ee57ea3e883477dcca3f11b65d58199f1080acaf4cd6ad9a99698be4", size = 452771, upload-time = "2026-06-07T21:07:09.669Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d9/ea367c75f16ac9c6cdc8febb25e8318fa21a2b1bc8d6514d4b2d890bface/aiohttp-3.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:2aa92c87868cd13674989f9ee83e5f9f7ea4237589b728048e1f0c8f6caa3271", size = 479873, upload-time = "2026-06-07T21:07:11.538Z" },
+    { url = "https://files.pythonhosted.org/packages/03/64/8d96784a7851156db8a4c6c3f6f91042fdf39fb15a4cc38c8b3c14833c45/aiohttp-3.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:2c840c90759922cb5e6dda94596e079a30fb5a5ba548e7e0dc00574703940847", size = 448073, upload-time = "2026-06-07T21:07:13.637Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/97/bd137012dd97e1649162b099135a80e1fd59aaa807b2430fc448d1029aff/aiohttp-3.14.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:b3a03285a7f9c7b016324574a6d92a1c895da6b978cb8f1deee3ac72bc6da178", size = 506882, upload-time = "2026-06-07T21:07:15.501Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/79/e5cc690e9d922a66887ceeaca53a8ffd5a7b0be3816142b7abc433742d89/aiohttp-3.14.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:2a73f487ab8ef5abbb24b7aa9b73e98eaba9e9e031804ff2416f02eca315ccaf", size = 515270, upload-time = "2026-06-07T21:07:17.53Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/22/a73ccbf9dbd6e26dda0b24d5fd5db7da92ee3383a79f47677ffb834c5c5b/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:915fbb7b41b115192259f8c9ae58f3ddc444d2b5579917270211858e606a4afd", size = 485841, upload-time = "2026-06-07T21:07:19.555Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b9/57ed8eaf596321c2ad747bd480fb1700dbd7177c60dfc9e4c187f629662e/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:7fb4bdf95b0561a79f259f9d28fbc109728c5ee7f27aff6391f0ca703a329abe", size = 492088, upload-time = "2026-06-07T21:07:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c0/5ebe5270a7c140d7c6f79dcb018640225f14d406c149e4eec04a7d82fe71/aiohttp-3.14.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:1b9748363260121d2927704f5d4fc498150669ca3ae93625986ee89c8f80dcd4", size = 501564, upload-time = "2026-06-07T21:07:23.388Z" },
+    { url = "https://files.pythonhosted.org/packages/75/7f/8cdaa24fc7983865e0915153b96a9ac5bcdd3548d64c5a27d17cecccad2d/aiohttp-3.14.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:86a6dab78b0e43e2897a3bbe15745aa60dc5423ca437b7b0b164c069bf91b876", size = 751998, upload-time = "2026-06-07T21:07:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f4/c4227aacfacc5cb0cc2d119b65301d177912a6842cd64e120c47af76064f/aiohttp-3.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dfd6e47d3c44c2279907607f73a4240b88c69eb8b90da7e2441a8045dfd21da", size = 510918, upload-time = "2026-06-07T21:07:27.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/01/a2d5f96cd4e74424864d30bc0a7e44d0a12dacdcfa91b5b2d1bd3dca6bf3/aiohttp-3.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:317acd9f8602858dc7d59679812c376c7f0b97bcbbf16e0d6237f54141d8a8a6", size = 508657, upload-time = "2026-06-07T21:07:29.252Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ed/3c0fb5c500fdd8e7ebc10d1889c04384fffa1a9163eac1356088ca9da1b1/aiohttp-3.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd869c427324e5cb15195793de951295710db28be7d818247f3097b4ab5d4b96", size = 1757907, upload-time = "2026-06-07T21:07:31.03Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ab/d4c924d9bd5be3050c226612413ce68cb54c70d2c31b661bfc8d9a5b6a70/aiohttp-3.14.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:93b032b5ec3255473c143627d21a69ac74ae12f7f33974cb587c564d11b1066f", size = 1737565, upload-time = "2026-06-07T21:07:33.031Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/37326821ff779084020cdc33224d20b19f42f4183a500ff92022a739eda7/aiohttp-3.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f234b4deb12f3ad59127e037bc57c40c21e45b45282df7d3a55a0f409f595296", size = 1799018, upload-time = "2026-06-07T21:07:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/4f/6e947ba73e4ce09070761c05ed3a8ceb7c21f5e46798671d8b2aac0e4626/aiohttp-3.14.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9af6779bfb46abf124068327abcdf9ce95c9ef8287a3e8da76ccf2d0f16c28fa", size = 1894416, upload-time = "2026-06-07T21:07:36.956Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6e/dbf1d0625dc711fb2851f4f3c3055c39ed58bae92082d8c627dbe6013736/aiohttp-3.14.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faccab372e66bc76d5731525e7f1143c922271725b9d38c9f97edcc66266b451", size = 1783881, upload-time = "2026-06-07T21:07:39.063Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c2/5e25098a67268ed369483ae7d1a58bd0a13d03aab860d2a0e4a6eb25b046/aiohttp-3.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f380468b09d2a81633ee863b0ec5648d364bd17bb8ecfb8c2f387f7ac1faf42c", size = 1587572, upload-time = "2026-06-07T21:07:41.058Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/bd/cf9cee17e140f942a3de73e658a543aa8fbf35a5fc67a9d2538d52d77f0b/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:97e704dcd26271f5bda3fa07c3ce0fb76d6d3f8659f4baa1a24442cc9ba177ca", size = 1722137, upload-time = "2026-06-07T21:07:43.014Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6d/5684f8c59045c96f81a18cefbc1fbbd79d25b88f1c622f2a5c5c08fcb632/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:269b76ac5394092b95bc4a098f4fc6c191c083c3bd12775d1e30e663132f6a09", size = 1755953, upload-time = "2026-06-07T21:07:45.933Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/35caf3170f8359760740a7d9aa0fff2e344bef98e1d1186f5a0f6dec17e6/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0b3e614340c889d575451696374c9d17affd54cd607ca0babed8f8c37b9397", size = 1766479, upload-time = "2026-06-07T21:07:48.047Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a1/b0c61e7a137f0d81de49a82023a6df73c3c16d6fefb0f8e4a93d21639002/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:5663ee9257cfa1add7253a7da3035a02f31b6600ec48261585e1800a81533080", size = 1580077, upload-time = "2026-06-07T21:07:50.069Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/41/194ea4623693009fcefebef7aef63c141754f153e9cd0d39d3b9e36c175c/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:603a2c834142172ffddc054067f5ec0ca65d57a0aa98a71bc81952573208e345", size = 1791688, upload-time = "2026-06-07T21:07:52.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/45/4de841f005cfe1fd63e2a2fe011262c515e2a62aa6994b15947e7d717ac9/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cb21957bb8aca671c1765e32f58164cf0c50e6bf41c0bbbd16da20732ecaf588", size = 1761094, upload-time = "2026-06-07T21:07:54.113Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/ae/dbce10533d3896d544d5053939ed75b7dc31a1b0973d959b1b5ae21028d6/aiohttp-3.14.1-cp313-cp313-win32.whl", hash = "sha256:e509a55f681e6158c20f70f102f9cf61fb20fbc382272bc6d94b7343f2582780", size = 452662, upload-time = "2026-06-07T21:07:56.06Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d9/0bf1a19362c32f06229da5e7ddfcec91f93474d6307f7a2d3135e9c674dc/aiohttp-3.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:1ac8531b638959718e18c2207fbfe297819875da46a740b29dfa29beba64355a", size = 479748, upload-time = "2026-06-07T21:07:58.319Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0a/62e7232dc9484fbec112ceb32efb6a624cc7994ec6e2b019286f17c4e8f2/aiohttp-3.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:250d14af67f6b6a1a4a811049b1afa69d61d617fca6bf33149b3ab1a6dbcf7b8", size = 447723, upload-time = "2026-06-07T21:08:00.154Z" },
 ]
 
 [[package]]
@@ -322,7 +330,7 @@ wheels = [
 
 [[package]]
 name = "gql"
-version = "3.5.3"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -330,9 +338,9 @@ dependencies = [
     { name = "graphql-core" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/ed/44ffd30b06b3afc8274ee2f38c3c1b61fe4740bf03d92083e43d2c17ac77/gql-3.5.3.tar.gz", hash = "sha256:393b8c049d58e0d2f5461b9d738a2b5f904186a40395500b4a84dd092d56e42b", size = 180504, upload-time = "2025-05-20T12:34:08.954Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/9f/cf224a88ed71eb223b7aa0b9ff0aa10d7ecc9a4acdca2279eb046c26d5dc/gql-4.0.0.tar.gz", hash = "sha256:f22980844eb6a7c0266ffc70f111b9c7e7c7c13da38c3b439afc7eab3d7c9c8e", size = 215644, upload-time = "2025-08-17T14:32:35.397Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/50/2f4e99b216821ac921dbebf91c644ba95818f5d07857acadee17220221f3/gql-3.5.3-py2.py3-none-any.whl", hash = "sha256:e1fcbde2893fcafdd28114ece87ff47f1cc339a31db271fc4e1d528f5a1d4fbc", size = 74348, upload-time = "2025-05-20T12:34:07.687Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/30bbd09e8d45339fa77a48f5778d74d47e9242c11b3cd1093b3d994770a5/gql-4.0.0-py3-none-any.whl", hash = "sha256:f3beed7c531218eb24d97cb7df031b4a84fdb462f4a2beb86e2633d395937479", size = 89900, upload-time = "2025-08-17T14:32:34.029Z" },
 ]
 
 [[package]]
@@ -591,7 +599,7 @@ requires-dist = [
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "keyring", specifier = ">=24.0.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.10.0" },
-    { name = "monarchmoneycommunity", specifier = ">=1.2.0" },
+    { name = "monarchmoneycommunity", specifier = ">=1.4.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -603,16 +611,16 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "monarchmoneycommunity"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "gql" },
     { name = "oathtool" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/60/6dea6eebbfc814cfefb9a5e9cbe983b45ace907c7eb29db60d93b8387759/monarchmoneycommunity-1.3.0.tar.gz", hash = "sha256:f771bdfe66ce0ea45e30b4b324d017bcbc85cc81db8c5af9c3f788171cde18dc", size = 27931, upload-time = "2026-02-11T02:53:15.343Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/06/4de2984bf2a8c1883d8c4469883e5a6026aa8bcb98ac55cc7cf2e18bed31/monarchmoneycommunity-1.4.0.tar.gz", hash = "sha256:70f78fcb1deeb6e32e63d4dd15c98ff8096bb24652b4fd7c17f752d072273b13", size = 32227, upload-time = "2026-06-04T03:52:37.795Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/3c/451fb2af0930de84ae2f631bc9ae9f7b0f883548e507e7e68c5ac36b7cdb/monarchmoneycommunity-1.3.0-py3-none-any.whl", hash = "sha256:57df2fc8c8d2db57a2d38d1bd1ff1514e2f871ac6ed1db60ec8d551dbe576a08", size = 22772, upload-time = "2026-02-11T02:53:13.676Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/7e/2c8f627b35f100f1c7e21269484e4d131839bf6934229178cbbeb2e92528/monarchmoneycommunity-1.4.0-py3-none-any.whl", hash = "sha256:9c89904904893400dfe3c2d1df9a6ad6579f09c74bf7b1f84f99a9a96d7c78f4", size = 26395, upload-time = "2026-06-04T03:52:36.6Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Two distinct auth failure modes in production:

1. **Sessions die in 30 to 120 minutes mid-use.** Tracked upstream in [hammem/monarchmoney#139](https://github.com/hammem/monarchmoney/issues/139). Root cause: PR #71's `monarch_auth.build_login_payload` set `trusted_device=False`. Monarch reads that as "untrusted device" and returns a 1-hour token instead of the long-lived one the web app gets.

2. **Cloudflare CAPTCHA gates programmatic login for some accounts.** Returns 403 with `error_code=CAPTCHA_REQUIRED`, which our code previously misclassified as a generic MFA challenge.

## Fix

Compose the upstream `monarchmoneycommunity` 1.4.0 cookie-auth APIs with our existing token-auth path, and correct the trusted_device payload bug.

### `monarch_auth.py`

- `build_login_payload` now sends `trusted_device=True`.
- `login_with_current_auth` detects `CaptchaRequiredException` and surfaces it with a clear "switch to cookies" message. Rejects JWT-shape (1-hour features) tokens. Rejects any `tokenExpiration` other than `None` or `"null"`.
- New `login_with_browser_cookies(cookie_string)` delegates to upstream's `login_with_cookies` and verifies against `get_accounts` before returning.
- New `cookies_from_client(mm)` helper for session persistence.

### `secure_session.py`

- `save_session_blob(token=, device_uuid=, cookies=, auth_mode=)` stores token, cookies, or both in a single JSON keyring entry.
- `load_session` returns a typed dict and infers `auth_mode` from cookie presence when not explicitly stored.
- `get_authenticated_client` calls `set_cookies()` on the client in cookie mode; falls back to the token + device_uuid path otherwise.
- Backward compatible with bare-token strings and pre-cookie JSON blobs.

### `login_setup.py`

Refactored to a three-option menu:

1. Session cookies from browser (recommended, long-lived, supports SSO)
2. Email and password
3. Legacy session token paste

Removed the dead "retry on session expired" block that was specific to the old auth flow.

### Dependencies

- `monarchmoneycommunity>=1.4.0` (was `>=1.2.0`). v1.4.0 added `set_cookies()` and `login_with_cookies()`.
- `gql` resolved to 4.0.0 as a transitive effect of the bump. One existing test updated to use the new `GraphQLRequest.document.loc.source.body` location.

## Test plan

- [x] `uv run pytest tests/ -q` — 222 passing (was 206, +16 new tests).
- [x] New tests cover: cookie roundtrip storage, backward compat loading (bare token, pre-cookie JSON, cookie-without-auth-mode), `get_authenticated_client` dispatch on `auth_mode`, `_looks_like_jwt`, `_is_captcha_required`, `cookies_from_client` returns copies.
- [x] Existing tests updated for `trusted_device=True` and the gql 4.x query API.
- [ ] Live verified locally by completing the cookie-paste flow against a real Monarch account.

## Backward compatibility

- Existing keyring entries (raw token string, or `{"token": ..., "device_uuid": ...}` JSON) load and work as before.
- `auth_mode` defaults to `"token"` when not present in a stored blob, unless cookies are present, in which case it defaults to `"cookie"`.
- The MCP tool surface is unchanged; only auth internals moved.