### PR TITLE
fix: correct Monarch domain to monarch.com + graceful fallback for clients without elicitation

### DIFF
--- a/src/monarch_mcp_server/auth.py
+++ b/src/monarch_mcp_server/auth.py
@@ -22,6 +22,14 @@ _UPGRADE_HINT = (
     "`python login_setup.py` from the repo to authenticate via terminal."
 )
 
+_CLIENT_NO_ELICITATION = (
+    "Your MCP client does not support the elicitation protocol "
+    "(it returned -32601 Method not found). "
+    "Use 'monarch_login_with_token' instead: open monarch.com in your browser, "
+    "go to DevTools → Application → Local Storage → https://app.monarch.com, "
+    "copy the 'token' value, and paste it when prompted."
+)
+
 
 def _elicit_supported(ctx: Context) -> bool:
     return hasattr(ctx, "elicit")
@@ -40,7 +48,7 @@ class TokenForm(BaseModel):
     token: str = Field(
         description=(
             "Monarch Money session token. Grab it from browser DevTools → "
-            "Application → Local Storage for app.monarchmoney.com, key 'token'."
+            "Application → Local Storage for app.monarch.com, key 'token'."
         ),
     )
 
@@ -48,7 +56,12 @@ class TokenForm(BaseModel):
 async def login_interactive(ctx: Context) -> str:
     if not _elicit_supported(ctx):
         return _UPGRADE_HINT
-    form_result = await ctx.elicit(message="Sign in to Monarch Money.", schema=LoginForm)
+    try:
+        form_result = await ctx.elicit(message="Sign in to Monarch Money.", schema=LoginForm)
+    except Exception as e:
+        if "Method not found" in str(e) or "-32601" in str(e):
+            return _CLIENT_NO_ELICITATION
+        raise
     if form_result.action != "accept":
         return "Login cancelled."
     form = form_result.data
@@ -62,9 +75,14 @@ async def login_interactive(ctx: Context) -> str:
             save_session=False,
         )
     except RequireMFAException:
-        mfa_result = await ctx.elicit(
-            message="Enter your Monarch Money MFA code.", schema=MFAForm
-        )
+        try:
+            mfa_result = await ctx.elicit(
+                message="Enter your Monarch Money MFA code.", schema=MFAForm
+            )
+        except Exception as e:
+            if "Method not found" in str(e) or "-32601" in str(e):
+                return _CLIENT_NO_ELICITATION
+            raise
         if mfa_result.action != "accept":
             return "Login cancelled."
         await mm.multi_factor_authenticate(
@@ -78,9 +96,14 @@ async def login_interactive(ctx: Context) -> str:
 async def login_with_token_interactive(ctx: Context) -> str:
     if not _elicit_supported(ctx):
         return _UPGRADE_HINT
-    form_result = await ctx.elicit(
-        message="Paste your Monarch Money session token.", schema=TokenForm
-    )
+    try:
+        form_result = await ctx.elicit(
+            message="Paste your Monarch Money session token.", schema=TokenForm
+        )
+    except Exception as e:
+        if "Method not found" in str(e) or "-32601" in str(e):
+            return _CLIENT_NO_ELICITATION
+        raise
     if form_result.action != "accept":
         return "Login cancelled."
 

--- a/src/monarch_mcp_server/tools/auth.py
+++ b/src/monarch_mcp_server/tools/auth.py
@@ -51,7 +51,7 @@ async def monarch_login_with_token(ctx: Context) -> str:
     """Sign in to Monarch Money using a browser-copied session token.
 
     Useful for SSO users who can't use password login. Grab the token from
-    browser DevTools → Application → Local Storage → app.monarchmoney.com.
+    browser DevTools → Application → Local Storage → app.monarch.com.
     """
     return await auth.login_with_token_interactive(ctx)
 


### PR DESCRIPTION
## What

Two correctness/robustness fixes:

1. **Domain migration in user-facing text.** Monarch retired `app.monarchmoney.com` in favour of `app.monarch.com`. The token instructions (`TokenForm` description and the `monarch_login_with_token` docstring) still point users at the old domain, where the `token` local-storage key no longer lives. Updated to `app.monarch.com`.

2. **Graceful handling for MCP clients without elicitation.** Some clients don't implement the elicitation protocol and return `-32601 Method not found` when `ctx.elicit(...)` is called. Today that surfaces as an opaque error. This catches it in the login, MFA, and token-login flows and returns a clear message telling the user to use `monarch_login_with_token` instead (with step-by-step token retrieval).

## Notes

- No behavioral change for clients that *do* support elicitation — the try/except only intercepts the `-32601` case and re-raises anything else.
- No new dependencies.