### PR TITLE
Fix: token fallback file briefly world-readable before chmod

### DIFF
--- a/src/monarch_mcp_server/secure_session.py
+++ b/src/monarch_mcp_server/secure_session.py
@@ -72,10 +72,20 @@ class SecureMonarchSession:
 
     def _save_token_file(self, token: str) -> None:
         _TOKEN_DIR.mkdir(parents=True, exist_ok=True)
-        # Write with owner-only permissions
-        _TOKEN_FILE.write_text(token)
-        _TOKEN_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 600
         _TOKEN_DIR.chmod(stat.S_IRWXU)  # 700
+        # Create the file already locked to owner-only (0600) instead of
+        # write_text()-then-chmod, which leaves a window where the token is
+        # world-readable under a default umask.
+        fd = os.open(
+            _TOKEN_FILE,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        with os.fdopen(fd, "w") as f:
+            f.write(token)
+        # O_CREAT honors the mode only when creating; enforce it for an
+        # existing file too.
+        _TOKEN_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 600
         logger.info(f"✅ Token saved to {_TOKEN_FILE}")
 
     def _load_token_file(self) -> Optional[str]:

--- a/tests/test_secure_session.py
+++ b/tests/test_secure_session.py
@@ -334,3 +334,38 @@ class TestGetAuthenticatedClient:
     def test_no_session_returns_none(self, storage_keyring):
         session, _ = storage_keyring
         assert session.get_authenticated_client() is None
+
+
+class TestFileFallbackPermissions:
+    """The plaintext file fallback must never expose the token to other users."""
+
+    def test_token_file_created_locked_not_via_write_text(self, tmp_path, monkeypatch):
+        """The token file must be created already locked to 0600, not written
+        world-readable and chmod'd afterward (which leaves a race window)."""
+        import stat as _stat
+
+        monkeypatch.setattr(ss_module, "_TOKEN_DIR", tmp_path / "store")
+        monkeypatch.setattr(ss_module, "_TOKEN_FILE", tmp_path / "store" / "token")
+
+        # A revert to write_text()-then-chmod would trip this and fail loudly.
+        def _boom(*_a, **_k):
+            raise AssertionError("token file must not be created via write_text()")
+
+        monkeypatch.setattr(ss_module.Path, "write_text", _boom)
+
+        create_modes = []
+        real_open = ss_module.os.open
+
+        def _recording_open(path, flags, mode=0o777):
+            create_modes.append(mode)
+            return real_open(path, flags, mode)
+
+        monkeypatch.setattr(ss_module.os, "open", _recording_open)
+
+        session = ss_module.SecureMonarchSession()
+        session._save_token_file("super-secret-token")
+
+        token_file = tmp_path / "store" / "token"
+        assert token_file.read_text() == "super-secret-token"
+        assert create_modes and all(m == 0o600 for m in create_modes)
+        assert _stat.S_IMODE(token_file.stat().st_mode) == 0o600


### PR DESCRIPTION
## What

Closes #75.

The file-based session fallback (used when no keyring backend is available — WSL, headless Linux) wrote the long-lived Monarch session token via `Path.write_text()` and narrowed permissions to `0600` only *afterward*:

```python
_TOKEN_FILE.write_text(token)                   # created under umask, typically 0644
_TOKEN_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 600, but too late
```

`write_text()` creates the file under the process umask (commonly `0644`), so between the write and the `chmod` the token is world-readable by any local user. The payload is a long-lived, full-access financial credential, so the window is worth closing.

## How

Create the file already locked to `0600` via `os.open(..., O_CREAT, 0o600)`, then still `chmod` to enforce `0600` if the file already existed. No behavior change for keyring users (unaffected path).

## Test

Adds `TestFileFallbackPermissions`, which intercepts creation and fails if the token file is created via `write_text()` or with any mode other than `0600`. Verified the test fails against the old implementation and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)