### PR TITLE
Add flex-budget context to get_budgets (flex bucket + section totals)

### DIFF
--- a/src/monarch_mcp_server/tools/budgets.py
+++ b/src/monarch_mcp_server/tools/budgets.py
@@ -16,8 +16,16 @@ logger = logging.getLogger(__name__)
 
 # The upstream SDK's get_budgets() requests category-group fields (e.g.
 # budgetVariability/rolloverPeriod) that Monarch's current API rejects for some
-# accounts, so it can fail outright. This narrower query asks only for fields
-# the current API still returns.
+# accounts, so it can fail outright. This query asks only for fields the current
+# API still returns.
+#
+# Alongside the per-category amounts it pulls the Flex-budget context those
+# amounts alone can't convey: under "Fixed & Flexible" budgeting the real
+# flexible budget is a single "flex bucket" total (``monthlyAmountsForFlexExpense``)
+# that the per-category flex sub-budgets do NOT sum to, and ``totalsByMonth`` gives
+# the Fixed / Non-Monthly / Flexible / overall rollups the way Monarch computes
+# them. Both live on ``budgetData`` and don't touch the guarded category-group
+# fields above.
 BUDGET_QUERY = gql(
     """
     query MCPBudgetData($startDate: Date!, $endDate: Date!) {
@@ -31,6 +39,50 @@ BUDGET_QUERY = gql(
             month
             plannedCashFlowAmount
             plannedSetAsideAmount
+            actualAmount
+            remainingAmount
+            __typename
+          }
+          __typename
+        }
+        monthlyAmountsForFlexExpense {
+          monthlyAmounts {
+            month
+            plannedCashFlowAmount
+            actualAmount
+            remainingAmount
+            __typename
+          }
+          __typename
+        }
+        totalsByMonth {
+          month
+          totalIncome {
+            plannedAmount
+            actualAmount
+            remainingAmount
+            __typename
+          }
+          totalExpenses {
+            plannedAmount
+            actualAmount
+            remainingAmount
+            __typename
+          }
+          totalFixedExpenses {
+            plannedAmount
+            actualAmount
+            remainingAmount
+            __typename
+          }
+          totalNonMonthlyExpenses {
+            plannedAmount
+            actualAmount
+            remainingAmount
+            __typename
+          }
+          totalFlexibleExpenses {
+            plannedAmount
             actualAmount
             remainingAmount
             __typename
@@ -80,7 +132,14 @@ async def get_budget_data(
 
 
 def format_budget_data(budget_data: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Format Monarch budget data into one row per category/month."""
+    """Format Monarch budget data into one row per category/month.
+
+    NOTE: for categories in the Flexible bucket the per-category ``planned`` is
+    only a guideline sub-budget — the real flexible budget is the single
+    flex-bucket total (see ``format_flex_bucket``), which these sub-budgets do
+    not sum to. Analyze flexible spending against the flex bucket / section
+    totals, not these per-category planned amounts.
+    """
     category_lookup: Dict[str, Dict[str, Optional[str]]] = {}
     for group in budget_data.get("categoryGroups", []):
         for category in group.get("categories", []):
@@ -114,6 +173,64 @@ def format_budget_data(budget_data: Dict[str, Any]) -> List[Dict[str, Any]]:
     return budget_rows
 
 
+def format_flex_bucket(budget_data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Format the Flex-bucket total per month.
+
+    Under Fixed & Flexible budgeting the flexible budget is a single "flex
+    bucket" amount set independently of the flex sub-categories. This is the
+    number that actually counts toward the budget, so compare total flexible
+    *spend* against this — not against the sum of the flex category sub-budgets.
+    """
+    flex = (budget_data.get("budgetData", {}) or {}).get(
+        "monthlyAmountsForFlexExpense"
+    ) or {}
+    rows = []
+    for monthly_amount in flex.get("monthlyAmounts", []):
+        rows.append(
+            {
+                "month": monthly_amount.get("month"),
+                "planned": monthly_amount.get("plannedCashFlowAmount"),
+                "actual": monthly_amount.get("actualAmount"),
+                "remaining": monthly_amount.get("remainingAmount"),
+            }
+        )
+    return rows
+
+
+def _totals(node: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    node = node or {}
+    return {
+        "planned": node.get("plannedAmount"),
+        "actual": node.get("actualAmount"),
+        "remaining": node.get("remainingAmount"),
+    }
+
+
+def format_section_totals(budget_data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Format the per-month section rollups the way Monarch computes them.
+
+    Total budget = Fixed + Non-Monthly + Flex bucket (NOT the sum of individual
+    flex categories). Fixed and Non-Monthly totals auto-sum from their
+    sub-budgets; the Flexible total is the flex bucket.
+    """
+    totals_by_month = (budget_data.get("budgetData", {}) or {}).get(
+        "totalsByMonth", []
+    )
+    rows = []
+    for month_totals in totals_by_month:
+        rows.append(
+            {
+                "month": month_totals.get("month"),
+                "income": _totals(month_totals.get("totalIncome")),
+                "total_expenses": _totals(month_totals.get("totalExpenses")),
+                "fixed": _totals(month_totals.get("totalFixedExpenses")),
+                "non_monthly": _totals(month_totals.get("totalNonMonthlyExpenses")),
+                "flexible": _totals(month_totals.get("totalFlexibleExpenses")),
+            }
+        )
+    return rows
+
+
 @mcp.tool()
 async def get_budgets(
     start_date: Optional[str] = None,
@@ -127,15 +244,34 @@ async def get_budgets(
         end_date: End month in YYYY-MM-DD format (defaults to the current month)
 
     Returns:
-        A JSON list with one row per budgeted category per month. Each row has:
-        ``id`` (category id), ``name`` (category name), ``planned`` (planned
-        cash-flow amount), ``actual`` (actual amount), ``remaining``,
-        ``category_group`` (group name), and ``month`` (YYYY-MM-DD).
+        A JSON object with three keys:
+
+        ``categories``: one row per budgeted category per month, each with
+            ``id``, ``name``, ``planned`` (planned cash-flow amount), ``actual``,
+            ``remaining``, ``category_group``, and ``month`` (YYYY-MM-DD).
+        ``flex_bucket``: the Flex-bucket total per month (``month``, ``planned``,
+            ``actual``, ``remaining``). Under Fixed & Flexible budgeting THIS is
+            the real flexible budget — the flex categories' ``planned`` values are
+            only guidelines and do NOT sum to it. Compare total flexible spend
+            against this.
+        ``section_totals``: per-month rollups (``fixed``, ``non_monthly``,
+            ``flexible``, ``total_expenses``, ``income``), each with
+            ``planned`` / ``actual`` / ``remaining``. Total budget = Fixed +
+            Non-Monthly + Flex bucket.
+
+        (For category-based budgets not using Flex, ``flex_bucket`` /
+        ``section_totals`` may be empty; use ``categories``.)
     """
     try:
         client = await get_monarch_client()
         budget_data = await get_budget_data(client, start_date, end_date)
-        return json_success(format_budget_data(budget_data))
+        return json_success(
+            {
+                "categories": format_budget_data(budget_data),
+                "flex_bucket": format_flex_bucket(budget_data),
+                "section_totals": format_section_totals(budget_data),
+            }
+        )
     except Exception as e:
         return json_error("get_budgets", e)
 

--- a/tests/test_budgets.py
+++ b/tests/test_budgets.py
@@ -8,9 +8,11 @@ from monarch_mcp_server.tools.budgets import get_budgets
 class TestGetBudgets:
     async def test_returns_formatted_category_rows(self):
         result = json.loads(await get_budgets())
-        assert isinstance(result, list)
-        assert len(result) == 2
-        groceries = next(row for row in result if row["id"] == "cat-1")
+        assert isinstance(result, dict)
+        assert set(result) >= {"categories", "flex_bucket", "section_totals"}
+        rows = result["categories"]
+        assert len(rows) == 2
+        groceries = next(row for row in rows if row["id"] == "cat-1")
         assert groceries == {
             "id": "cat-1",
             "name": "Groceries",

--- a/tests/test_server_budget.py
+++ b/tests/test_server_budget.py
@@ -1,4 +1,9 @@
-from monarch_mcp_server.tools.budgets import BUDGET_QUERY, format_budget_data
+from monarch_mcp_server.tools.budgets import (
+    BUDGET_QUERY,
+    format_budget_data,
+    format_flex_bucket,
+    format_section_totals,
+)
 
 
 def test_budget_query_avoids_stale_category_group_fields():
@@ -9,6 +14,16 @@ def test_budget_query_avoids_stale_category_group_fields():
 
     assert "budgetVariability" not in query_text
     assert "rolloverPeriod" not in query_text
+
+
+def test_budget_query_includes_flex_and_section_totals():
+    # Flex-budget context lives on budgetData (safe fields), so it must be
+    # requested for the flexible-budget analysis to be correct.
+    query_text = BUDGET_QUERY.document.loc.source.body
+
+    assert "monthlyAmountsForFlexExpense" in query_text
+    assert "totalsByMonth" in query_text
+    assert "totalFlexibleExpenses" in query_text
 
 
 def test_format_budget_data_returns_current_month_category_rows():
@@ -46,5 +61,82 @@ def test_format_budget_data_returns_current_month_category_rows():
             "remaining": -75,
             "category_group": "Food",
             "month": "2026-06-01",
+        }
+    ]
+
+
+def test_format_flex_bucket_extracts_monthly_totals():
+    raw = {
+        "budgetData": {
+            "monthlyAmountsForFlexExpense": {
+                "budgetVariability": "flexible",
+                "monthlyAmounts": [
+                    {
+                        "month": "2026-06-01",
+                        "plannedCashFlowAmount": 2650.0,
+                        "actualAmount": 5302.75,
+                        "remainingAmount": -2652.75,
+                    }
+                ],
+            }
+        }
+    }
+    assert format_flex_bucket(raw) == [
+        {
+            "month": "2026-06-01",
+            "planned": 2650.0,
+            "actual": 5302.75,
+            "remaining": -2652.75,
+        }
+    ]
+
+
+def test_format_flex_bucket_handles_missing():
+    assert format_flex_bucket({"budgetData": {}}) == []
+
+
+def test_format_section_totals_extracts_rollups():
+    raw = {
+        "budgetData": {
+            "totalsByMonth": [
+                {
+                    "month": "2026-06-01",
+                    "totalIncome": {
+                        "plannedAmount": 100,
+                        "actualAmount": 90,
+                        "remainingAmount": 10,
+                    },
+                    "totalExpenses": {
+                        "plannedAmount": 80,
+                        "actualAmount": 70,
+                        "remainingAmount": 10,
+                    },
+                    "totalFixedExpenses": {
+                        "plannedAmount": 40,
+                        "actualAmount": 38,
+                        "remainingAmount": 2,
+                    },
+                    "totalNonMonthlyExpenses": {
+                        "plannedAmount": 10,
+                        "actualAmount": 12,
+                        "remainingAmount": -2,
+                    },
+                    "totalFlexibleExpenses": {
+                        "plannedAmount": 30,
+                        "actualAmount": 20,
+                        "remainingAmount": 10,
+                    },
+                }
+            ]
+        }
+    }
+    assert format_section_totals(raw) == [
+        {
+            "month": "2026-06-01",
+            "income": {"planned": 100, "actual": 90, "remaining": 10},
+            "total_expenses": {"planned": 80, "actual": 70, "remaining": 10},
+            "fixed": {"planned": 40, "actual": 38, "remaining": 2},
+            "non_monthly": {"planned": 10, "actual": 12, "remaining": -2},
+            "flexible": {"planned": 30, "actual": 20, "remaining": 10},
         }
     ]


### PR DESCRIPTION
## What & why

Under Monarch's **Fixed & Flexible** budgeting mode, the real flexible budget is a single **flex-bucket** total (`budgetData.monthlyAmountsForFlexExpense`) that the individual flex category sub-budgets do **not** sum to. Today `get_budgets` only returns per-category `planned`/`actual`, so any analysis of flexible spending compares against sub-budgets that aren't the real budget — which is misleading (you can be "under" on every flex category while the flex bucket is blown).

## Change

`get_budgets` now returns, alongside the existing category rows:

- **`flex_bucket`** — per-month flex-bucket `planned` / `actual` / `remaining`.
- **`section_totals`** — per-month **Fixed / Non-Monthly / Flexible / total_expenses / income** rollups, the way Monarch computes the budget (total budget = Fixed + Non-Monthly + Flex bucket).

Both come from fields on `budgetData` (`monthlyAmountsForFlexExpense`, `totalsByMonth`). They deliberately **do not** touch the guarded category-group fields (`budgetVariability` / `rolloverPeriod`) that some accounts reject — the existing compatibility guard and its test are preserved.

## Return shape

Changes from a bare list to `{ "categories": [...], "flex_bucket": [...], "section_totals": [...] }`. For category-based (non-flex) budgets, `flex_bucket` / `section_totals` come back empty and `categories` is unchanged.

## Tests

- Updated the return-shape and category-row tests.
- Added unit tests for `format_flex_bucket` and `format_section_totals`.
- Added a test asserting the query requests the flex fields (and the existing guard test still asserts no `budgetVariability`/`rolloverPeriod`).
- Full suite: **226 passing**.

Verified live against a Fixed & Flex account: the flex bucket and Fixed/Non-Monthly/Flexible section totals return correctly per month.

🤖 Generated with [Claude Code](https://claude.com/claude-code)