### PR TITLE
Add remote HTTP serve mode: bearer-token auth, headless login, and Claude connector support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,6 @@ docs
 scripts
 .pytest_cache
 .mypy_cache
+.github
+.gitignore
+.superpowers

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.venv
+__pycache__
+*.pyc
+tests
+docs
+scripts
+.pytest_cache
+.mypy_cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN pip install --no-cache-dir .
 
 # Non-root user; HOME=/data puts the file-fallback session store
 # (~/.monarch-mcp-server/token) on the persistent volume.
-RUN useradd --create-home --uid 1000 monarch \
+RUN useradd --no-create-home --uid 1000 monarch \
     && mkdir -p /data \
     && chown monarch:monarch /data
 ENV HOME=/data \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
+COPY login_setup.py ./
+
+RUN pip install --no-cache-dir .
+
+# Non-root user; HOME=/data puts the file-fallback session store
+# (~/.monarch-mcp-server/token) on the persistent volume.
+RUN useradd --create-home --uid 1000 monarch \
+    && mkdir -p /data \
+    && chown monarch:monarch /data
+ENV HOME=/data \
+    MONARCH_MCP_MODE=serve \
+    MONARCH_MCP_HOST=0.0.0.0 \
+    MONARCH_MCP_PORT=8000
+USER monarch
+VOLUME /data
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz')"
+
+ENTRYPOINT ["monarch-mcp-server"]
+CMD ["serve"]

--- a/README.md
+++ b/README.md
@@ -476,6 +476,166 @@ monarch-mcp-server/
 - Session tokens are stored in the system keyring
 - Authentication handled in secure terminal environment
 
+## 🌐 Remote Access (HTTP)
+
+The server can run over streamable HTTP with bearer-token authentication for remote deployment scenarios. The default stdio mode remains unchanged and is recommended for local use with Claude Desktop or Claude Code.
+
+### What It Is
+
+Run `monarch-mcp-server serve` to expose the MCP server over HTTP instead of stdio. All requests require a bearer token for authentication. This mode is designed for:
+
+- Running the server on a remote machine (VPS, home server, cloud instance)
+- Accessing your Monarch data from multiple devices
+- Deploying behind a reverse proxy with TLS
+
+### Generate an Authentication Token
+
+Create a secure random token:
+
+```bash
+openssl rand -base64 33
+```
+
+Store it securely and provide it to the server via environment variables.
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MONARCH_MCP_AUTH_TOKEN` | Bearer token for authentication | (required) |
+| `MONARCH_MCP_AUTH_TOKEN_FILE` | Path to file containing the token (preferred; env vars show in `docker inspect`) | — |
+| `MONARCH_MCP_HOST` | Bind address | `127.0.0.1` |
+| `MONARCH_MCP_PORT` | Bind port | `8000` |
+| `MONARCH_MCP_ALLOWED_HOSTS` | Comma-separated list of allowed Host headers (e.g., `monarch.example.com`) | — |
+| `MONARCH_MCP_PUBLIC_URL` | Public-facing URL for the server (used in responses) | `http://{host}:{port}` |
+
+**Note:** Tokens must be at least 32 characters. The server enforces this on startup.
+
+### Docker Quick Start
+
+1. **Create a `.env` file** in the repository root:
+
+   ```bash
+   MONARCH_MCP_AUTH_TOKEN=<output-of-openssl-rand-base64-33>
+   ```
+
+2. **Start the server**:
+
+   ```bash
+   docker compose up -d
+   ```
+
+   The server binds to `127.0.0.1:8000` by default. Never expose this port directly to the internet without TLS.
+
+3. **Verify it's running**:
+
+   ```bash
+   curl http://127.0.0.1:8000/healthz
+   ```
+
+### Monarch Login Inside the Container
+
+The MCP login tools (`monarch_login`, `monarch_login_with_token`) are disabled in serve mode by design. Authenticate using the standalone `login_setup.py` script inside the container:
+
+```bash
+docker compose run --rm -it --entrypoint python monarch-mcp login_setup.py
+```
+
+**Recommended:** Use cookie-paste (option 1 in the script). Password login from VPS or datacenter IPs is frequently CAPTCHA-blocked by Cloudflare. Cookie sessions track your browser login lifetime and avoid this issue entirely.
+
+Sessions persist in the `monarch-data` volume, where the server reads them.
+
+### Cloudflare Tunnel (Recommended)
+
+Cloudflare Tunnel provides zero-configuration TLS and DDOS protection without opening firewall ports.
+
+1. **Create a tunnel** in the [Cloudflare Zero Trust dashboard](https://one.dash.cloudflare.com/):
+   - Navigate to **Networks > Tunnels**
+   - Create a new tunnel and note the tunnel token
+   - Configure a public hostname (e.g., `monarch.example.com`) pointing to `http://monarch-mcp:8000`
+
+2. **Add the tunnel token to `.env`**:
+
+   ```bash
+   TUNNEL_TOKEN=<your-cloudflare-tunnel-token>
+   ```
+
+3. **Update `.env` with your public hostname**:
+
+   ```bash
+   MONARCH_MCP_ALLOWED_HOSTS=monarch.example.com
+   MONARCH_MCP_PUBLIC_URL=https://monarch.example.com
+   ```
+
+4. **Start the tunnel**:
+
+   ```bash
+   docker compose --profile tunnel up -d
+   ```
+
+5. **Verify**:
+
+   ```bash
+   curl https://monarch.example.com/healthz
+   ```
+
+### Generic Reverse Proxy
+
+If not using Cloudflare Tunnel, deploy a reverse proxy with TLS. Example with [Caddy](https://caddyserver.com/):
+
+```
+monarch.example.com {
+    reverse_proxy 127.0.0.1:8000
+}
+```
+
+**Warning:** NEVER expose port 8000 directly to the internet without TLS and authentication. The bearer token is transmitted in HTTP headers and must be protected by transport encryption.
+
+### Connect Claude Code
+
+Add the server to Claude Code using the `claude mcp add` command:
+
+```bash
+claude mcp add --transport http monarch https://monarch.example.com/mcp \
+    --header "Authorization: Bearer <your-token>"
+```
+
+Replace `https://monarch.example.com` with your actual server URL and `<your-token>` with the token from your `.env` file.
+
+### Connect Claude Desktop
+
+Claude Desktop can connect via the `mcp-remote` proxy:
+
+```json
+{
+  "mcpServers": {
+    "monarch": {
+      "command": "npx",
+      "args": [
+        "mcp-remote", "https://monarch.example.com/mcp",
+        "--header", "Authorization: Bearer ${MONARCH_TOKEN}"
+      ],
+      "env": { "MONARCH_TOKEN": "<your-token>" }
+    }
+  }
+}
+```
+
+Add this to your Claude Desktop configuration:
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+**Note:** The native paste-URL connector UI in Claude Desktop requires OAuth support, which is planned for a future phase.
+
+### Security Notes
+
+- **Full Account Access:** The bearer token grants complete access to your Monarch account. Treat it like a password.
+- **Token Rotation:** To rotate the token, generate a new one, update your `.env` file, and restart the server (`docker compose restart monarch-mcp`).
+- **Unauthenticated Routes:** `/healthz` is the only route that does not require authentication. All MCP endpoints require a valid bearer token.
+- **Login Tools Disabled:** The `monarch_login` and `monarch_login_with_token` MCP tools are disabled in serve mode. Use the standalone `login_setup.py` script inside the container (see above).
+- **Transport Security:** Always use TLS (HTTPS) when exposing the server over a network. Unencrypted HTTP exposes the bearer token to interception.
+
 ### Recommended: require approval for mutating tools
 
 Several tools mutate your Monarch ledger (`create_transaction`, `update_transaction`, `delete_transaction`, `bulk_categorize_transactions`, `upload_account_balance_history`, `set_transaction_tags`, `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`, `split_transaction`, `set_budget_amount`, `update_merchant`, `review_recurring_stream`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  monarch-mcp:
+    build: .
+    restart: unless-stopped
+    # Bind to localhost only; a reverse proxy or tunnel provides TLS.
+    # NEVER publish 8000 directly to the internet.
+    ports:
+      - "127.0.0.1:8000:8000"
+    environment:
+      # Generate with: openssl rand -base64 33
+      # Prefer MONARCH_MCP_AUTH_TOKEN_FILE with a mounted secret in
+      # production; env vars are visible via `docker inspect`.
+      MONARCH_MCP_AUTH_TOKEN: ${MONARCH_MCP_AUTH_TOKEN:?set in .env}
+      # Uncomment behind a proxy so Host-header checks are enforced:
+      # MONARCH_MCP_ALLOWED_HOSTS: monarch.example.com
+      # MONARCH_MCP_PUBLIC_URL: https://monarch.example.com
+    volumes:
+      - monarch-data:/data
+
+  # Optional: Cloudflare Tunnel. Create a tunnel + token in the Zero Trust
+  # dashboard, point its public hostname at http://monarch-mcp:8000, then:
+  #   docker compose --profile tunnel up -d
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    profiles: ["tunnel"]
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      TUNNEL_TOKEN: ${TUNNEL_TOKEN:?set in .env}
+    depends_on:
+      - monarch-mcp
+
+volumes:
+  monarch-data:

--- a/docs/superpowers/plans/2026-07-08-remote-http-phase1a.md
+++ b/docs/superpowers/plans/2026-07-08-remote-http-phase1a.md
@@ -1,0 +1,1295 @@
+# Remote HTTP Access (Phase 1a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `serve` mode that exposes the existing MCP server over streamable HTTP with static bearer-token auth, deployable via Docker behind Cloudflare Tunnel or any reverse proxy, while leaving stdio mode byte-for-byte compatible.
+
+**Architecture:** Mode is resolved from CLI/env *before* `app.py` is imported (FastMCP auth is constructor-only). A new `cli.py` dispatcher sets `MONARCH_MCP_MODE` then imports `app`, which builds `FastMCP` with a `StaticTokenVerifier` in serve mode. Login MCP tools are not registered in serve mode; Monarch sessions come from `login_setup.py` run on the host (cookie-paste primary). Session storage is unchanged (keyring/file).
+
+**Tech Stack:** Python 3.12, `mcp>=1.28,<2` (FastMCP, streamable HTTP, TokenVerifier), uvicorn (ships with `mcp[cli]`), Docker multi-arch, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-08-remote-http-phase1a-design.md`
+
+## Global Constraints
+
+- `mcp>=1.28,<2` (1.13.x has a session/credential binding hole in stateful HTTP).
+- `requires-python = ">=3.12,<3.14"` — unchanged.
+- Stdio mode must keep working with zero behavior change (existing tests keep passing unmodified except where a test asserts import-time keyring probing).
+- Auth token: min 32 chars, compared with `hmac.compare_digest`, sourced from `MONARCH_MCP_AUTH_TOKEN_FILE` (precedence) or `MONARCH_MCP_AUTH_TOKEN`. Serve mode refuses to start without it.
+- Serve mode: `json_response=True`, stateful sessions (default), no proxy-header trust, global (not per-IP) auth-failure throttle.
+- `/healthz` returns exactly `ok`, unauthenticated, no version info.
+- Serve mode never registers: `setup_authentication`, `monarch_login`, `monarch_login_with_token`, `monarch_logout`, `debug_session_loading`. It DOES register `check_auth_status`.
+- No new runtime Python dependencies.
+- Spec deviation (documented): the SDK requires `AuthSettings.issuer_url` even in TokenVerifier-only mode, so serve mode accepts optional `MONARCH_MCP_PUBLIC_URL` (default `http://127.0.0.1:<port>`). It only affects the RFC 9728 metadata advertised in 401 responses; static-token clients ignore it.
+- Commit messages: plain, no AI attribution of any kind.
+- Repo uses `uv` (uv.lock present). Run tests with `uv run pytest`; sync with `uv sync --extra dev`.
+
+## File Structure
+
+- Create: `src/monarch_mcp_server/config.py` — mode resolution + `ServeConfig`
+- Create: `src/monarch_mcp_server/http_auth.py` — `StaticTokenVerifier`
+- Create: `src/monarch_mcp_server/cli.py` — entry-point dispatcher (parses argv before importing `app`)
+- Modify: `src/monarch_mcp_server/app.py` — mode-aware FastMCP construction, `/healthz`
+- Modify: `src/monarch_mcp_server/secure_session.py` — lazy keyring probe
+- Modify: `src/monarch_mcp_server/tools/auth.py` — conditional login-tool registration
+- Modify: `pyproject.toml` — mcp floor, entry point → `cli:main`
+- Create: `tests/test_config.py`, `tests/test_http_auth.py`, `tests/test_serve_http.py`
+- Create: `Dockerfile`, `.dockerignore`, `docker-compose.yml`, `scripts/e2e_http.py`
+- Modify: `README.md`, `requirements.txt`
+
+---
+
+### Task 1: Upgrade MCP SDK to >=1.28,<2
+
+**Files:**
+- Modify: `pyproject.toml:23` (`"mcp[cli]>=1.10.0"` → `"mcp[cli]>=1.28,<2"`)
+- Modify: `requirements.txt` (mcp line, if pinned)
+
+**Interfaces:**
+- Produces: an environment where `from mcp.server.auth.provider import TokenVerifier, AccessToken`, `from mcp.server.auth.settings import AuthSettings`, and `from mcp.server.transport_security import TransportSecuritySettings` all import.
+
+- [ ] **Step 1: Bump the constraint**
+
+In `pyproject.toml` dependencies, change `"mcp[cli]>=1.10.0"` to `"mcp[cli]>=1.28,<2"`. Check `requirements.txt` for an `mcp` line and align it if present.
+
+- [ ] **Step 2: Re-lock and sync**
+
+Run: `uv sync --extra dev`
+Expected: resolves mcp to 1.28.x, no conflicts.
+
+- [ ] **Step 3: Verify new APIs import**
+
+Run: `uv run python -c "from mcp.server.auth.provider import TokenVerifier, AccessToken; from mcp.server.auth.settings import AuthSettings; from mcp.server.transport_security import TransportSecuritySettings; print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 4: Run the full existing suite**
+
+Run: `uv run pytest`
+Expected: all existing tests pass. If any fail from SDK API drift (e.g. elicitation interfaces in `auth.py`), fix the call sites minimally and note it in the commit message.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml uv.lock requirements.txt
+git commit -m "Upgrade mcp SDK to >=1.28,<2 for streamable HTTP session-credential binding"
+```
+
+---
+
+### Task 2: Lazy keyring probe in SecureMonarchSession
+
+**Files:**
+- Modify: `src/monarch_mcp_server/secure_session.py:64-69` (`__init__`) and every `self._use_keyring` read (lines 131, 177, 221)
+- Test: `tests/test_secure_session.py` (append)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `SecureMonarchSession()` construction performs no keyring access; probing happens on first `save_session_blob`/`load_session`/`delete_token` call via the private property `_keyring_ok: bool`. Public API unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_secure_session.py`:
+
+```python
+class TestLazyKeyringProbe:
+    def test_constructor_does_not_probe_keyring(self):
+        from monarch_mcp_server import secure_session as ss
+
+        with patch.object(ss, "_keyring_available") as probe:
+            ss.SecureMonarchSession()
+            probe.assert_not_called()
+
+    def test_first_use_probes_keyring_once(self, tmp_path):
+        from monarch_mcp_server import secure_session as ss
+
+        with patch.object(ss, "_keyring_available", return_value=False) as probe, \
+             patch.object(ss, "_TOKEN_DIR", tmp_path), \
+             patch.object(ss, "_TOKEN_FILE", tmp_path / "token"):
+            session = ss.SecureMonarchSession()
+            session.load_session()
+            session.load_session()
+            assert probe.call_count == 1
+```
+
+(`patch` is already imported in this test file; if not, add `from unittest.mock import patch`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_secure_session.py::TestLazyKeyringProbe -v`
+Expected: FAIL — constructor currently calls `_keyring_available()`.
+
+- [ ] **Step 3: Implement the lazy probe**
+
+Replace `__init__` in `secure_session.py`:
+
+```python
+    def __init__(self) -> None:
+        # Keyring availability is probed lazily on first use. Probing in the
+        # constructor triggers keyring access (a macOS Keychain prompt in some
+        # setups) for any import of this package, even when the session store
+        # is never used (e.g. serve mode).
+        self._use_keyring: Optional[bool] = None
+
+    @property
+    def _keyring_ok(self) -> bool:
+        if self._use_keyring is None:
+            self._use_keyring = _keyring_available()
+            if self._use_keyring:
+                logger.info("🔐 Using system keyring for token storage")
+            else:
+                logger.info("🔐 Keyring unavailable — using file-based token storage")
+        return self._use_keyring
+```
+
+Then replace the three reads: `if self._use_keyring:` → `if self._keyring_ok:` in `save_session_blob`, `load_session`, and `delete_token`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_secure_session.py -v`
+Expected: PASS (all, including pre-existing tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/monarch_mcp_server/secure_session.py tests/test_secure_session.py
+git commit -m "Probe keyring lazily instead of at import time"
+```
+
+---
+
+### Task 3: Mode resolution and serve configuration (`config.py`)
+
+**Files:**
+- Create: `src/monarch_mcp_server/config.py`
+- Test: `tests/test_config.py`
+
+**Interfaces:**
+- Consumes: environment variables only.
+- Produces:
+  - `get_mode() -> str` — returns `"stdio"` or `"serve"` from `MONARCH_MCP_MODE` (default `"stdio"`; unknown values raise `ValueError`).
+  - `ServeConfig` frozen dataclass: `host: str`, `port: int`, `auth_token: str`, `issuer_url: str`, `allowed_hosts: list[str]`; classmethod `from_env() -> ServeConfig` raising `ValueError` on missing/short token.
+  - `MIN_TOKEN_LENGTH = 32` constant (Task 4 reuses it).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_config.py`:
+
+```python
+"""Tests for mode resolution and serve configuration."""
+
+import pytest
+
+from monarch_mcp_server.config import MIN_TOKEN_LENGTH, ServeConfig, get_mode
+
+VALID_TOKEN = "x" * MIN_TOKEN_LENGTH
+
+
+class TestGetMode:
+    def test_default_is_stdio(self, monkeypatch):
+        monkeypatch.delenv("MONARCH_MCP_MODE", raising=False)
+        assert get_mode() == "stdio"
+
+    def test_serve_from_env(self, monkeypatch):
+        monkeypatch.setenv("MONARCH_MCP_MODE", "serve")
+        assert get_mode() == "serve"
+
+    def test_unknown_mode_raises(self, monkeypatch):
+        monkeypatch.setenv("MONARCH_MCP_MODE", "bananas")
+        with pytest.raises(ValueError, match="MONARCH_MCP_MODE"):
+            get_mode()
+
+
+class TestServeConfig:
+    def _clear(self, monkeypatch):
+        for var in (
+            "MONARCH_MCP_AUTH_TOKEN",
+            "MONARCH_MCP_AUTH_TOKEN_FILE",
+            "MONARCH_MCP_HOST",
+            "MONARCH_MCP_PORT",
+            "MONARCH_MCP_PUBLIC_URL",
+            "MONARCH_MCP_ALLOWED_HOSTS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_defaults(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("MONARCH_MCP_AUTH_TOKEN", VALID_TOKEN)
+        cfg = ServeConfig.from_env()
+        assert cfg.host == "127.0.0.1"
+        assert cfg.port == 8000
+        assert cfg.auth_token == VALID_TOKEN
+        assert cfg.issuer_url == "http://127.0.0.1:8000"
+        assert cfg.allowed_hosts == []
+
+    def test_missing_token_raises(self, monkeypatch):
+        self._clear(monkeypatch)
+        with pytest.raises(ValueError, match="MONARCH_MCP_AUTH_TOKEN"):
+            ServeConfig.from_env()
+
+    def test_short_token_raises(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("MONARCH_MCP_AUTH_TOKEN", "short")
+        with pytest.raises(ValueError, match="32"):
+            ServeConfig.from_env()
+
+    def test_token_file_takes_precedence(self, monkeypatch, tmp_path):
+        self._clear(monkeypatch)
+        token_file = tmp_path / "token"
+        token_file.write_text("f" * MIN_TOKEN_LENGTH + "\n")
+        monkeypatch.setenv("MONARCH_MCP_AUTH_TOKEN", "e" * MIN_TOKEN_LENGTH)
+        monkeypatch.setenv("MONARCH_MCP_AUTH_TOKEN_FILE", str(token_file))
+        cfg = ServeConfig.from_env()
+        assert cfg.auth_token == "f" * MIN_TOKEN_LENGTH  # stripped, file wins
+
+    def test_custom_host_port_public_url_and_allowed_hosts(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("MONARCH_MCP_AUTH_TOKEN", VALID_TOKEN)
+        monkeypatch.setenv("MONARCH_MCP_HOST", "0.0.0.0")
+        monkeypatch.setenv("MONARCH_MCP_PORT", "9100")
+        monkeypatch.setenv("MONARCH_MCP_PUBLIC_URL", "https://monarch.example.com")
+        monkeypatch.setenv(
+            "MONARCH_MCP_ALLOWED_HOSTS", "monarch.example.com, localhost:9100"
+        )
+        cfg = ServeConfig.from_env()
+        assert cfg.host == "0.0.0.0"
+        assert cfg.port == 9100
+        assert cfg.issuer_url == "https://monarch.example.com"
+        assert cfg.allowed_hosts == ["monarch.example.com", "localhost:9100"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_config.py -v`
+Expected: FAIL — `monarch_mcp_server.config` does not exist.
+
+- [ ] **Step 3: Implement `config.py`**
+
+Create `src/monarch_mcp_server/config.py`:
+
+```python
+"""Run-mode resolution and serve-mode configuration.
+
+Mode must be resolved before ``app.py`` is imported: FastMCP accepts auth
+settings only at construction, and tools register at import time.
+"""
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+MODE_ENV = "MONARCH_MCP_MODE"
+MIN_TOKEN_LENGTH = 32
+
+
+def get_mode() -> str:
+    """Return the run mode: "stdio" (default) or "serve"."""
+    mode = os.environ.get(MODE_ENV, "stdio").strip().lower()
+    if mode not in ("stdio", "serve"):
+        raise ValueError(
+            f"{MODE_ENV} must be 'stdio' or 'serve', got {mode!r}"
+        )
+    return mode
+
+
+@dataclass(frozen=True)
+class ServeConfig:
+    """Configuration for serve (streamable HTTP) mode, read from env vars."""
+
+    host: str
+    port: int
+    auth_token: str
+    issuer_url: str
+    allowed_hosts: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_env(cls) -> "ServeConfig":
+        host = os.environ.get("MONARCH_MCP_HOST", "127.0.0.1")
+        port = int(os.environ.get("MONARCH_MCP_PORT", "8000"))
+
+        token = ""
+        token_file = os.environ.get("MONARCH_MCP_AUTH_TOKEN_FILE")
+        if token_file:
+            token = Path(token_file).read_text().strip()
+        if not token:
+            token = os.environ.get("MONARCH_MCP_AUTH_TOKEN", "").strip()
+        if not token:
+            raise ValueError(
+                "Serve mode requires MONARCH_MCP_AUTH_TOKEN or "
+                "MONARCH_MCP_AUTH_TOKEN_FILE. Generate one with: "
+                "openssl rand -base64 33"
+            )
+        if len(token) < MIN_TOKEN_LENGTH:
+            raise ValueError(
+                f"Auth token must be at least {MIN_TOKEN_LENGTH} characters "
+                f"(got {len(token)}). Generate one with: openssl rand -base64 33"
+            )
+
+        issuer_url = os.environ.get(
+            "MONARCH_MCP_PUBLIC_URL", f"http://{host}:{port}"
+        ).rstrip("/")
+
+        raw_hosts = os.environ.get("MONARCH_MCP_ALLOWED_HOSTS", "")
+        allowed_hosts = [h.strip() for h in raw_hosts.split(",") if h.strip()]
+
+        return cls(
+            host=host,
+            port=port,
+            auth_token=token,
+            issuer_url=issuer_url,
+            allowed_hosts=allowed_hosts,
+        )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_config.py -v`
+Expected: PASS (all 9).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/monarch_mcp_server/config.py tests/test_config.py
+git commit -m "Add run-mode resolution and serve-mode configuration"
+```
+
+---
+
+### Task 4: Static token verifier (`http_auth.py`)
+
+**Files:**
+- Create: `src/monarch_mcp_server/http_auth.py`
+- Test: `tests/test_http_auth.py`
+
+**Interfaces:**
+- Consumes: `mcp.server.auth.provider.AccessToken` (SDK model: `token`, `client_id`, `scopes` required).
+- Produces: `StaticTokenVerifier(expected_token: str, max_failures_per_minute: int = 10)` implementing the SDK `TokenVerifier` protocol — `async verify_token(token: str) -> AccessToken | None`. Constant-time comparison; after `max_failures_per_minute` failures within 60s, each further failure sleeps 2s before returning None (global throttle, deliberately not per-IP).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_http_auth.py`:
+
+```python
+"""Tests for the static bearer token verifier."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from monarch_mcp_server.http_auth import StaticTokenVerifier
+
+TOKEN = "t" * 40
+
+
+class TestStaticTokenVerifier:
+    async def test_valid_token_returns_access_token(self):
+        verifier = StaticTokenVerifier(TOKEN)
+        result = await verifier.verify_token(TOKEN)
+        assert result is not None
+        assert result.client_id == "static-token-client"
+
+    async def test_invalid_token_returns_none(self):
+        verifier = StaticTokenVerifier(TOKEN)
+        assert await verifier.verify_token("w" * 40) is None
+
+    async def test_empty_and_prefix_tokens_rejected(self):
+        verifier = StaticTokenVerifier(TOKEN)
+        assert await verifier.verify_token("") is None
+        assert await verifier.verify_token(TOKEN[:-1]) is None
+        assert await verifier.verify_token(TOKEN + "x") is None
+
+    async def test_uses_constant_time_comparison(self):
+        verifier = StaticTokenVerifier(TOKEN)
+        with patch("monarch_mcp_server.http_auth.hmac.compare_digest",
+                   wraps=__import__("hmac").compare_digest) as cmp:
+            await verifier.verify_token(TOKEN)
+            cmp.assert_called_once()
+
+    async def test_throttles_after_repeated_failures(self):
+        verifier = StaticTokenVerifier(TOKEN, max_failures_per_minute=3)
+        with patch("monarch_mcp_server.http_auth.asyncio.sleep",
+                   new=AsyncMock()) as sleep:
+            for _ in range(3):
+                await verifier.verify_token("bad" * 20)
+            sleep.assert_not_called()
+            await verifier.verify_token("bad" * 20)
+            sleep.assert_awaited_once_with(2)
+
+    async def test_successes_do_not_throttle(self):
+        verifier = StaticTokenVerifier(TOKEN, max_failures_per_minute=1)
+        with patch("monarch_mcp_server.http_auth.asyncio.sleep",
+                   new=AsyncMock()) as sleep:
+            for _ in range(5):
+                await verifier.verify_token(TOKEN)
+            sleep.assert_not_called()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_http_auth.py -v`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the verifier**
+
+Create `src/monarch_mcp_server/http_auth.py`:
+
+```python
+"""Static bearer-token verification for serve mode."""
+
+import asyncio
+import hmac
+import logging
+import time
+from collections import deque
+from typing import Deque, Optional
+
+from mcp.server.auth.provider import AccessToken
+
+logger = logging.getLogger(__name__)
+
+_THROTTLE_WINDOW_SECONDS = 60.0
+_THROTTLE_DELAY_SECONDS = 2
+
+
+class StaticTokenVerifier:
+    """Verifies the single operator-issued bearer token.
+
+    Failed attempts are throttled globally (not per-IP): behind a tunnel all
+    traffic shares one peer address, and trusting X-Forwarded-For would let a
+    direct-connecting client dodge the limit by spoofing the header.
+    """
+
+    def __init__(self, expected_token: str, max_failures_per_minute: int = 10):
+        self._expected = expected_token.encode()
+        self._max_failures = max_failures_per_minute
+        self._failures: Deque[float] = deque()
+
+    async def verify_token(self, token: str) -> Optional[AccessToken]:
+        if hmac.compare_digest(token.encode(), self._expected):
+            return AccessToken(
+                token=token, client_id="static-token-client", scopes=[]
+            )
+
+        now = time.monotonic()
+        self._failures.append(now)
+        while self._failures and now - self._failures[0] > _THROTTLE_WINDOW_SECONDS:
+            self._failures.popleft()
+        if len(self._failures) > self._max_failures:
+            logger.warning(
+                "Auth failure throttle engaged (%d failures in the last minute)",
+                len(self._failures),
+            )
+            await asyncio.sleep(_THROTTLE_DELAY_SECONDS)
+        return None
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_http_auth.py -v`
+Expected: PASS (all 6).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/monarch_mcp_server/http_auth.py tests/test_http_auth.py
+git commit -m "Add static bearer token verifier with global failure throttle"
+```
+
+---
+
+### Task 5: Mode-aware app construction and conditional tool registration
+
+**Files:**
+- Modify: `src/monarch_mcp_server/app.py` (full rewrite shown below)
+- Modify: `src/monarch_mcp_server/tools/auth.py` (registration block)
+- Test: `tests/test_serve_mode.py` (new; uses subprocesses because tool registration is an import-time effect)
+
+**Interfaces:**
+- Consumes: `get_mode()`, `ServeConfig.from_env()` (Task 3), `StaticTokenVerifier` (Task 4).
+- Produces: `monarch_mcp_server.app.mcp` — a `FastMCP` built for the resolved mode; `monarch_mcp_server.app.MODE` — the resolved mode string; `main()` unchanged for stdio. In serve mode `/healthz` is registered via `custom_route`. Tool functions in `tools/auth.py` remain importable in both modes (the `server.py` shim keeps working); only their *registration* is conditional.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_serve_mode.py`:
+
+```python
+"""Mode-dependent app construction and tool registration.
+
+Registration happens at import time, so each case runs in a fresh
+interpreter with the mode set via environment variables.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+LIST_TOOLS_SNIPPET = (
+    "import asyncio, json;"
+    "from monarch_mcp_server.app import mcp;"
+    "tools = asyncio.run(mcp.list_tools());"
+    "print(json.dumps(sorted(t.name for t in tools)))"
+)
+
+LOGIN_TOOLS = {
+    "setup_authentication",
+    "monarch_login",
+    "monarch_login_with_token",
+    "monarch_logout",
+    "debug_session_loading",
+}
+
+
+def _tool_names(extra_env):
+    env = os.environ | extra_env
+    out = subprocess.run(
+        [sys.executable, "-c", LIST_TOOLS_SNIPPET],
+        capture_output=True, text=True, env=env, check=True,
+    )
+    return set(json.loads(out.stdout.strip().splitlines()[-1]))
+
+
+def test_stdio_mode_registers_login_tools():
+    names = _tool_names({"MONARCH_MCP_MODE": "stdio"})
+    assert LOGIN_TOOLS <= names
+    assert "check_auth_status" in names
+    assert "get_accounts" in names
+
+
+def test_serve_mode_omits_login_tools():
+    names = _tool_names({
+        "MONARCH_MCP_MODE": "serve",
+        "MONARCH_MCP_AUTH_TOKEN": "x" * 40,
+    })
+    assert LOGIN_TOOLS.isdisjoint(names)
+    assert "check_auth_status" in names
+    assert "get_accounts" in names
+
+
+def test_serve_mode_without_token_fails_fast():
+    env = os.environ | {"MONARCH_MCP_MODE": "serve"}
+    env.pop("MONARCH_MCP_AUTH_TOKEN", None)
+    env.pop("MONARCH_MCP_AUTH_TOKEN_FILE", None)
+    out = subprocess.run(
+        [sys.executable, "-c", "import monarch_mcp_server.app"],
+        capture_output=True, text=True, env=env,
+    )
+    assert out.returncode != 0
+    assert "MONARCH_MCP_AUTH_TOKEN" in out.stderr
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_serve_mode.py -v`
+Expected: `test_stdio_mode_registers_login_tools` PASSES already (current behavior); the serve-mode tests FAIL (no mode awareness exists).
+
+- [ ] **Step 3: Rewrite `app.py`**
+
+Replace the contents of `src/monarch_mcp_server/app.py` with:
+
+```python
+"""FastMCP application instance and entry point.
+
+The run mode (stdio vs serve) must be known before the FastMCP instance is
+created: auth settings are constructor-only, and tool modules register
+against the instance at import time. ``cli.main`` resolves the mode into
+``MONARCH_MCP_MODE`` before importing this module.
+"""
+
+import logging
+
+from mcp.server.fastmcp import FastMCP
+
+from monarch_mcp_server.config import ServeConfig, get_mode
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# The gql aiohttp transport logs full GraphQL requests/responses at INFO, which
+# can include Monarch account payloads. Raise its floor to WARNING so those
+# payloads are not written to logs. Transport-level errors still surface; drop
+# this to INFO/DEBUG temporarily if you need to trace GraphQL traffic.
+logging.getLogger("gql.transport.aiohttp").setLevel(logging.WARNING)
+
+MODE = get_mode()
+
+
+def _build_mcp() -> FastMCP:
+    if MODE != "serve":
+        return FastMCP("Monarch Money MCP Server")
+
+    from mcp.server.auth.settings import AuthSettings
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    from monarch_mcp_server.http_auth import StaticTokenVerifier
+
+    cfg = ServeConfig.from_env()
+    return FastMCP(
+        "Monarch Money MCP Server",
+        host=cfg.host,
+        port=cfg.port,
+        # Plain JSON tool responses survive buffering proxies that break SSE.
+        json_response=True,
+        token_verifier=StaticTokenVerifier(cfg.auth_token),
+        auth=AuthSettings(
+            issuer_url=cfg.issuer_url,
+            resource_server_url=cfg.issuer_url,
+        ),
+        # DNS-rebinding protection only makes sense when the operator says
+        # which Host values are legitimate; with no allowlist it would reject
+        # every request.
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=bool(cfg.allowed_hosts),
+            allowed_hosts=cfg.allowed_hosts,
+        ),
+    )
+
+
+mcp = _build_mcp()
+
+if MODE == "serve":
+    from starlette.requests import Request
+    from starlette.responses import PlainTextResponse
+
+    @mcp.custom_route("/healthz", methods=["GET"])
+    async def healthz(_: Request) -> PlainTextResponse:
+        # Liveness only — no version or config details.
+        return PlainTextResponse("ok")
+
+
+# Import tools package to trigger @mcp.tool() registration
+import monarch_mcp_server.tools  # noqa: E402, F401
+
+# Export for `mcp run`
+app = mcp
+
+
+def main() -> None:
+    """Main entry point for the server."""
+    logger.info("Starting Monarch Money MCP Server...")
+    try:
+        mcp.run()
+    except Exception as e:
+        logger.error(f"Failed to run server: {str(e)}")
+        raise
+```
+
+- [ ] **Step 4: Make login-tool registration conditional in `tools/auth.py`**
+
+In `src/monarch_mcp_server/tools/auth.py`: remove the five `@mcp.tool()` decorator lines from `setup_authentication`, `monarch_login`, `monarch_login_with_token`, `monarch_logout`, and `debug_session_loading` (keep the decorator on `check_auth_status`), and append at the end of the file:
+
+```python
+# Login tools accept credentials via the MCP channel, which is appropriate on
+# a local stdio transport but not over a remote HTTP connection. In serve
+# mode, sessions are installed on the host with login_setup.py instead.
+if app_module.MODE == "stdio":
+    mcp.tool()(setup_authentication)
+    mcp.tool()(monarch_login)
+    mcp.tool()(monarch_login_with_token)
+    mcp.tool()(monarch_logout)
+    mcp.tool()(debug_session_loading)
+```
+
+And change the import at the top from `from monarch_mcp_server.app import mcp` to:
+
+```python
+import monarch_mcp_server.app as app_module
+from monarch_mcp_server.app import mcp
+```
+
+- [ ] **Step 5: Run the new tests and the full suite**
+
+Run: `uv run pytest tests/test_serve_mode.py -v && uv run pytest`
+Expected: all PASS. (`tests/test_auth.py` and `tests/test_server_auth.py` import the tool functions directly — they still exist as plain functions, so those tests must keep passing; if a test asserts on FastMCP registration of a login tool, run it with `MONARCH_MCP_MODE` unset, which is the default stdio.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/monarch_mcp_server/app.py src/monarch_mcp_server/tools/auth.py tests/test_serve_mode.py
+git commit -m "Build FastMCP per run mode; register login tools only on stdio"
+```
+
+---
+
+### Task 6: CLI dispatcher and entry point
+
+**Files:**
+- Create: `src/monarch_mcp_server/cli.py`
+- Modify: `pyproject.toml:47` (entry point)
+- Test: extend `tests/test_serve_mode.py`
+
+**Interfaces:**
+- Consumes: `monarch_mcp_server.app` (imported *after* mode env vars are set).
+- Produces: console script `monarch-mcp-server` → `monarch_mcp_server.cli:main`. `monarch-mcp-server` (no args) = stdio exactly as before; `monarch-mcp-server serve [--host H] [--port P]` = streamable HTTP. CLI flags override env vars.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_serve_mode.py`:
+
+```python
+def test_cli_serve_subcommand_sets_mode_and_flags():
+    from monarch_mcp_server import cli
+
+    captured = {}
+
+    def fake_run(transport=None):
+        captured["transport"] = transport
+        captured["mode"] = os.environ.get("MONARCH_MCP_MODE")
+        captured["host"] = os.environ.get("MONARCH_MCP_HOST")
+        captured["port"] = os.environ.get("MONARCH_MCP_PORT")
+
+    def fake_import():
+        class FakeApp:
+            class mcp:
+                run = staticmethod(fake_run)
+        return FakeApp
+
+    old_env = {k: os.environ.get(k) for k in
+               ("MONARCH_MCP_MODE", "MONARCH_MCP_HOST", "MONARCH_MCP_PORT")}
+    try:
+        cli.main(["serve", "--host", "0.0.0.0", "--port", "9100"],
+                 _app_loader=fake_import)
+        assert captured == {
+            "transport": "streamable-http",
+            "mode": "serve",
+            "host": "0.0.0.0",
+            "port": "9100",
+        }
+    finally:
+        for k, v in old_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_serve_mode.py::test_cli_serve_subcommand_sets_mode_and_flags -v`
+Expected: FAIL — `cli` module does not exist.
+
+- [ ] **Step 3: Implement `cli.py`**
+
+Create `src/monarch_mcp_server/cli.py`:
+
+```python
+"""Console entry point.
+
+Parses argv and resolves the run mode into MONARCH_MCP_MODE *before*
+importing ``app`` — FastMCP auth settings are constructor-only and tools
+register at import time, so the mode cannot change after that import.
+"""
+
+import argparse
+import os
+import sys
+from typing import Callable, List, Optional
+
+
+def _load_app():
+    from monarch_mcp_server import app
+
+    return app
+
+
+def main(
+    argv: Optional[List[str]] = None,
+    _app_loader: Callable = _load_app,
+) -> None:
+    args = sys.argv[1:] if argv is None else argv
+
+    if args and args[0] == "serve":
+        parser = argparse.ArgumentParser(
+            prog="monarch-mcp-server serve",
+            description="Run over streamable HTTP with bearer-token auth.",
+        )
+        parser.add_argument("--host", help="Bind address (default 127.0.0.1)")
+        parser.add_argument("--port", type=int, help="Bind port (default 8000)")
+        parsed = parser.parse_args(args[1:])
+
+        os.environ["MONARCH_MCP_MODE"] = "serve"
+        if parsed.host:
+            os.environ["MONARCH_MCP_HOST"] = parsed.host
+        if parsed.port:
+            os.environ["MONARCH_MCP_PORT"] = str(parsed.port)
+
+        app = _app_loader()
+        app.mcp.run(transport="streamable-http")
+        return
+
+    # Default: stdio, exactly as before.
+    app = _app_loader()
+    app.main()
+```
+
+- [ ] **Step 4: Update the entry point**
+
+In `pyproject.toml`, change:
+
+```toml
+[project.scripts]
+monarch-mcp-server = "monarch_mcp_server.cli:main"
+```
+
+Then run `uv sync --extra dev` to refresh the installed script.
+
+- [ ] **Step 5: Run tests and a smoke check**
+
+Run: `uv run pytest tests/test_serve_mode.py -v && uv run pytest`
+Expected: PASS.
+
+Run: `MONARCH_MCP_AUTH_TOKEN=$(openssl rand -base64 33) uv run monarch-mcp-server serve --port 8901 & sleep 3; curl -s http://127.0.0.1:8901/healthz; kill %1`
+Expected: prints `ok`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/monarch_mcp_server/cli.py pyproject.toml uv.lock tests/test_serve_mode.py
+git commit -m "Add serve subcommand dispatching mode before app import"
+```
+
+---
+
+### Task 7: HTTP auth-boundary integration test
+
+**Files:**
+- Test: `tests/test_serve_http.py`
+
+**Interfaces:**
+- Consumes: the `monarch-mcp-server serve` process (Task 6), `httpx` (already a transitive dep of mcp).
+- Produces: regression coverage for the full auth boundary over real HTTP.
+
+- [ ] **Step 1: Write the integration test**
+
+Create `tests/test_serve_http.py`:
+
+```python
+"""Integration tests: real serve-mode process, real HTTP, auth boundary."""
+
+import os
+import socket
+import subprocess
+import sys
+import time
+
+import httpx
+import pytest
+
+TOKEN = "integration-test-token-" + "x" * 20
+
+INIT_BODY = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-06-18",
+        "capabilities": {},
+        "clientInfo": {"name": "pytest", "version": "0"},
+    },
+}
+MCP_HEADERS = {
+    "Content-Type": "application/json",
+    "Accept": "application/json, text/event-stream",
+}
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def server():
+    port = _free_port()
+    env = os.environ | {
+        "MONARCH_MCP_MODE": "serve",
+        "MONARCH_MCP_AUTH_TOKEN": TOKEN,
+        "MONARCH_MCP_PORT": str(port),
+    }
+    proc = subprocess.Popen(
+        [sys.executable, "-c",
+         "from monarch_mcp_server.cli import main; main(['serve'])"],
+        env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    base = f"http://127.0.0.1:{port}"
+    try:
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            try:
+                if httpx.get(f"{base}/healthz", timeout=1).status_code == 200:
+                    break
+            except httpx.TransportError:
+                time.sleep(0.2)
+        else:
+            raise RuntimeError("server did not become healthy")
+        yield base
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+
+def test_healthz_is_unauthenticated_and_bare(server):
+    resp = httpx.get(f"{server}/healthz")
+    assert resp.status_code == 200
+    assert resp.text == "ok"
+
+
+def test_mcp_without_token_is_401(server):
+    resp = httpx.post(f"{server}/mcp", json=INIT_BODY, headers=MCP_HEADERS)
+    assert resp.status_code == 401
+    assert "www-authenticate" in {k.lower() for k in resp.headers}
+
+
+def test_mcp_with_wrong_token_is_401(server):
+    resp = httpx.post(
+        f"{server}/mcp", json=INIT_BODY,
+        headers=MCP_HEADERS | {"Authorization": "Bearer " + "w" * 40},
+    )
+    assert resp.status_code == 401
+
+
+def test_mcp_with_valid_token_initializes(server):
+    resp = httpx.post(
+        f"{server}/mcp", json=INIT_BODY,
+        headers=MCP_HEADERS | {"Authorization": f"Bearer {TOKEN}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["serverInfo"]["name"] == "Monarch Money MCP Server"
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `uv run pytest tests/test_serve_http.py -v`
+Expected: PASS (4 tests). If the initialize response is SSE-framed rather than JSON despite `json_response=True`, parse the `data:` line — but with `json_response=True` it should be plain JSON.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `uv run pytest`
+Expected: everything passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_serve_http.py
+git commit -m "Add HTTP auth-boundary integration tests for serve mode"
+```
+
+---
+
+### Task 8: Docker packaging
+
+**Files:**
+- Create: `Dockerfile`, `.dockerignore`, `docker-compose.yml`
+
+**Interfaces:**
+- Consumes: the `monarch-mcp-server` console script (Task 6).
+- Produces: an image whose default command is serve mode on `0.0.0.0:8000`, sessions persisted under the `/data` volume (via `HOME=/data`, so `secure_session`'s file fallback lands at `/data/.monarch-mcp-server/token`).
+
+- [ ] **Step 1: Write `.dockerignore`**
+
+```
+.git
+.venv
+__pycache__
+*.pyc
+tests
+docs
+scripts
+.pytest_cache
+.mypy_cache
+```
+
+- [ ] **Step 2: Write `Dockerfile`**
+
+```dockerfile
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
+COPY login_setup.py ./
+
+RUN pip install --no-cache-dir .
+
+# Non-root user; HOME=/data puts the file-fallback session store
+# (~/.monarch-mcp-server/token) on the persistent volume.
+RUN useradd --create-home --uid 1000 monarch \
+    && mkdir -p /data \
+    && chown monarch:monarch /data
+ENV HOME=/data \
+    MONARCH_MCP_MODE=serve \
+    MONARCH_MCP_HOST=0.0.0.0 \
+    MONARCH_MCP_PORT=8000
+USER monarch
+VOLUME /data
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz')"
+
+ENTRYPOINT ["monarch-mcp-server"]
+CMD ["serve"]
+```
+
+- [ ] **Step 3: Write `docker-compose.yml`**
+
+```yaml
+services:
+  monarch-mcp:
+    build: .
+    restart: unless-stopped
+    # Bind to localhost only; a reverse proxy or tunnel provides TLS.
+    # NEVER publish 8000 directly to the internet.
+    ports:
+      - "127.0.0.1:8000:8000"
+    environment:
+      # Generate with: openssl rand -base64 33
+      # Prefer MONARCH_MCP_AUTH_TOKEN_FILE with a mounted secret in
+      # production; env vars are visible via `docker inspect`.
+      MONARCH_MCP_AUTH_TOKEN: ${MONARCH_MCP_AUTH_TOKEN:?set in .env}
+      # Uncomment behind a proxy so Host-header checks are enforced:
+      # MONARCH_MCP_ALLOWED_HOSTS: monarch.example.com
+      # MONARCH_MCP_PUBLIC_URL: https://monarch.example.com
+    volumes:
+      - monarch-data:/data
+
+  # Optional: Cloudflare Tunnel. Create a tunnel + token in the Zero Trust
+  # dashboard, point its public hostname at http://monarch-mcp:8000, then:
+  #   docker compose --profile tunnel up -d
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    profiles: ["tunnel"]
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      TUNNEL_TOKEN: ${TUNNEL_TOKEN:?set in .env}
+    depends_on:
+      - monarch-mcp
+
+volumes:
+  monarch-data:
+```
+
+- [ ] **Step 4: Build and smoke-test the container**
+
+Run:
+```bash
+docker build -t monarch-mcp-server:dev .
+TOKEN=$(openssl rand -base64 33)
+docker run -d --name mm-smoke -e MONARCH_MCP_AUTH_TOKEN="$TOKEN" -p 127.0.0.1:8902:8000 monarch-mcp-server:dev
+sleep 5
+curl -s http://127.0.0.1:8902/healthz           # expect: ok
+curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:8902/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"c","version":"0"}}}'
+# expect: 401
+docker rm -f mm-smoke
+```
+
+Expected: `ok` then `401`.
+
+- [ ] **Step 5: Verify multi-arch build works**
+
+Run: `docker buildx build --platform linux/amd64,linux/arm64 -t monarch-mcp-server:multiarch . 2>&1 | tail -3`
+Expected: builds succeed for both platforms (pure-Python deps have arm64 wheels). If buildx/QEMU is unavailable locally, note it and rely on CI/release tooling — do not block the task.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Dockerfile .dockerignore docker-compose.yml
+git commit -m "Add Docker packaging with compose and Cloudflare Tunnel example"
+```
+
+---
+
+### Task 9: End-to-end script with the real MCP client
+
+**Files:**
+- Create: `scripts/e2e_http.py`
+
+**Interfaces:**
+- Consumes: a running serve-mode server (local process or Docker), env vars `E2E_URL` (default `http://127.0.0.1:8000/mcp`) and `E2E_TOKEN`.
+- Produces: an executable check that a real `mcp` Python client completes initialize → list_tools → call `check_auth_status` over streamable HTTP, and that a wrong token is rejected.
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/e2e_http.py`:
+
+```python
+"""End-to-end check: real MCP client against a running serve-mode server.
+
+Usage:
+    E2E_TOKEN=<token> [E2E_URL=http://127.0.0.1:8000/mcp] \
+        uv run python scripts/e2e_http.py
+"""
+
+import asyncio
+import os
+import sys
+
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+URL = os.environ.get("E2E_URL", "http://127.0.0.1:8000/mcp")
+TOKEN = os.environ.get("E2E_TOKEN")
+
+LOGIN_TOOLS = {
+    "setup_authentication",
+    "monarch_login",
+    "monarch_login_with_token",
+    "monarch_logout",
+    "debug_session_loading",
+}
+
+
+async def check_valid_token() -> None:
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+    async with streamablehttp_client(URL, headers=headers) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            info = await session.initialize()
+            assert info.serverInfo.name == "Monarch Money MCP Server", info
+            print(f"✅ initialize: {info.serverInfo.name}")
+
+            tools = await session.list_tools()
+            names = {t.name for t in tools.tools}
+            assert "get_accounts" in names, names
+            assert LOGIN_TOOLS.isdisjoint(names), (
+                f"login tools leaked into serve mode: {LOGIN_TOOLS & names}"
+            )
+            print(f"✅ list_tools: {len(names)} tools, no login tools")
+
+            result = await session.call_tool("check_auth_status", {})
+            text = result.content[0].text
+            print(f"✅ check_auth_status: {text.splitlines()[0]}")
+
+
+async def check_wrong_token() -> None:
+    headers = {"Authorization": "Bearer " + "w" * 40}
+    try:
+        async with streamablehttp_client(URL, headers=headers) as (r, w, _):
+            async with ClientSession(r, w) as session:
+                await session.initialize()
+    except* (httpx.HTTPStatusError, Exception) as eg:
+        print(f"✅ wrong token rejected ({type(eg.exceptions[0]).__name__})")
+        return
+    raise AssertionError("wrong token was accepted!")
+
+
+async def main() -> None:
+    if not TOKEN:
+        sys.exit("Set E2E_TOKEN (the server's MONARCH_MCP_AUTH_TOKEN).")
+    await check_valid_token()
+    await check_wrong_token()
+    print("\n🎉 E2E checks passed")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+- [ ] **Step 2: Run it against the Docker container**
+
+Run:
+```bash
+TOKEN=$(openssl rand -base64 33)
+docker run -d --name mm-e2e -e MONARCH_MCP_AUTH_TOKEN="$TOKEN" -p 127.0.0.1:8903:8000 monarch-mcp-server:dev
+sleep 5
+E2E_URL=http://127.0.0.1:8903/mcp E2E_TOKEN="$TOKEN" uv run python scripts/e2e_http.py
+docker rm -f mm-e2e
+```
+
+Expected: all ✅ lines and `🎉 E2E checks passed`. (`check_auth_status` legitimately reports "no token" — the container has no Monarch session; that still exercises a real tool call end-to-end.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/e2e_http.py
+git commit -m "Add end-to-end HTTP check script using the real MCP client"
+```
+
+---
+
+### Task 10: Documentation
+
+**Files:**
+- Modify: `README.md` (new "Remote access (HTTP)" section)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: operator docs for deploy + connect.
+
+- [ ] **Step 1: Add the README section**
+
+Append a "Remote access (HTTP)" section to `README.md` covering, with exact commands/snippets:
+
+1. **What it is:** `monarch-mcp-server serve` = streamable HTTP + bearer token; stdio remains the default and is unchanged.
+2. **Generate a token:** `openssl rand -base64 33`. Env vars table: `MONARCH_MCP_AUTH_TOKEN`, `MONARCH_MCP_AUTH_TOKEN_FILE` (preferred; env vars show in `docker inspect`), `MONARCH_MCP_HOST/PORT`, `MONARCH_MCP_ALLOWED_HOSTS`, `MONARCH_MCP_PUBLIC_URL`.
+3. **Docker quick start:** `docker compose up -d`, `.env` with the token.
+4. **Monarch login inside the container** (cookie-paste is the primary path — password login from VPS/datacenter IPs is frequently CAPTCHA-blocked):
+   ```bash
+   docker compose run --rm -it --entrypoint python monarch-mcp login_setup.py
+   ```
+   Sessions persist in the `monarch-data` volume, where the server reads them.
+5. **Cloudflare Tunnel:** enable the `tunnel` profile, set `TUNNEL_TOKEN`, point the tunnel's public hostname at `http://monarch-mcp:8000`, set `MONARCH_MCP_ALLOWED_HOSTS` to the public hostname.
+6. **Generic reverse proxy:** Caddy two-liner (`reverse_proxy 127.0.0.1:8000`) and the warning: never expose the port without TLS + token.
+7. **Connect Claude Code:** `claude mcp add --transport http monarch https://monarch.example.com/mcp --header "Authorization: Bearer <token>"`.
+8. **Connect Claude Desktop** via `mcp-remote`:
+   ```json
+   {
+     "mcpServers": {
+       "monarch": {
+         "command": "npx",
+         "args": [
+           "mcp-remote", "https://monarch.example.com/mcp",
+           "--header", "Authorization: Bearer ${MONARCH_TOKEN}"
+         ],
+         "env": { "MONARCH_TOKEN": "<token>" }
+       }
+     }
+   }
+   ```
+   Note: the native paste-URL connector UI requires OAuth (future phase).
+9. **Security notes:** token = full account access; rotate by restarting with a new token; `/healthz` is the only unauthenticated route; login MCP tools are disabled in serve mode by design.
+
+- [ ] **Step 2: Proofread against the actual flags/vars implemented in Tasks 3-8**
+
+Verify every env var name, flag, and command in the section matches the code. Fix drift.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "Document remote HTTP deployment and client setup"
+```
+
+---
+
+### Task 11: Final verification sweep
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full test suite**
+
+Run: `uv run pytest -q`
+Expected: all pass.
+
+- [ ] **Step 2: Stdio regression check**
+
+Run: `uv run python -c "from monarch_mcp_server.server import get_accounts, main, mcp; print('shim ok')"` and `printf '' | timeout 5 uv run monarch-mcp-server; echo "exit=$?"`
+Expected: `shim ok`; stdio server starts and exits cleanly on closed stdin (exit 0 or the timeout's 124 — either proves it launched without error).
+
+- [ ] **Step 3: Fresh Docker E2E (repeat Task 9 Step 2 from a clean image build)**
+
+Expected: `🎉 E2E checks passed`.
+
+- [ ] **Step 4: Manual pass checklist (operator, before release)**
+
+Document as done/not-done in the PR description:
+- Real Monarch cookie-paste login from the deployment host via `login_setup.py` in the container.
+- `get_accounts` returns real data through a real tunnel/proxy with the bearer token.
+- Wrong token rejected through the proxy.

--- a/docs/superpowers/specs/2026-07-08-remote-http-phase1a-design.md
+++ b/docs/superpowers/specs/2026-07-08-remote-http-phase1a-design.md
@@ -1,0 +1,210 @@
+# Remote HTTP Access — Phase 1a: Single-Tenant + Static Bearer Token
+
+**Date:** 2026-07-08
+**Status:** Draft — pending review
+**Supersedes:** the earlier full multi-tenant OAuth draft in this file; that
+design is preserved as the roadmap in the final section.
+
+## Goal
+
+Let the owner deploy monarch-mcp-server on a VPS, Raspberry Pi, or any Docker
+host and reach it remotely over MCP streamable HTTP through Cloudflare Tunnel
+or any TLS-terminating reverse proxy, authenticated with a static bearer
+token. Claude Desktop connects via an `mcp-remote` config snippet; Claude Code
+and other header-capable MCP clients connect directly.
+
+Non-goals for this phase (see Roadmap): multiple tenants, OAuth 2.1
+authorization server, web onboarding page, encrypted SQLite. Household members
+who each want their own Monarch account run their own container.
+
+## Design reviews incorporated
+
+Three review passes (security, SDK feasibility, architecture) ran against the
+original full-scope draft. Findings that apply at this scope are folded in
+below; findings that only apply to multi-tenant/OAuth phases are recorded in
+the Roadmap section.
+
+## Run modes
+
+| Mode | Invocation | Transport | Auth | Session storage |
+|------|-----------|-----------|------|-----------------|
+| stdio (default, unchanged) | `monarch-mcp-server` | stdio | none (local) | system keyring / file fallback |
+| serve (new) | `monarch-mcp-server serve` | streamable HTTP | static bearer token | same keyring / file fallback |
+
+Backward compatibility is a hard requirement: existing stdio installs (Claude
+Desktop local config, `login_setup.py`, keyring sessions) keep working with no
+changes.
+
+## SDK prerequisite
+
+Upgrade to `mcp>=1.28,<2` (currently locked at 1.13.1). Reasons verified
+against SDK source:
+
+- 1.13.1 stateful streamable HTTP does not bind sessions to credentials (a
+  bearer-holder can replay another session's `mcp-session-id`); 1.28.x keeps
+  `_session_owners` and rejects mismatches.
+- 1.28.x adds `FastMCP.remove_tool()`, constant-time secret comparison, and
+  the path-suffixed protected-resource metadata route needed by the OAuth
+  phase later.
+
+## Entry point & import-graph restructuring (key code change #1)
+
+Both the SDK (`FastMCP` accepts `token_verifier`/`auth` only at construction)
+and the current code (tools register via `@mcp.tool()` at import time in
+`app.py`) require the mode to be known **before** `app.py` is imported.
+
+- `main()` moves to a thin dispatcher module that parses the CLI
+  (`serve` subcommand + flags, falling back to `MONARCH_MCP_MODE` env var),
+  records the resolved mode (internal env var), **then** imports `app`.
+- `app.py` reads the resolved mode at import and constructs `FastMCP`
+  accordingly: stdio → exactly today's construction; serve → with
+  `token_verifier` (see Auth), `stateless_http` left stateful (single user),
+  `json_response=True` (proxy-safe; avoids SSE buffering issues), and
+  `TransportSecuritySettings` with `allowed_hosts`/`allowed_origins` derived
+  from config (DNS-rebinding protection is off by default in the SDK).
+- In serve mode, the auth MCP tools (`monarch_login`,
+  `monarch_login_with_token`, `setup_authentication`, `debug_session_loading`,
+  `monarch_logout`) are not registered — `tools/__init__.py` skips the auth
+  module's login tools based on mode. Monarch credentials never transit the
+  remote MCP channel; login happens on the server via `login_setup.py` (SSH).
+  `check_auth_status` stays, reporting session state and pointing at
+  `login_setup.py` when missing.
+- `secure_session` becomes lazily instantiated (module-level accessor instead
+  of import-time instance) so importing the package doesn't probe the keyring
+  (today it can pop a macOS Keychain prompt on any import).
+- The `server.py` shim and `app = mcp` export keep working for stdio.
+
+## Auth (serve mode)
+
+A ~50-line implementation of the SDK's `TokenVerifier` protocol:
+
+- Expected token comes from `MONARCH_MCP_AUTH_TOKEN` or
+  `MONARCH_MCP_AUTH_TOKEN_FILE` (file preferred in docs; env vars leak via
+  `docker inspect`). Server refuses to start in serve mode without one, and
+  refuses tokens shorter than 32 characters.
+- Comparison via `hmac.compare_digest` (constant-time).
+- The SDK's `RequireAuthMiddleware` then 401s unauthenticated `/mcp` traffic.
+- Global (not per-IP) failure rate limit: after N failed auth attempts per
+  minute, delay responses. Per-IP limiting is deliberately avoided — behind a
+  tunnel all traffic shares one peer IP, and trusting `X-Forwarded-For`
+  invites spoofing (security review H1). uvicorn runs with proxy headers
+  **disabled**; nothing in this phase needs the client IP.
+- `GET /healthz` via `custom_route`, unauthenticated, returns `ok` only — no
+  version/config (recon hygiene).
+
+Token generation is the operator's job; docs show
+`openssl rand -base64 33`.
+
+## Serve-mode HTTP surface
+
+- `POST/GET/DELETE /mcp` — MCP streamable HTTP (SDK-provided), bearer-protected.
+- `GET /healthz` — liveness only.
+
+Nothing else. No OAuth routes, no web pages in this phase.
+
+## Configuration (env vars)
+
+- `MONARCH_MCP_MODE` — `stdio` (default) | `serve`; CLI subcommand wins.
+- `MONARCH_MCP_AUTH_TOKEN` / `MONARCH_MCP_AUTH_TOKEN_FILE` — required in serve mode.
+- `MONARCH_MCP_HOST` / `MONARCH_MCP_PORT` — default `127.0.0.1:8000`
+  (`0.0.0.0:8000` in the Docker image, where the container boundary is the
+  isolation).
+- `MONARCH_MCP_ALLOWED_HOSTS` — comma-separated Host header allowlist for
+  transport security (e.g. `monarch.example.com`); default: the bind host.
+
+No `PUBLIC_URL` needed in this phase (no absolute URLs are generated); it
+arrives with OAuth in Phase 3.
+
+## Monarch session on the server
+
+Unchanged storage (`secure_session`: keyring, or file fallback at
+`~/.monarch-mcp-server/token` — the file path is what headless Docker/VPS
+hosts will use; it's already `chmod 600/700`).
+
+Login on the deployment host uses `login_setup.py` over SSH (or
+`docker exec`). Important caveat surfaced by review: Monarch password login
+from datacenter IPs is frequently CAPTCHA-blocked
+(`CaptchaRequiredException`), and email-OTP/MFA chaining makes the
+interactive flow the only reliable password path. `login_setup.py` already
+supports browser-cookie paste as the recommended alternative — the deployment
+docs make **cookie-paste the primary documented path** for VPS installs.
+Docker docs must cover running `login_setup.py` inside the container with the
+data volume mounted so the session lands where the server reads it.
+
+When Monarch rejects the stored session (401), tools return a structured
+error directing the operator to re-run `login_setup.py`; the MCP connection
+stays valid.
+
+## Client connection story
+
+- **Claude Code / header-capable clients:** point at `https://host/mcp` with
+  `Authorization: Bearer <token>`.
+- **Claude Desktop:** local config with the `mcp-remote` stdio→HTTP shim
+  passing the header. Documented snippet in README. (The native paste-URL
+  connector UI requires OAuth — Phase 3. Note: connector traffic originates
+  from Anthropic's cloud, so even for Desktop the server must be
+  internet-reachable when that phase lands.)
+
+## Packaging & deployment
+
+- Multi-arch Dockerfile (linux/amd64 + linux/arm64), non-root user, volume at
+  `/data` (mapped to the session file location via `HOME`), `HEALTHCHECK`
+  hitting `/healthz`.
+- `docker-compose.yml` example with commented env vars and an optional
+  `cloudflared` sidecar for Cloudflare Tunnel.
+- README walkthrough: build/run, token generation, cookie-paste login inside
+  the container, Cloudflare Tunnel, generic nginx/Caddy TLS example, and an
+  explicit warning: never expose the port without TLS + token.
+- No new Python dependencies (uvicorn ships with `mcp[cli]`).
+
+## Testing
+
+1. **Unit:** token verifier (valid/invalid/missing/short token, constant-time
+   path), mode resolution (CLI vs env), mode-dependent tool registration
+   (login tools absent in serve mode, present in stdio), lazy secure_session
+   (no keyring probe on bare import).
+2. **Integration (in-process ASGI, mocked Monarch client):** streamable HTTP
+   initialize + tool call with valid bearer succeeds; missing/wrong bearer →
+   401; `/healthz` unauthenticated; stdio path unchanged (existing suite keeps
+   passing).
+3. **End-to-end (required before done):** real server in Docker, real MCP
+   Python client over streamable HTTP: container up → session installed via
+   `login_setup.py` (stubbed Monarch for the repeatable scripted variant) →
+   initialize with bearer → `get_accounts` returns data → wrong token
+   rejected. One manual verification pass against a real Monarch account and
+   a real tunnel/proxy before release, including confirming Monarch
+   cookie-paste login works from the deployment host.
+
+## Roadmap (later phases, designed but not built now)
+
+- **Phase 2 — multi-tenant static tokens:** N operator-issued bearer tokens →
+  N Monarch sessions in Fernet-encrypted SQLite; admin CLI (`user
+  add/list/remove`); `get_monarch_client()` resolves the tenant from the
+  verified token via `get_access_token()` (empirically confirmed working in
+  the SDK); per-user client cache replaces the module-global
+  `_cached_client`; cookie-paste web onboarding page. Carry-over review
+  findings: WAL mode + busy_timeout for SQLite; DB file perms 600/700;
+  onboarding is a multi-step state machine (credentials → email OTP → MFA)
+  with cookie-paste primary; CSRF tokens on all forms; scrub request bodies
+  from logs on credential routes.
+- **Phase 3 — OAuth 2.1 AS** for the native Claude Desktop/claude.ai
+  connector UX: SDK `OAuthAuthorizationServerProvider`,
+  `ClientRegistrationOptions(enabled=True)` (off by default), setup-token
+  identity step (reusable-until-expiry, no remember-browser cookie), PKCE
+  S256 only, refresh rotation **with reuse detection** (revoke token family
+  on replay), exact-match redirect URI validation bound through code
+  exchange, encrypt (don't hash) OAuth client secrets (SDK compares
+  retrievable values), rate-limit `/register`, `PUBLIC_URL` required and
+  https-enforced, `MultiFernet` key-rotation story.
+
+## Decisions log
+
+- Scope cut from full multi-tenant OAuth to single-tenant static token after
+  review: the full design is 3 phases of work and Phase 1a alone satisfies
+  the immediate need (owner + Claude Desktop via mcp-remote).
+- Per-IP rate limiting rejected (spoofable/meaningless behind tunnels);
+  global failure throttle instead.
+- Login tools disabled in serve mode; SSH + `login_setup.py` with
+  cookie-paste is the credential path.
+- `json_response=True` chosen for proxy friendliness over SSE streaming
+  responses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.12,<3.14"
 dependencies = [
-    "mcp[cli]>=1.10.0",
+    "mcp[cli]>=1.28,<2",
     "monarchmoneycommunity>=1.4.0",
     "gql>=3.4",
     "keyring>=24.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Repository = "https://github.com/robcerda/monarch-mcp-server"
 Issues = "https://github.com/robcerda/monarch-mcp-server/issues"
 
 [project.scripts]
-monarch-mcp-server = "monarch_mcp_server.server:main"
+monarch-mcp-server = "monarch_mcp_server.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mcp[cli]>=1.10.0
+mcp[cli]>=1.28,<2
 monarchmoneycommunity>=1.4.0
 gql>=3.4
 keyring>=24.0.0

--- a/scripts/e2e_http.py
+++ b/scripts/e2e_http.py
@@ -1,0 +1,70 @@
+"""End-to-end check: real MCP client against a running serve-mode server.
+
+Usage:
+    E2E_TOKEN=<token> [E2E_URL=http://127.0.0.1:8000/mcp] \
+        uv run python scripts/e2e_http.py
+"""
+
+import asyncio
+import os
+import sys
+
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+URL = os.environ.get("E2E_URL", "http://127.0.0.1:8000/mcp")
+TOKEN = os.environ.get("E2E_TOKEN")
+
+LOGIN_TOOLS = {
+    "setup_authentication",
+    "monarch_login",
+    "monarch_login_with_token",
+    "monarch_logout",
+    "debug_session_loading",
+}
+
+
+async def check_valid_token() -> None:
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+    async with streamablehttp_client(URL, headers=headers) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            info = await session.initialize()
+            assert info.serverInfo.name == "Monarch Money MCP Server", info
+            print(f"✅ initialize: {info.serverInfo.name}")
+
+            tools = await session.list_tools()
+            names = {t.name for t in tools.tools}
+            assert "get_accounts" in names, names
+            assert LOGIN_TOOLS.isdisjoint(names), (
+                f"login tools leaked into serve mode: {LOGIN_TOOLS & names}"
+            )
+            print(f"✅ list_tools: {len(names)} tools, no login tools")
+
+            result = await session.call_tool("check_auth_status", {})
+            text = result.content[0].text
+            print(f"✅ check_auth_status: {text.splitlines()[0]}")
+
+
+async def check_wrong_token() -> None:
+    headers = {"Authorization": "Bearer " + "w" * 40}
+    try:
+        async with streamablehttp_client(URL, headers=headers) as (r, w, _):
+            async with ClientSession(r, w) as session:
+                await session.initialize()
+    except (httpx.HTTPStatusError, Exception) as e:
+        print(f"✅ wrong token rejected ({type(e).__name__})")
+        return
+    raise AssertionError("wrong token was accepted!")
+
+
+async def main() -> None:
+    if not TOKEN:
+        sys.exit("Set E2E_TOKEN (the server's MONARCH_MCP_AUTH_TOKEN).")
+    await check_valid_token()
+    await check_wrong_token()
+    print("\n🎉 E2E checks passed")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/monarch_mcp_server/app.py
+++ b/src/monarch_mcp_server/app.py
@@ -1,8 +1,16 @@
-"""FastMCP application instance and entry point."""
+"""FastMCP application instance and entry point.
+
+The run mode (stdio vs serve) must be known before the FastMCP instance is
+created: auth settings are constructor-only, and tool modules register
+against the instance at import time. ``cli.main`` resolves the mode into
+``MONARCH_MCP_MODE`` before importing this module.
+"""
 
 import logging
 
 from mcp.server.fastmcp import FastMCP
+
+from monarch_mcp_server.config import ServeConfig, get_mode
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -14,8 +22,51 @@ logger = logging.getLogger(__name__)
 # this to INFO/DEBUG temporarily if you need to trace GraphQL traffic.
 logging.getLogger("gql.transport.aiohttp").setLevel(logging.WARNING)
 
-# Initialize FastMCP server
-mcp = FastMCP("Monarch Money MCP Server")
+MODE = get_mode()
+
+
+def _build_mcp() -> FastMCP:
+    if MODE != "serve":
+        return FastMCP("Monarch Money MCP Server")
+
+    from mcp.server.auth.settings import AuthSettings
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    from monarch_mcp_server.http_auth import StaticTokenVerifier
+
+    cfg = ServeConfig.from_env()
+    return FastMCP(
+        "Monarch Money MCP Server",
+        host=cfg.host,
+        port=cfg.port,
+        # Plain JSON tool responses survive buffering proxies that break SSE.
+        json_response=True,
+        token_verifier=StaticTokenVerifier(cfg.auth_token),
+        auth=AuthSettings(
+            issuer_url=cfg.issuer_url,
+            resource_server_url=cfg.issuer_url,
+        ),
+        # DNS-rebinding protection only makes sense when the operator says
+        # which Host values are legitimate; with no allowlist it would reject
+        # every request.
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=bool(cfg.allowed_hosts),
+            allowed_hosts=cfg.allowed_hosts,
+        ),
+    )
+
+
+mcp = _build_mcp()
+
+if MODE == "serve":
+    from starlette.requests import Request
+    from starlette.responses import PlainTextResponse
+
+    @mcp.custom_route("/healthz", methods=["GET"])
+    async def healthz(_: Request) -> PlainTextResponse:
+        # Liveness only — no version or config details.
+        return PlainTextResponse("ok")
+
 
 # Import tools package to trigger @mcp.tool() registration
 import monarch_mcp_server.tools  # noqa: E402, F401
@@ -32,7 +83,3 @@ def main() -> None:
     except Exception as e:
         logger.error(f"Failed to run server: {str(e)}")
         raise
-
-
-if __name__ == "__main__":
-    main()

--- a/src/monarch_mcp_server/app.py
+++ b/src/monarch_mcp_server/app.py
@@ -24,6 +24,9 @@ logging.getLogger("gql.transport.aiohttp").setLevel(logging.WARNING)
 
 MODE = get_mode()
 
+# Populated by _build_mcp() in serve mode; read by the /setup route below.
+_serve_cfg: ServeConfig | None = None
+
 
 def _build_mcp() -> FastMCP:
     if MODE != "serve":
@@ -34,7 +37,9 @@ def _build_mcp() -> FastMCP:
 
     from monarch_mcp_server.http_auth import StaticTokenVerifier
 
+    global _serve_cfg
     cfg = ServeConfig.from_env()
+    _serve_cfg = cfg
     return FastMCP(
         "Monarch Money MCP Server",
         host=cfg.host,
@@ -60,12 +65,23 @@ mcp = _build_mcp()
 
 if MODE == "serve":
     from starlette.requests import Request
-    from starlette.responses import PlainTextResponse
+    from starlette.responses import HTMLResponse, PlainTextResponse
+
+    from monarch_mcp_server.setup_page import render_setup_page
 
     @mcp.custom_route("/healthz", methods=["GET"])
     async def healthz(_: Request) -> PlainTextResponse:
         # Liveness only — no version or config details.
         return PlainTextResponse("ok")
+
+    @mcp.custom_route("/setup", methods=["GET"])
+    async def setup(_: Request) -> HTMLResponse:
+        # No auth of our own here — this path must sit behind Cloudflare
+        # Access at the edge (see docs/SECRETS.md in home-infra). Custom
+        # routes bypass the MCP transport's bearer-token check entirely,
+        # same as /healthz.
+        assert _serve_cfg is not None
+        return HTMLResponse(render_setup_page(_serve_cfg))
 
 
 # Import tools package to trigger @mcp.tool() registration

--- a/src/monarch_mcp_server/app.py
+++ b/src/monarch_mcp_server/app.py
@@ -74,12 +74,16 @@ if MODE == "serve":
         # Liveness only — no version or config details.
         return PlainTextResponse("ok")
 
-    @mcp.custom_route("/setup", methods=["GET"])
+    @mcp.custom_route("/", methods=["GET"])
     async def setup(_: Request) -> HTMLResponse:
         # No auth of our own here — this path must sit behind Cloudflare
-        # Access at the edge (see docs/SECRETS.md in home-infra). Custom
-        # routes bypass the MCP transport's bearer-token check entirely,
-        # same as /healthz.
+        # Access at the edge (see docs/SECRETS.md in home-infra: root is
+        # gated by a whole-hostname Access Application, with narrow bypass
+        # Applications carving out /mcp and /healthz — a bare-hostname
+        # Access Application protects the whole domain by default, so those
+        # two need their own explicit exception, same pattern mindbody-mcp
+        # already uses). Custom routes bypass the MCP transport's
+        # bearer-token check entirely, same as /healthz.
         assert _serve_cfg is not None
         return HTMLResponse(render_setup_page(_serve_cfg))
 

--- a/src/monarch_mcp_server/cli.py
+++ b/src/monarch_mcp_server/cli.py
@@ -42,6 +42,21 @@ def main(
         app.mcp.run(transport="streamable-http")
         return
 
+    if args and args[0] == "login-cookies":
+        parser = argparse.ArgumentParser(
+            prog="monarch-mcp-server login-cookies",
+            description=(
+                "Save a Monarch session from a browser Cookie header read "
+                "on stdin (non-interactive login_setup.py option 1)."
+            ),
+        )
+        parser.parse_args(args[1:])
+
+        from monarch_mcp_server.login_cookies import main as login_cookies_main
+
+        login_cookies_main()
+        return
+
     # Default: stdio, exactly as before.
     app = _app_loader()
     app.main()

--- a/src/monarch_mcp_server/cli.py
+++ b/src/monarch_mcp_server/cli.py
@@ -35,7 +35,7 @@ def main(
         os.environ["MONARCH_MCP_MODE"] = "serve"
         if parsed.host:
             os.environ["MONARCH_MCP_HOST"] = parsed.host
-        if parsed.port:
+        if parsed.port is not None:
             os.environ["MONARCH_MCP_PORT"] = str(parsed.port)
 
         app = _app_loader()

--- a/src/monarch_mcp_server/cli.py
+++ b/src/monarch_mcp_server/cli.py
@@ -57,6 +57,22 @@ def main(
         login_cookies_main()
         return
 
+    if args and args[0] == "login-password":
+        parser = argparse.ArgumentParser(
+            prog="monarch-mcp-server login-password",
+            description=(
+                "Save a Monarch session from newline-separated credentials "
+                "on stdin: email, password, optional one-time code "
+                "(non-interactive login_setup.py option 2)."
+            ),
+        )
+        parser.parse_args(args[1:])
+
+        from monarch_mcp_server.login_password import main as login_password_main
+
+        login_password_main()
+        return
+
     # Default: stdio, exactly as before.
     app = _app_loader()
     app.main()

--- a/src/monarch_mcp_server/cli.py
+++ b/src/monarch_mcp_server/cli.py
@@ -1,0 +1,47 @@
+"""Console entry point.
+
+Parses argv and resolves the run mode into MONARCH_MCP_MODE *before*
+importing ``app`` — FastMCP auth settings are constructor-only and tools
+register at import time, so the mode cannot change after that import.
+"""
+
+import argparse
+import os
+import sys
+from typing import Callable, List, Optional
+
+
+def _load_app():
+    from monarch_mcp_server import app
+
+    return app
+
+
+def main(
+    argv: Optional[List[str]] = None,
+    _app_loader: Callable = _load_app,
+) -> None:
+    args = sys.argv[1:] if argv is None else argv
+
+    if args and args[0] == "serve":
+        parser = argparse.ArgumentParser(
+            prog="monarch-mcp-server serve",
+            description="Run over streamable HTTP with bearer-token auth.",
+        )
+        parser.add_argument("--host", help="Bind address (default 127.0.0.1)")
+        parser.add_argument("--port", type=int, help="Bind port (default 8000)")
+        parsed = parser.parse_args(args[1:])
+
+        os.environ["MONARCH_MCP_MODE"] = "serve"
+        if parsed.host:
+            os.environ["MONARCH_MCP_HOST"] = parsed.host
+        if parsed.port:
+            os.environ["MONARCH_MCP_PORT"] = str(parsed.port)
+
+        app = _app_loader()
+        app.mcp.run(transport="streamable-http")
+        return
+
+    # Default: stdio, exactly as before.
+    app = _app_loader()
+    app.main()

--- a/src/monarch_mcp_server/cli.py
+++ b/src/monarch_mcp_server/cli.py
@@ -17,9 +17,30 @@ def _load_app():
     return app
 
 
+def _default_serve_http(app) -> None:
+    """Serve the streamable-HTTP ASGI app ourselves (instead of
+    ``app.mcp.run(transport=...)``) so we can wrap it with
+    QueryTokenAuthMiddleware — FastMCP's own run method has no hook for
+    that. The `mcp` package itself is untouched; this only wraps the ASGI
+    app it hands back."""
+    import uvicorn
+
+    from monarch_mcp_server.query_token_auth import QueryTokenAuthMiddleware
+
+    asgi_app = QueryTokenAuthMiddleware(app.mcp.streamable_http_app())
+    settings = app.mcp.settings
+    uvicorn.run(
+        asgi_app,
+        host=settings.host,
+        port=settings.port,
+        log_level=settings.log_level.lower(),
+    )
+
+
 def main(
     argv: Optional[List[str]] = None,
     _app_loader: Callable = _load_app,
+    _serve_http: Callable = _default_serve_http,
 ) -> None:
     args = sys.argv[1:] if argv is None else argv
 
@@ -39,7 +60,7 @@ def main(
             os.environ["MONARCH_MCP_PORT"] = str(parsed.port)
 
         app = _app_loader()
-        app.mcp.run(transport="streamable-http")
+        _serve_http(app)
         return
 
     if args and args[0] == "login-cookies":

--- a/src/monarch_mcp_server/config.py
+++ b/src/monarch_mcp_server/config.py
@@ -1,0 +1,72 @@
+"""Run-mode resolution and serve-mode configuration.
+
+Mode must be resolved before ``app.py`` is imported: FastMCP accepts auth
+settings only at construction, and tools register at import time.
+"""
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+MODE_ENV = "MONARCH_MCP_MODE"
+MIN_TOKEN_LENGTH = 32
+
+
+def get_mode() -> str:
+    """Return the run mode: "stdio" (default) or "serve"."""
+    mode = os.environ.get(MODE_ENV, "stdio").strip().lower()
+    if mode not in ("stdio", "serve"):
+        raise ValueError(
+            f"{MODE_ENV} must be 'stdio' or 'serve', got {mode!r}"
+        )
+    return mode
+
+
+@dataclass(frozen=True)
+class ServeConfig:
+    """Configuration for serve (streamable HTTP) mode, read from env vars."""
+
+    host: str
+    port: int
+    auth_token: str
+    issuer_url: str
+    allowed_hosts: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_env(cls) -> "ServeConfig":
+        host = os.environ.get("MONARCH_MCP_HOST", "127.0.0.1")
+        port = int(os.environ.get("MONARCH_MCP_PORT", "8000"))
+
+        token = ""
+        token_file = os.environ.get("MONARCH_MCP_AUTH_TOKEN_FILE")
+        if token_file:
+            token = Path(token_file).read_text().strip()
+        if not token:
+            token = os.environ.get("MONARCH_MCP_AUTH_TOKEN", "").strip()
+        if not token:
+            raise ValueError(
+                "Serve mode requires MONARCH_MCP_AUTH_TOKEN or "
+                "MONARCH_MCP_AUTH_TOKEN_FILE. Generate one with: "
+                "openssl rand -base64 33"
+            )
+        if len(token) < MIN_TOKEN_LENGTH:
+            raise ValueError(
+                f"Auth token must be at least {MIN_TOKEN_LENGTH} characters "
+                f"(got {len(token)}). Generate one with: openssl rand -base64 33"
+            )
+
+        issuer_url = os.environ.get(
+            "MONARCH_MCP_PUBLIC_URL", f"http://{host}:{port}"
+        ).rstrip("/")
+
+        raw_hosts = os.environ.get("MONARCH_MCP_ALLOWED_HOSTS", "")
+        allowed_hosts = [h.strip() for h in raw_hosts.split(",") if h.strip()]
+
+        return cls(
+            host=host,
+            port=port,
+            auth_token=token,
+            issuer_url=issuer_url,
+            allowed_hosts=allowed_hosts,
+        )

--- a/src/monarch_mcp_server/config.py
+++ b/src/monarch_mcp_server/config.py
@@ -40,14 +40,21 @@ class ServeConfig:
 
         token = ""
         token_file = os.environ.get("MONARCH_MCP_AUTH_TOKEN_FILE")
-        if token_file:
+        if token_file and Path(token_file).is_file():
             token = Path(token_file).read_text().strip()
         if not token:
             token = os.environ.get("MONARCH_MCP_AUTH_TOKEN", "").strip()
         if not token:
+            # A set-but-absent token file falls through here (rather than
+            # crashing on read) so the operator can point at a file that an
+            # init step creates later, and still get a clear error meanwhile.
+            hint = (
+                f" (MONARCH_MCP_AUTH_TOKEN_FILE={token_file} is missing or"
+                " empty)" if token_file else ""
+            )
             raise ValueError(
                 "Serve mode requires MONARCH_MCP_AUTH_TOKEN or "
-                "MONARCH_MCP_AUTH_TOKEN_FILE. Generate one with: "
+                f"MONARCH_MCP_AUTH_TOKEN_FILE{hint}. Generate one with: "
                 "openssl rand -base64 33"
             )
         if len(token) < MIN_TOKEN_LENGTH:

--- a/src/monarch_mcp_server/config.py
+++ b/src/monarch_mcp_server/config.py
@@ -32,6 +32,10 @@ class ServeConfig:
     auth_token: str
     issuer_url: str
     allowed_hosts: List[str] = field(default_factory=list)
+    # Set only when MONARCH_MCP_AUTH_TOKEN_FILE was used, so callers that
+    # want the *current* token (e.g. the /setup page, after a same-container
+    # rotation) can re-read the file instead of trusting this frozen value.
+    auth_token_file: str = ""
 
     @classmethod
     def from_env(cls) -> "ServeConfig":
@@ -76,4 +80,5 @@ class ServeConfig:
             auth_token=token,
             issuer_url=issuer_url,
             allowed_hosts=allowed_hosts,
+            auth_token_file=token_file or "",
         )

--- a/src/monarch_mcp_server/http_auth.py
+++ b/src/monarch_mcp_server/http_auth.py
@@ -1,6 +1,7 @@
 """Static bearer-token verification for serve mode."""
 
 import asyncio
+import hashlib
 import hmac
 import logging
 import time
@@ -21,15 +22,19 @@ class StaticTokenVerifier:
     Failed attempts are throttled globally (not per-IP): behind a tunnel all
     traffic shares one peer address, and trusting X-Forwarded-For would let a
     direct-connecting client dodge the limit by spoofing the header.
+
+    Token comparison uses SHA256 digests to avoid timing/length leaks: both
+    inputs to hmac.compare_digest are always 32 bytes (fixed-length).
     """
 
     def __init__(self, expected_token: str, max_failures_per_minute: int = 10):
-        self._expected = expected_token.encode()
+        self._expected_digest = hashlib.sha256(expected_token.encode()).digest()
         self._max_failures = max_failures_per_minute
         self._failures: Deque[float] = deque()
 
     async def verify_token(self, token: str) -> Optional[AccessToken]:
-        if hmac.compare_digest(token.encode(), self._expected):
+        candidate = hashlib.sha256(token.encode()).digest()
+        if hmac.compare_digest(candidate, self._expected_digest):
             return AccessToken(
                 token=token, client_id="static-token-client", scopes=[]
             )

--- a/src/monarch_mcp_server/http_auth.py
+++ b/src/monarch_mcp_server/http_auth.py
@@ -1,0 +1,47 @@
+"""Static bearer-token verification for serve mode."""
+
+import asyncio
+import hmac
+import logging
+import time
+from collections import deque
+from typing import Deque, Optional
+
+from mcp.server.auth.provider import AccessToken
+
+logger = logging.getLogger(__name__)
+
+_THROTTLE_WINDOW_SECONDS = 60.0
+_THROTTLE_DELAY_SECONDS = 2
+
+
+class StaticTokenVerifier:
+    """Verifies the single operator-issued bearer token.
+
+    Failed attempts are throttled globally (not per-IP): behind a tunnel all
+    traffic shares one peer address, and trusting X-Forwarded-For would let a
+    direct-connecting client dodge the limit by spoofing the header.
+    """
+
+    def __init__(self, expected_token: str, max_failures_per_minute: int = 10):
+        self._expected = expected_token.encode()
+        self._max_failures = max_failures_per_minute
+        self._failures: Deque[float] = deque()
+
+    async def verify_token(self, token: str) -> Optional[AccessToken]:
+        if hmac.compare_digest(token.encode(), self._expected):
+            return AccessToken(
+                token=token, client_id="static-token-client", scopes=[]
+            )
+
+        now = time.monotonic()
+        self._failures.append(now)
+        while self._failures and now - self._failures[0] > _THROTTLE_WINDOW_SECONDS:
+            self._failures.popleft()
+        if len(self._failures) > self._max_failures:
+            logger.warning(
+                "Auth failure throttle engaged (%d failures in the last minute)",
+                len(self._failures),
+            )
+            await asyncio.sleep(_THROTTLE_DELAY_SECONDS)
+        return None

--- a/src/monarch_mcp_server/login_cookies.py
+++ b/src/monarch_mcp_server/login_cookies.py
@@ -1,0 +1,42 @@
+"""Non-interactive cookie login for headless deployments.
+
+Reads a browser ``Cookie`` header string from stdin, verifies it against
+the live Monarch API, and saves the session to secure storage — the same
+flow as ``login_setup.py`` option 1, minus the prompts. Built for remote
+hosts where no interactive terminal exists (e.g. ``docker exec`` driven
+by a CI runner): stdin keeps the cookie out of process listings and shell
+history, and nothing derived from the cookie is ever printed.
+"""
+
+import asyncio
+import sys
+
+from monarch_mcp_server.monarch_auth import login_with_browser_cookies
+from monarch_mcp_server.secure_session import secure_session
+
+
+async def _run() -> int:
+    cookie_string = sys.stdin.read().strip()
+    if not cookie_string:
+        print(
+            "No cookie data on stdin. Pipe the browser Cookie header value, "
+            "e.g.: cat cookie.txt | monarch-mcp-server login-cookies",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        mm = await login_with_browser_cookies(cookie_string)
+        accounts = await mm.get_accounts()
+    except Exception as e:
+        print(f"Cookie login failed: {type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+
+    account_count = len(accounts.get("accounts", [])) if isinstance(accounts, dict) else 0
+    secure_session.save_authenticated_session(mm)
+    print(f"Monarch session verified ({account_count} accounts visible) and saved.")
+    return 0
+
+
+def main() -> None:
+    sys.exit(asyncio.run(_run()))

--- a/src/monarch_mcp_server/login_cookies.py
+++ b/src/monarch_mcp_server/login_cookies.py
@@ -15,6 +15,30 @@ from monarch_mcp_server.monarch_auth import login_with_browser_cookies
 from monarch_mcp_server.secure_session import secure_session
 
 
+async def verify_and_save(mm) -> int:
+    """Verify a logged-in client against the live API, then persist it.
+
+    Shared by the headless login subcommands (login-cookies,
+    login-password). Prints only a success line — never credentials.
+    """
+    try:
+        accounts = await mm.get_accounts()
+    except Exception as e:
+        print(
+            f"Verification call failed: {type(e).__name__}: {e}",
+            file=sys.stderr,
+        )
+        return 1
+    account_count = (
+        len(accounts.get("accounts", [])) if isinstance(accounts, dict) else 0
+    )
+    secure_session.save_authenticated_session(mm)
+    print(
+        f"Monarch session verified ({account_count} accounts visible) and saved."
+    )
+    return 0
+
+
 async def _run() -> int:
     cookie_string = sys.stdin.read().strip()
     if not cookie_string:
@@ -27,15 +51,11 @@ async def _run() -> int:
 
     try:
         mm = await login_with_browser_cookies(cookie_string)
-        accounts = await mm.get_accounts()
     except Exception as e:
         print(f"Cookie login failed: {type(e).__name__}: {e}", file=sys.stderr)
         return 1
 
-    account_count = len(accounts.get("accounts", [])) if isinstance(accounts, dict) else 0
-    secure_session.save_authenticated_session(mm)
-    print(f"Monarch session verified ({account_count} accounts visible) and saved.")
-    return 0
+    return await verify_and_save(mm)
 
 
 def main() -> None:

--- a/src/monarch_mcp_server/login_password.py
+++ b/src/monarch_mcp_server/login_password.py
@@ -1,0 +1,98 @@
+"""Non-interactive email/password login for headless deployments.
+
+Reads newline-separated credentials from stdin — line 1 email, line 2
+password, optional line 3 a one-time code — verifies the resulting
+session against the live Monarch API, and saves it. The login_setup.py
+option 2 flow without the prompts, for remote hosts where the session
+must be seeded via docker exec from a CI runner.
+
+Monarch commonly emails a one-time code for a new device (even with MFA
+off). The first attempt without a code triggers that email and exits with
+instructions; the operator re-runs with the code as line 3. A TOTP MFA
+code goes in the same slot — whichever challenge Monarch raises, the code
+is applied to it. Stdin keeps credentials out of argv and shell history;
+nothing derived from them is printed.
+"""
+
+import asyncio
+import sys
+
+from monarchmoney import CaptchaRequiredException, RequireMFAException
+
+from monarch_mcp_server.login_cookies import verify_and_save
+from monarch_mcp_server.monarch_auth import (
+    EmailOtpRequiredException,
+    login_with_current_auth,
+)
+
+
+async def _run() -> int:
+    lines = [line.strip() for line in sys.stdin.read().splitlines() if line.strip()]
+    if len(lines) < 2:
+        print(
+            "Expected credentials on stdin: line 1 email, line 2 password, "
+            "optional line 3 a one-time code (email OTP or TOTP).",
+            file=sys.stderr,
+        )
+        return 1
+    email, password = lines[0], lines[1]
+    code = lines[2] if len(lines) > 2 else None
+
+    try:
+        mm = await login_with_current_auth(email, password)
+    except CaptchaRequiredException:
+        print(
+            "Programmatic login is blocked by Cloudflare CAPTCHA for this "
+            "IP. Fall back to browser-cookie login (login-cookies).",
+            file=sys.stderr,
+        )
+        return 1
+    except EmailOtpRequiredException:
+        if not code:
+            print(
+                "Monarch sent a one-time code to the account email. Re-run "
+                "with the code as a third stdin line.",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            mm = await login_with_current_auth(email, password, email_otp=code)
+        except RequireMFAException:
+            print(
+                "Monarch also requires a TOTP MFA code after email "
+                "verification — this headless flow handles one code per "
+                "run. Use browser-cookie login (login-cookies) instead.",
+                file=sys.stderr,
+            )
+            return 1
+        except Exception as e:
+            print(
+                f"Login with email code failed: {type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
+            return 1
+    except RequireMFAException:
+        if not code:
+            print(
+                "Account has TOTP MFA enabled. Re-run with the current MFA "
+                "code as a third stdin line.",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            mm = await login_with_current_auth(email, password, mfa_code=code)
+        except Exception as e:
+            print(
+                f"Login with MFA code failed: {type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
+            return 1
+    except Exception as e:
+        print(f"Login failed: {type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+
+    return await verify_and_save(mm)
+
+
+def main() -> None:
+    sys.exit(asyncio.run(_run()))

--- a/src/monarch_mcp_server/login_password.py
+++ b/src/monarch_mcp_server/login_password.py
@@ -38,60 +38,74 @@ async def _run() -> int:
     email, password = lines[0], lines[1]
     code = lines[2] if len(lines) > 2 else None
 
+    if code:
+        mm = await _login_with_code(email, password, code)
+    else:
+        mm = await _login_without_code(email, password)
+    if mm is None:
+        return 1
+    return await verify_and_save(mm)
+
+
+async def _login_without_code(email: str, password: str):
+    """First-run attempt with no code. Detects which challenge Monarch
+    raises and instructs the operator to re-run with the emailed / TOTP
+    code — returns None so the caller exits non-zero."""
     try:
-        mm = await login_with_current_auth(email, password)
+        return await login_with_current_auth(email, password)
     except CaptchaRequiredException:
         print(
             "Programmatic login is blocked by Cloudflare CAPTCHA for this "
             "IP. Fall back to browser-cookie login (login-cookies).",
             file=sys.stderr,
         )
-        return 1
     except EmailOtpRequiredException:
-        if not code:
-            print(
-                "Monarch sent a one-time code to the account email. Re-run "
-                "with the code as a third stdin line.",
-                file=sys.stderr,
-            )
-            return 1
-        try:
-            mm = await login_with_current_auth(email, password, email_otp=code)
-        except RequireMFAException:
-            print(
-                "Monarch also requires a TOTP MFA code after email "
-                "verification — this headless flow handles one code per "
-                "run. Use browser-cookie login (login-cookies) instead.",
-                file=sys.stderr,
-            )
-            return 1
-        except Exception as e:
-            print(
-                f"Login with email code failed: {type(e).__name__}: {e}",
-                file=sys.stderr,
-            )
-            return 1
+        print(
+            "Monarch sent a one-time code to the account email. Re-run with "
+            "the code as a third stdin line.",
+            file=sys.stderr,
+        )
     except RequireMFAException:
-        if not code:
-            print(
-                "Account has TOTP MFA enabled. Re-run with the current MFA "
-                "code as a third stdin line.",
-                file=sys.stderr,
-            )
-            return 1
-        try:
-            mm = await login_with_current_auth(email, password, mfa_code=code)
-        except Exception as e:
-            print(
-                f"Login with MFA code failed: {type(e).__name__}: {e}",
-                file=sys.stderr,
-            )
-            return 1
+        print(
+            "Account has TOTP MFA enabled. Re-run with the current MFA code "
+            "as a third stdin line.",
+            file=sys.stderr,
+        )
     except Exception as e:
         print(f"Login failed: {type(e).__name__}: {e}", file=sys.stderr)
-        return 1
+    return None
 
-    return await verify_and_save(mm)
+
+async def _login_with_code(email: str, password: str, code: str):
+    """Apply a supplied code on the FIRST login call.
+
+    Doing a no-code attempt first would make Monarch send a fresh email
+    OTP and invalidate the code the operator already holds — so the code
+    must ride the initial request. Monarch's email-OTP and TOTP codes are
+    indistinguishable to us, so try it as an email OTP first (the common
+    new-device case) and fall back to treating it as a TOTP MFA code if
+    Monarch says it wanted MFA instead."""
+    try:
+        return await login_with_current_auth(email, password, email_otp=code)
+    except (EmailOtpRequiredException, RequireMFAException):
+        try:
+            return await login_with_current_auth(email, password, mfa_code=code)
+        except Exception as e:
+            print(
+                f"Login with code failed: {type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
+            return None
+    except CaptchaRequiredException:
+        print(
+            "Programmatic login is blocked by Cloudflare CAPTCHA for this "
+            "IP. Fall back to browser-cookie login (login-cookies).",
+            file=sys.stderr,
+        )
+        return None
+    except Exception as e:
+        print(f"Login with code failed: {type(e).__name__}: {e}", file=sys.stderr)
+        return None
 
 
 def main() -> None:

--- a/src/monarch_mcp_server/query_token_auth.py
+++ b/src/monarch_mcp_server/query_token_auth.py
@@ -1,0 +1,41 @@
+"""ASGI middleware: accept the bearer token via a ``?token=`` query param.
+
+Custom MCP connectors (Claude Desktop's and Claude mobile's "Remote MCP
+server URL" field) only take a URL — there's no way to set a custom
+header. mindbody-mcp solved this in its own hand-rolled HTTP layer (a
+``?token=`` query param, checked only when no Authorization header is
+present); this is the FastMCP/ASGI-layer equivalent, since the MCP Python
+SDK's built-in ``BearerAuthBackend`` only ever reads the Authorization
+header.
+
+This wraps the ASGI app FastMCP already builds — it does not modify the
+``mcp`` package, which stays a stock, general-purpose dependency.
+"""
+
+from urllib.parse import parse_qs
+
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class QueryTokenAuthMiddleware:
+    """Copies ``?token=`` into the Authorization header before the wrapped
+    app sees the request — only when no Authorization header is already
+    present, so an explicit header always wins."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = MutableHeaders(scope=scope)
+        if not headers.get("authorization"):
+            query = parse_qs(scope.get("query_string", b"").decode())
+            token = query.get("token", [None])[0]
+            if token:
+                headers["authorization"] = f"Bearer {token}"
+
+        await self.app(scope, receive, send)

--- a/src/monarch_mcp_server/secure_session.py
+++ b/src/monarch_mcp_server/secure_session.py
@@ -62,11 +62,21 @@ class SecureMonarchSession:
     falling back to a file-based store when no keyring backend is available."""
 
     def __init__(self) -> None:
-        self._use_keyring = _keyring_available()
-        if self._use_keyring:
-            logger.info("🔐 Using system keyring for token storage")
-        else:
-            logger.info("🔐 Keyring unavailable — using file-based token storage")
+        # Keyring availability is probed lazily on first use. Probing in the
+        # constructor triggers keyring access (a macOS Keychain prompt in some
+        # setups) for any import of this package, even when the session store
+        # is never used (e.g. serve mode).
+        self._use_keyring: Optional[bool] = None
+
+    @property
+    def _keyring_ok(self) -> bool:
+        if self._use_keyring is None:
+            self._use_keyring = _keyring_available()
+            if self._use_keyring:
+                logger.info("🔐 Using system keyring for token storage")
+            else:
+                logger.info("🔐 Keyring unavailable — using file-based token storage")
+        return self._use_keyring
 
     # -- file-based helpers --------------------------------------------------
 
@@ -128,7 +138,7 @@ class SecureMonarchSession:
             session_data["cookies"] = dict(cookies)
         blob = json.dumps(session_data)
 
-        if self._use_keyring:
+        if self._keyring_ok:
             try:
                 import keyring
                 keyring.set_password(KEYRING_SERVICE, KEYRING_USERNAME, blob)
@@ -174,7 +184,7 @@ class SecureMonarchSession:
         everything to ``str(value)`` which corrupted nested dicts).
         """
         raw_session = None
-        if self._use_keyring:
+        if self._keyring_ok:
             try:
                 import keyring
                 raw_session = keyring.get_password(KEYRING_SERVICE, KEYRING_USERNAME)
@@ -218,7 +228,7 @@ class SecureMonarchSession:
     def delete_token(self) -> None:
         """Delete the authentication token from all storage backends."""
         # Try keyring
-        if self._use_keyring:
+        if self._keyring_ok:
             try:
                 import keyring
                 keyring.delete_password(KEYRING_SERVICE, KEYRING_USERNAME)

--- a/src/monarch_mcp_server/setup_page.py
+++ b/src/monarch_mcp_server/setup_page.py
@@ -1,12 +1,13 @@
 """Self-service copy-paste client setup page (serve mode only).
 
-Rendered at /setup, behind Cloudflare Access at the edge (this module adds
-no auth of its own — see docs/SECRETS.md in home-infra for the Access
-Application that gates this path to a specific Google account). Reads the
-bearer token live off disk on every request when the operator uses
-MONARCH_MCP_AUTH_TOKEN_FILE, so a same-container token rotation (delete the
-file, let an init step regenerate it) shows up here without a page reload
-needing anything more than a fresh network request.
+Rendered at root "/", behind Cloudflare Access at the edge (this module
+adds no auth of its own — see docs/SECRETS.md in home-infra for the
+whole-hostname Access Application that gates it to a specific Google
+account, with narrow bypass Applications carving out /mcp and /healthz).
+Reads the bearer token live off disk on every request when the operator
+uses MONARCH_MCP_AUTH_TOKEN_FILE, so a same-container token rotation
+(delete the file, let an init step regenerate it) shows up here without a
+page reload needing anything more than a fresh network request.
 """
 
 import html

--- a/src/monarch_mcp_server/setup_page.py
+++ b/src/monarch_mcp_server/setup_page.py
@@ -1,0 +1,138 @@
+"""Self-service copy-paste client setup page (serve mode only).
+
+Rendered at /setup, behind Cloudflare Access at the edge (this module adds
+no auth of its own — see docs/SECRETS.md in home-infra for the Access
+Application that gates this path to a specific Google account). Reads the
+bearer token live off disk on every request when the operator uses
+MONARCH_MCP_AUTH_TOKEN_FILE, so a same-container token rotation (delete the
+file, let an init step regenerate it) shows up here without a page reload
+needing anything more than a fresh network request.
+"""
+
+import html
+import json
+from pathlib import Path
+
+from monarch_mcp_server.config import ServeConfig
+
+
+def current_auth_token(cfg: ServeConfig) -> str:
+    """Return the token to display right now — re-read from disk if the
+    operator configured a token file, so rotations are picked up live."""
+    if cfg.auth_token_file:
+        try:
+            live = Path(cfg.auth_token_file).read_text().strip()
+        except OSError:
+            live = ""
+        if live:
+            return live
+    return cfg.auth_token
+
+
+def render_setup_page(cfg: ServeConfig) -> str:
+    token = current_auth_token(cfg)
+    mcp_url = f"{cfg.issuer_url}/mcp"
+
+    claude_code_cmd = (
+        f"claude mcp add --transport http monarch {mcp_url} \\\n"
+        f'  --header "Authorization: Bearer {token}"'
+    )
+    desktop_json = json.dumps(
+        {
+            "mcpServers": {
+                "monarch": {
+                    "command": "npx",
+                    "args": [
+                        "mcp-remote",
+                        mcp_url,
+                        "--header",
+                        f"Authorization: Bearer {token}",
+                    ],
+                }
+            }
+        },
+        indent=2,
+    )
+
+    e = html.escape
+    blocks = [
+        ("Claude Code", claude_code_cmd),
+        ("Claude Desktop (claude_desktop_config.json)", desktop_json),
+        ("MCP URL", mcp_url),
+        ("Bearer token", token),
+    ]
+    sections = "\n".join(
+        f"""
+        <section>
+          <h2>{e(title)}</h2>
+          <div class="block">
+            <pre id="v{i}">{e(value)}</pre>
+            <button onclick="copyBlock('v{i}', this)">Copy</button>
+          </div>
+        </section>"""
+        for i, (title, value) in enumerate(blocks)
+    )
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>monarch-mcp — client setup</title>
+<style>
+  :root {{
+    color-scheme: light dark;
+    --bg: #f7f7f8; --fg: #1a1a1a; --card: #ffffff; --border: #e2e2e4;
+    --mono-bg: #f0f0f2; --accent: #6a4cff;
+  }}
+  @media (prefers-color-scheme: dark) {{
+    :root {{ --bg: #16161a; --fg: #ececee; --card: #201f24; --border: #33323a; --mono-bg: #100f13; --accent: #a48bff; }}
+  }}
+  * {{ box-sizing: border-box; }}
+  body {{
+    margin: 0; padding: 2rem 1rem 4rem; background: var(--bg); color: var(--fg);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }}
+  main {{ max-width: 42rem; margin: 0 auto; }}
+  h1 {{ font-size: 1.4rem; margin-bottom: 0.25rem; }}
+  p.lede {{ opacity: 0.7; margin-top: 0; }}
+  section {{
+    background: var(--card); border: 1px solid var(--border); border-radius: 10px;
+    padding: 1rem 1.25rem; margin-bottom: 1rem;
+  }}
+  h2 {{ font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.04em; opacity: 0.65; margin: 0 0 0.6rem; }}
+  .block {{ display: flex; align-items: flex-start; gap: 0.6rem; }}
+  pre {{
+    flex: 1; min-width: 0; overflow-x: auto; background: var(--mono-bg); border-radius: 8px;
+    padding: 0.75rem 0.9rem; margin: 0; font-size: 0.85rem; white-space: pre-wrap; word-break: break-all;
+  }}
+  button {{
+    flex-shrink: 0; border: 1px solid var(--border); background: transparent; color: var(--fg);
+    border-radius: 8px; padding: 0.5rem 0.8rem; cursor: pointer; font-size: 0.85rem;
+  }}
+  button:hover {{ border-color: var(--accent); color: var(--accent); }}
+  button.copied {{ border-color: var(--accent); color: var(--accent); }}
+  .warn {{ font-size: 0.85rem; opacity: 0.75; margin-top: 2rem; }}
+</style>
+</head>
+<body>
+<main>
+  <h1>monarch-mcp client setup</h1>
+  <p class="lede">Copy what your client needs. The token below is live — if it was just rotated, reload this page.</p>
+  {sections}
+  <p class="warn">This token grants full read/write access to the Monarch account. Don't share this page or its contents.</p>
+</main>
+<script>
+function copyBlock(id, btn) {{
+  const text = document.getElementById(id).textContent;
+  navigator.clipboard.writeText(text).then(() => {{
+    const original = btn.textContent;
+    btn.textContent = "Copied";
+    btn.classList.add("copied");
+    setTimeout(() => {{ btn.textContent = original; btn.classList.remove("copied"); }}, 1500);
+  }});
+}}
+</script>
+</body>
+</html>"""

--- a/src/monarch_mcp_server/setup_page.py
+++ b/src/monarch_mcp_server/setup_page.py
@@ -55,23 +55,32 @@ def render_setup_page(cfg: ServeConfig) -> str:
         indent=2,
     )
 
+    connector_url = f"{mcp_url}?token={token}"
+
     e = html.escape
     blocks = [
-        ("Claude Code", claude_code_cmd),
-        ("Claude Desktop (claude_desktop_config.json)", desktop_json),
-        ("MCP URL", mcp_url),
-        ("Bearer token", token),
+        (
+            'Claude Desktop / Mobile — "Add custom connector" URL field',
+            connector_url,
+            "Paste as-is into the “Remote MCP server URL” field. "
+            "Leave OAuth Client ID/Secret blank — not needed.",
+        ),
+        ("Claude Code", claude_code_cmd, None),
+        ("Claude Desktop (claude_desktop_config.json)", desktop_json, None),
+        ("MCP URL", mcp_url, None),
+        ("Bearer token", token, None),
     ]
     sections = "\n".join(
         f"""
         <section>
           <h2>{e(title)}</h2>
+          {f'<p class="hint">{e(hint)}</p>' if hint else ""}
           <div class="block">
             <pre id="v{i}">{e(value)}</pre>
             <button onclick="copyBlock('v{i}', this)">Copy</button>
           </div>
         </section>"""
-        for i, (title, value) in enumerate(blocks)
+        for i, (title, value, hint) in enumerate(blocks)
     )
 
     return f"""<!doctype html>
@@ -103,6 +112,7 @@ def render_setup_page(cfg: ServeConfig) -> str:
     padding: 1rem 1.25rem; margin-bottom: 1rem;
   }}
   h2 {{ font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.04em; opacity: 0.65; margin: 0 0 0.6rem; }}
+  p.hint {{ font-size: 0.8rem; opacity: 0.65; margin: -0.3rem 0 0.6rem; }}
   .block {{ display: flex; align-items: flex-start; gap: 0.6rem; }}
   pre {{
     flex: 1; min-width: 0; overflow-x: auto; background: var(--mono-bg); border-radius: 8px;

--- a/src/monarch_mcp_server/tools/auth.py
+++ b/src/monarch_mcp_server/tools/auth.py
@@ -6,13 +6,13 @@ import os
 from mcp.server.fastmcp import Context
 
 from monarch_mcp_server import auth
+import monarch_mcp_server.app as app_module
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.secure_session import secure_session
 
 logger = logging.getLogger(__name__)
 
 
-@mcp.tool()
 async def setup_authentication() -> str:
     """Get instructions for setting up secure authentication with Monarch Money."""
     return """🔐 Monarch Money - Authentication Options
@@ -35,7 +35,6 @@ Call 'monarch_logout' to clear the stored session.
 ✅ Token stored securely in system keyring"""
 
 
-@mcp.tool()
 async def monarch_login(ctx: Context) -> str:
     """Sign in to Monarch Money.
 
@@ -46,7 +45,6 @@ async def monarch_login(ctx: Context) -> str:
     return await auth.login_interactive(ctx)
 
 
-@mcp.tool()
 async def monarch_login_with_token(ctx: Context) -> str:
     """Sign in to Monarch Money using a browser-copied session token.
 
@@ -56,7 +54,6 @@ async def monarch_login_with_token(ctx: Context) -> str:
     return await auth.login_with_token_interactive(ctx)
 
 
-@mcp.tool()
 async def monarch_logout() -> str:
     """Clear the stored Monarch Money session from the system keyring."""
     return await auth.logout()
@@ -85,7 +82,6 @@ async def check_auth_status() -> str:
         return f"Error checking auth status: {str(e)}"
 
 
-@mcp.tool()
 async def debug_session_loading() -> str:
     """Debug keyring session loading issues."""
     try:
@@ -96,3 +92,14 @@ async def debug_session_loading() -> str:
     except Exception as e:
         logger.exception("Keyring access failed")
         return f"❌ Keyring access failed: {type(e).__name__}: {e}"
+
+
+# Login tools accept credentials via the MCP channel, which is appropriate on
+# a local stdio transport but not over a remote HTTP connection. In serve
+# mode, sessions are installed on the host with login_setup.py instead.
+if app_module.MODE == "stdio":
+    mcp.tool()(setup_authentication)
+    mcp.tool()(monarch_login)
+    mcp.tool()(monarch_login_with_token)
+    mcp.tool()(monarch_logout)
+    mcp.tool()(debug_session_loading)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 mm_mock = MagicMock()
 mm_mock.MonarchMoney = MagicMock
 mm_mock.RequireMFAException = Exception
+# Must be a real exception class: login_password has `except
+# CaptchaRequiredException` clauses, and a MagicMock there is a TypeError.
+mm_mock.CaptchaRequiredException = type(
+    "CaptchaRequiredException", (Exception,), {}
+)
 sys.modules.setdefault("monarchmoney", mm_mock)
 sys.modules.setdefault("monarchmoney.monarchmoney", MagicMock())
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,6 +64,24 @@ class TestServeConfig:
         cfg = ServeConfig.from_env()
         assert cfg.auth_token == "f" * MIN_TOKEN_LENGTH  # stripped, file wins
 
+    def test_missing_token_file_falls_back_to_env(self, monkeypatch, tmp_path):
+        self._clear(monkeypatch)
+        monkeypatch.setenv(
+            "MONARCH_MCP_AUTH_TOKEN_FILE", str(tmp_path / "not-there")
+        )
+        monkeypatch.setenv("MONARCH_MCP_AUTH_TOKEN", VALID_TOKEN)
+        assert ServeConfig.from_env().auth_token == VALID_TOKEN
+
+    def test_missing_token_file_and_no_env_raises_with_path_hint(
+        self, monkeypatch, tmp_path
+    ):
+        self._clear(monkeypatch)
+        monkeypatch.setenv(
+            "MONARCH_MCP_AUTH_TOKEN_FILE", str(tmp_path / "not-there")
+        )
+        with pytest.raises(ValueError, match="not-there"):
+            ServeConfig.from_env()
+
     def test_custom_host_port_public_url_and_allowed_hosts(self, monkeypatch):
         self._clear(monkeypatch)
         monkeypatch.setenv("MONARCH_MCP_AUTH_TOKEN", VALID_TOKEN)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,80 @@
+"""Tests for mode resolution and serve configuration."""
+
+import pytest
+
+from monarch_mcp_server.config import MIN_TOKEN_LENGTH, ServeConfig, get_mode
+
+VALID_TOKEN = "x" * MIN_TOKEN_LENGTH
+
+
+class TestGetMode:
+    def test_default_is_stdio(self, monkeypatch):
+        monkeypatch.delenv("MONARCH_MCP_MODE", raising=False)
+        assert get_mode() == "stdio"
+
+    def test_serve_from_env(self, monkeypatch):
+        monkeypatch.setenv("MONARCH_MCP_MODE", "serve")
+        assert get_mode() == "serve"
+
+    def test_unknown_mode_raises(self, monkeypatch):
+        monkeypatch.setenv("MONARCH_MCP_MODE", "bananas")
+        with pytest.raises(ValueError, match="MONARCH_MCP_MODE"):
+            get_mode()
+
+
+class TestServeConfig:
+    def _clear(self, monkeypatch):
+        for var in (
+            "MONARCH_MCP_AUTH_TOKEN",
+            "MONARCH_MCP_AUTH_TOKEN_FILE",
+            "MONARCH_MCP_HOST",
+            "MONARCH_MCP_PORT",
+            "MONARCH_MCP_PUBLIC_URL",
+            "MONARCH_MCP_ALLOWED_HOSTS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_defaults(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("MONARCH_MCP_AUTH_TOKEN", VALID_TOKEN)
+        cfg = ServeConfig.from_env()
+        assert cfg.host == "127.0.0.1"
+        assert cfg.port == 8000
+        assert cfg.auth_token == VALID_TOKEN
+        assert cfg.issuer_url == "http://127.0.0.1:8000"
+        assert cfg.allowed_hosts == []
+
+    def test_missing_token_raises(self, monkeypatch):
+        self._clear(monkeypatch)
+        with pytest.raises(ValueError, match="MONARCH_MCP_AUTH_TOKEN"):
+            ServeConfig.from_env()
+
+    def test_short_token_raises(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("MONARCH_MCP_AUTH_TOKEN", "short")
+        with pytest.raises(ValueError, match="32"):
+            ServeConfig.from_env()
+
+    def test_token_file_takes_precedence(self, monkeypatch, tmp_path):
+        self._clear(monkeypatch)
+        token_file = tmp_path / "token"
+        token_file.write_text("f" * MIN_TOKEN_LENGTH + "\n")
+        monkeypatch.setenv("MONARCH_MCP_AUTH_TOKEN", "e" * MIN_TOKEN_LENGTH)
+        monkeypatch.setenv("MONARCH_MCP_AUTH_TOKEN_FILE", str(token_file))
+        cfg = ServeConfig.from_env()
+        assert cfg.auth_token == "f" * MIN_TOKEN_LENGTH  # stripped, file wins
+
+    def test_custom_host_port_public_url_and_allowed_hosts(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("MONARCH_MCP_AUTH_TOKEN", VALID_TOKEN)
+        monkeypatch.setenv("MONARCH_MCP_HOST", "0.0.0.0")
+        monkeypatch.setenv("MONARCH_MCP_PORT", "9100")
+        monkeypatch.setenv("MONARCH_MCP_PUBLIC_URL", "https://monarch.example.com")
+        monkeypatch.setenv(
+            "MONARCH_MCP_ALLOWED_HOSTS", "monarch.example.com, localhost:9100"
+        )
+        cfg = ServeConfig.from_env()
+        assert cfg.host == "0.0.0.0"
+        assert cfg.port == 9100
+        assert cfg.issuer_url == "https://monarch.example.com"
+        assert cfg.allowed_hosts == ["monarch.example.com", "localhost:9100"]

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -1,0 +1,52 @@
+"""Tests for the static bearer token verifier."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from monarch_mcp_server.http_auth import StaticTokenVerifier
+
+TOKEN = "t" * 40
+
+
+class TestStaticTokenVerifier:
+    async def test_valid_token_returns_access_token(self):
+        verifier = StaticTokenVerifier(TOKEN)
+        result = await verifier.verify_token(TOKEN)
+        assert result is not None
+        assert result.client_id == "static-token-client"
+
+    async def test_invalid_token_returns_none(self):
+        verifier = StaticTokenVerifier(TOKEN)
+        assert await verifier.verify_token("w" * 40) is None
+
+    async def test_empty_and_prefix_tokens_rejected(self):
+        verifier = StaticTokenVerifier(TOKEN)
+        assert await verifier.verify_token("") is None
+        assert await verifier.verify_token(TOKEN[:-1]) is None
+        assert await verifier.verify_token(TOKEN + "x") is None
+
+    async def test_uses_constant_time_comparison(self):
+        verifier = StaticTokenVerifier(TOKEN)
+        with patch("monarch_mcp_server.http_auth.hmac.compare_digest",
+                   wraps=__import__("hmac").compare_digest) as cmp:
+            await verifier.verify_token(TOKEN)
+            cmp.assert_called_once()
+
+    async def test_throttles_after_repeated_failures(self):
+        verifier = StaticTokenVerifier(TOKEN, max_failures_per_minute=3)
+        with patch("monarch_mcp_server.http_auth.asyncio.sleep",
+                   new=AsyncMock()) as sleep:
+            for _ in range(3):
+                await verifier.verify_token("bad" * 20)
+            sleep.assert_not_called()
+            await verifier.verify_token("bad" * 20)
+            sleep.assert_awaited_once_with(2)
+
+    async def test_successes_do_not_throttle(self):
+        verifier = StaticTokenVerifier(TOKEN, max_failures_per_minute=1)
+        with patch("monarch_mcp_server.http_auth.asyncio.sleep",
+                   new=AsyncMock()) as sleep:
+            for _ in range(5):
+                await verifier.verify_token(TOKEN)
+            sleep.assert_not_called()

--- a/tests/test_login_cookies.py
+++ b/tests/test_login_cookies.py
@@ -1,0 +1,101 @@
+"""Tests for the non-interactive login-cookies subcommand."""
+
+import io
+
+import pytest
+
+from monarch_mcp_server import cli, login_cookies
+
+
+class _FakeClient:
+    def __init__(self, accounts):
+        self._accounts = accounts
+
+    async def get_accounts(self):
+        return self._accounts
+
+
+class TestLoginCookiesRun:
+    def _patch_stdin(self, monkeypatch, value):
+        monkeypatch.setattr("sys.stdin", io.StringIO(value))
+
+    @pytest.mark.asyncio
+    async def test_empty_stdin_fails_without_login_attempt(
+        self, monkeypatch, capsys
+    ):
+        self._patch_stdin(monkeypatch, "   \n")
+        called = []
+        monkeypatch.setattr(
+            login_cookies,
+            "login_with_browser_cookies",
+            lambda cookie: called.append(cookie),
+        )
+        assert await login_cookies._run() == 1
+        assert called == []
+        assert "stdin" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_success_saves_session_without_echoing_cookie(
+        self, monkeypatch, capsys
+    ):
+        cookie = "session_id=SECRETVALUE; csrftoken=ALSOSECRET"
+        self._patch_stdin(monkeypatch, cookie + "\n")
+        client = _FakeClient({"accounts": [{"id": "1"}, {"id": "2"}]})
+
+        async def fake_login(cookie_string):
+            assert cookie_string == cookie
+            return client
+
+        saved = []
+        monkeypatch.setattr(
+            login_cookies, "login_with_browser_cookies", fake_login
+        )
+        monkeypatch.setattr(
+            login_cookies.secure_session,
+            "save_authenticated_session",
+            saved.append,
+        )
+
+        assert await login_cookies._run() == 0
+        assert saved == [client]
+        out = capsys.readouterr()
+        assert "2 accounts" in out.out
+        assert "SECRETVALUE" not in out.out + out.err
+
+    @pytest.mark.asyncio
+    async def test_login_failure_returns_error_and_saves_nothing(
+        self, monkeypatch, capsys
+    ):
+        self._patch_stdin(monkeypatch, "session_id=whatever")
+
+        async def fake_login(cookie_string):
+            raise RuntimeError("401 from Monarch")
+
+        saved = []
+        monkeypatch.setattr(
+            login_cookies, "login_with_browser_cookies", fake_login
+        )
+        monkeypatch.setattr(
+            login_cookies.secure_session,
+            "save_authenticated_session",
+            saved.append,
+        )
+
+        assert await login_cookies._run() == 1
+        assert saved == []
+        assert "401 from Monarch" in capsys.readouterr().err
+
+
+class TestCliRouting:
+    def test_login_cookies_subcommand_does_not_load_app(self, monkeypatch):
+        invoked = []
+        monkeypatch.setattr(
+            "monarch_mcp_server.login_cookies.main",
+            lambda: invoked.append(True),
+        )
+
+        def fail_loader():  # pragma: no cover
+            raise AssertionError("app must not be imported for login-cookies")
+
+        cli.main(["login-cookies"], _app_loader=fail_loader)
+        assert invoked == [True]

--- a/tests/test_login_password.py
+++ b/tests/test_login_password.py
@@ -71,38 +71,44 @@ class TestLoginPasswordRun:
         assert "one-time code" in capsys.readouterr().err
 
     @pytest.mark.asyncio
-    async def test_email_otp_retry_with_code_succeeds(
-        self, monkeypatch, saved, capsys
+    async def test_supplied_code_is_applied_on_first_call(
+        self, monkeypatch, saved
     ):
+        # The provided code must ride the FIRST request (email_otp) so no
+        # fresh OTP email is triggered — a no-code attempt first would
+        # invalidate the operator's code.
         _stdin(monkeypatch, "user@example.com\nhunter2secret\n123456\n")
         client = _FakeClient({"accounts": []})
         calls = []
 
         async def fake_login(email, password, *, email_otp=None, mfa_code=None):
-            calls.append(email_otp)
-            if email_otp is None:
-                raise EmailOtpRequiredException()
+            calls.append((email_otp, mfa_code))
             assert email_otp == "123456"
             return client
 
         monkeypatch.setattr(login_password, "login_with_current_auth", fake_login)
         assert await login_password._run() == 0
-        assert calls == [None, "123456"]
+        assert calls == [("123456", None)]  # exactly one call, no no-code probe
         assert saved == [client]
 
     @pytest.mark.asyncio
-    async def test_mfa_retry_with_code_succeeds(self, monkeypatch, saved):
+    async def test_supplied_code_falls_back_to_mfa_slot(self, monkeypatch, saved):
+        # If Monarch rejects the code as an email OTP with an MFA-required
+        # signal, retry it as a TOTP code — still no fresh-email probe.
         _stdin(monkeypatch, "user@example.com\nhunter2secret\n654321\n")
         client = _FakeClient({"accounts": []})
+        calls = []
 
         async def fake_login(email, password, *, email_otp=None, mfa_code=None):
-            if mfa_code is None:
-                raise RequireMFAException("mfa")
+            calls.append((email_otp, mfa_code))
+            if email_otp is not None:
+                raise RequireMFAException("wanted totp")
             assert mfa_code == "654321"
             return client
 
         monkeypatch.setattr(login_password, "login_with_current_auth", fake_login)
         assert await login_password._run() == 0
+        assert calls == [("654321", None), (None, "654321")]
         assert saved == [client]
 
     @pytest.mark.asyncio

--- a/tests/test_login_password.py
+++ b/tests/test_login_password.py
@@ -1,0 +1,133 @@
+"""Tests for the non-interactive login-password subcommand."""
+
+import io
+
+import pytest
+from monarchmoney import CaptchaRequiredException, RequireMFAException
+
+from monarch_mcp_server import cli, login_password
+from monarch_mcp_server.monarch_auth import EmailOtpRequiredException
+
+
+class _FakeClient:
+    def __init__(self, accounts):
+        self._accounts = accounts
+
+    async def get_accounts(self):
+        return self._accounts
+
+
+@pytest.fixture
+def saved(monkeypatch):
+    saved = []
+    monkeypatch.setattr(
+        "monarch_mcp_server.login_cookies.secure_session.save_authenticated_session",
+        saved.append,
+    )
+    return saved
+
+
+def _stdin(monkeypatch, value):
+    monkeypatch.setattr("sys.stdin", io.StringIO(value))
+
+
+class TestLoginPasswordRun:
+    @pytest.mark.asyncio
+    async def test_missing_password_line_fails(self, monkeypatch, saved, capsys):
+        _stdin(monkeypatch, "user@example.com\n")
+        assert await login_password._run() == 1
+        assert saved == []
+        assert "stdin" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_plain_login_saves_session(self, monkeypatch, saved, capsys):
+        _stdin(monkeypatch, "user@example.com\nhunter2secret\n")
+        client = _FakeClient({"accounts": [{"id": "1"}]})
+
+        async def fake_login(email, password, *, email_otp=None, mfa_code=None):
+            assert (email, password) == ("user@example.com", "hunter2secret")
+            assert email_otp is None and mfa_code is None
+            return client
+
+        monkeypatch.setattr(login_password, "login_with_current_auth", fake_login)
+        assert await login_password._run() == 0
+        assert saved == [client]
+        out = capsys.readouterr()
+        assert "1 accounts" in out.out
+        assert "hunter2secret" not in out.out + out.err
+
+    @pytest.mark.asyncio
+    async def test_email_otp_required_without_code_instructs_retry(
+        self, monkeypatch, saved, capsys
+    ):
+        _stdin(monkeypatch, "user@example.com\nhunter2secret\n")
+
+        async def fake_login(email, password, *, email_otp=None, mfa_code=None):
+            raise EmailOtpRequiredException()
+
+        monkeypatch.setattr(login_password, "login_with_current_auth", fake_login)
+        assert await login_password._run() == 1
+        assert saved == []
+        assert "one-time code" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_email_otp_retry_with_code_succeeds(
+        self, monkeypatch, saved, capsys
+    ):
+        _stdin(monkeypatch, "user@example.com\nhunter2secret\n123456\n")
+        client = _FakeClient({"accounts": []})
+        calls = []
+
+        async def fake_login(email, password, *, email_otp=None, mfa_code=None):
+            calls.append(email_otp)
+            if email_otp is None:
+                raise EmailOtpRequiredException()
+            assert email_otp == "123456"
+            return client
+
+        monkeypatch.setattr(login_password, "login_with_current_auth", fake_login)
+        assert await login_password._run() == 0
+        assert calls == [None, "123456"]
+        assert saved == [client]
+
+    @pytest.mark.asyncio
+    async def test_mfa_retry_with_code_succeeds(self, monkeypatch, saved):
+        _stdin(monkeypatch, "user@example.com\nhunter2secret\n654321\n")
+        client = _FakeClient({"accounts": []})
+
+        async def fake_login(email, password, *, email_otp=None, mfa_code=None):
+            if mfa_code is None:
+                raise RequireMFAException("mfa")
+            assert mfa_code == "654321"
+            return client
+
+        monkeypatch.setattr(login_password, "login_with_current_auth", fake_login)
+        assert await login_password._run() == 0
+        assert saved == [client]
+
+    @pytest.mark.asyncio
+    async def test_captcha_points_to_cookie_flow(self, monkeypatch, saved, capsys):
+        _stdin(monkeypatch, "user@example.com\nhunter2secret\n")
+
+        async def fake_login(email, password, *, email_otp=None, mfa_code=None):
+            raise CaptchaRequiredException("blocked")
+
+        monkeypatch.setattr(login_password, "login_with_current_auth", fake_login)
+        assert await login_password._run() == 1
+        assert saved == []
+        assert "login-cookies" in capsys.readouterr().err
+
+
+class TestCliRouting:
+    def test_login_password_subcommand_does_not_load_app(self, monkeypatch):
+        invoked = []
+        monkeypatch.setattr(
+            "monarch_mcp_server.login_password.main",
+            lambda: invoked.append(True),
+        )
+
+        def fail_loader():  # pragma: no cover
+            raise AssertionError("app must not be imported for login-password")
+
+        cli.main(["login-password"], _app_loader=fail_loader)
+        assert invoked == [True]

--- a/tests/test_query_token_auth.py
+++ b/tests/test_query_token_auth.py
@@ -1,0 +1,83 @@
+"""Unit tests for the ?token= -> Authorization header ASGI shim."""
+
+import pytest
+
+from monarch_mcp_server.query_token_auth import QueryTokenAuthMiddleware
+
+
+class _RecordingApp:
+    """Minimal ASGI app that records the headers it was called with."""
+
+    def __init__(self):
+        self.received_scope = None
+
+    async def __call__(self, scope, receive, send):
+        self.received_scope = scope
+
+
+def _http_scope(*, query_string: bytes = b"", headers: list | None = None) -> dict:
+    return {
+        "type": "http",
+        "query_string": query_string,
+        "headers": headers or [],
+    }
+
+
+def _header_value(scope: dict, name: bytes) -> bytes | None:
+    for k, v in scope["headers"]:
+        if k.lower() == name.lower():
+            return v
+    return None
+
+
+@pytest.mark.asyncio
+class TestQueryTokenAuthMiddleware:
+    async def test_query_token_becomes_authorization_header(self):
+        inner = _RecordingApp()
+        mw = QueryTokenAuthMiddleware(inner)
+
+        await mw(_http_scope(query_string=b"token=abc123"), None, None)
+
+        assert _header_value(inner.received_scope, b"authorization") == b"Bearer abc123"
+
+    async def test_existing_authorization_header_wins_over_query_token(self):
+        inner = _RecordingApp()
+        mw = QueryTokenAuthMiddleware(inner)
+        headers = [(b"authorization", b"Bearer real-header-token")]
+
+        await mw(_http_scope(query_string=b"token=abc123", headers=headers), None, None)
+
+        assert _header_value(inner.received_scope, b"authorization") == b"Bearer real-header-token"
+
+    async def test_no_query_token_and_no_header_leaves_request_unauthenticated(self):
+        inner = _RecordingApp()
+        mw = QueryTokenAuthMiddleware(inner)
+
+        await mw(_http_scope(), None, None)
+
+        assert _header_value(inner.received_scope, b"authorization") is None
+
+    async def test_empty_token_value_is_ignored(self):
+        inner = _RecordingApp()
+        mw = QueryTokenAuthMiddleware(inner)
+
+        await mw(_http_scope(query_string=b"token="), None, None)
+
+        assert _header_value(inner.received_scope, b"authorization") is None
+
+    async def test_non_http_scope_passes_through_untouched(self):
+        inner = _RecordingApp()
+        mw = QueryTokenAuthMiddleware(inner)
+        scope = {"type": "lifespan"}
+
+        await mw(scope, None, None)
+
+        assert inner.received_scope == {"type": "lifespan"}
+
+    async def test_other_query_params_do_not_interfere(self):
+        inner = _RecordingApp()
+        mw = QueryTokenAuthMiddleware(inner)
+
+        await mw(_http_scope(query_string=b"foo=bar&token=abc123&baz=qux"), None, None)
+
+        assert _header_value(inner.received_scope, b"authorization") == b"Bearer abc123"

--- a/tests/test_secure_session.py
+++ b/tests/test_secure_session.py
@@ -2,7 +2,7 @@
 
 import sys
 import types
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -168,8 +168,8 @@ def storage_keyring(monkeypatch):
     monkeypatch.setitem(sys.modules, "keyring", module)
 
     session = ss_module.SecureMonarchSession()
-    # __init__ ran the probe and set _use_keyring=True via the fake.
-    assert session._use_keyring is True
+    # Check via _keyring_ok property, which triggers the lazy probe.
+    assert session._keyring_ok is True
     return session, fake
 
 
@@ -334,3 +334,23 @@ class TestGetAuthenticatedClient:
     def test_no_session_returns_none(self, storage_keyring):
         session, _ = storage_keyring
         assert session.get_authenticated_client() is None
+
+
+class TestLazyKeyringProbe:
+    def test_constructor_does_not_probe_keyring(self):
+        from monarch_mcp_server import secure_session as ss
+
+        with patch.object(ss, "_keyring_available") as probe:
+            ss.SecureMonarchSession()
+            probe.assert_not_called()
+
+    def test_first_use_probes_keyring_once(self, tmp_path):
+        from monarch_mcp_server import secure_session as ss
+
+        with patch.object(ss, "_keyring_available", return_value=False) as probe, \
+             patch.object(ss, "_TOKEN_DIR", tmp_path), \
+             patch.object(ss, "_TOKEN_FILE", tmp_path / "token"):
+            session = ss.SecureMonarchSession()
+            session.load_session()
+            session.load_session()
+            assert probe.call_count == 1

--- a/tests/test_serve_http.py
+++ b/tests/test_serve_http.py
@@ -115,3 +115,32 @@ def test_mcp_endpoint_unaffected_by_root_route(server):
         headers=MCP_HEADERS | {"Authorization": f"Bearer {TOKEN}"},
     )
     assert resp.status_code == 200
+
+
+def test_mcp_with_valid_token_as_query_param_initializes(server):
+    # Custom MCP connectors (Claude Desktop/mobile's "Remote MCP server
+    # URL" field) can't set a header — this is the path they use instead.
+    resp = httpx.post(
+        f"{server}/mcp?token={TOKEN}", json=INIT_BODY, headers=MCP_HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["serverInfo"]["name"] == "Monarch Money MCP Server"
+
+
+def test_mcp_with_wrong_token_as_query_param_is_401(server):
+    resp = httpx.post(
+        f"{server}/mcp?token=" + "w" * 40, json=INIT_BODY, headers=MCP_HEADERS,
+    )
+    assert resp.status_code == 401
+
+
+def test_mcp_header_wins_over_query_token_when_both_present(server):
+    # A real Authorization header must never be silently overridden by a
+    # query param — even a WRONG header should still fail, not fall back
+    # to a valid query token.
+    resp = httpx.post(
+        f"{server}/mcp?token={TOKEN}", json=INIT_BODY,
+        headers=MCP_HEADERS | {"Authorization": "Bearer " + "w" * 40},
+    )
+    assert resp.status_code == 401

--- a/tests/test_serve_http.py
+++ b/tests/test_serve_http.py
@@ -1,0 +1,93 @@
+"""Integration tests: real serve-mode process, real HTTP, auth boundary."""
+
+import os
+import socket
+import subprocess
+import sys
+import time
+
+import httpx
+import pytest
+
+TOKEN = "integration-test-token-" + "x" * 20
+
+INIT_BODY = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-06-18",
+        "capabilities": {},
+        "clientInfo": {"name": "pytest", "version": "0"},
+    },
+}
+MCP_HEADERS = {
+    "Content-Type": "application/json",
+    "Accept": "application/json, text/event-stream",
+}
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def server():
+    port = _free_port()
+    env = os.environ | {
+        "MONARCH_MCP_MODE": "serve",
+        "MONARCH_MCP_AUTH_TOKEN": TOKEN,
+        "MONARCH_MCP_PORT": str(port),
+    }
+    proc = subprocess.Popen(
+        [sys.executable, "-c",
+         "from monarch_mcp_server.cli import main; main(['serve'])"],
+        env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    base = f"http://127.0.0.1:{port}"
+    try:
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            try:
+                if httpx.get(f"{base}/healthz", timeout=1).status_code == 200:
+                    break
+            except httpx.TransportError:
+                time.sleep(0.2)
+        else:
+            raise RuntimeError("server did not become healthy")
+        yield base
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+
+def test_healthz_is_unauthenticated_and_bare(server):
+    resp = httpx.get(f"{server}/healthz")
+    assert resp.status_code == 200
+    assert resp.text == "ok"
+
+
+def test_mcp_without_token_is_401(server):
+    resp = httpx.post(f"{server}/mcp", json=INIT_BODY, headers=MCP_HEADERS)
+    assert resp.status_code == 401
+    assert "www-authenticate" in {k.lower() for k in resp.headers}
+
+
+def test_mcp_with_wrong_token_is_401(server):
+    resp = httpx.post(
+        f"{server}/mcp", json=INIT_BODY,
+        headers=MCP_HEADERS | {"Authorization": "Bearer " + "w" * 40},
+    )
+    assert resp.status_code == 401
+
+
+def test_mcp_with_valid_token_initializes(server):
+    resp = httpx.post(
+        f"{server}/mcp", json=INIT_BODY,
+        headers=MCP_HEADERS | {"Authorization": f"Bearer {TOKEN}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["serverInfo"]["name"] == "Monarch Money MCP Server"

--- a/tests/test_serve_http.py
+++ b/tests/test_serve_http.py
@@ -95,3 +95,23 @@ def test_mcp_with_valid_token_initializes(server):
     assert resp.status_code == 200
     body = resp.json()
     assert body["result"]["serverInfo"]["name"] == "Monarch Money MCP Server"
+
+
+def test_root_serves_setup_page_unauthenticated(server):
+    # No auth of its own (relies on Cloudflare Access at the edge in
+    # production) — but must not collide with the MCP transport's own
+    # root-adjacent routing, and must not require the bearer token.
+    resp = httpx.get(f"{server}/")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    assert TOKEN in resp.text
+    assert "claude mcp add" in resp.text
+
+
+def test_mcp_endpoint_unaffected_by_root_route(server):
+    # Guards against a regression where adding "/" ever shadows "/mcp".
+    resp = httpx.post(
+        f"{server}/mcp", json=INIT_BODY,
+        headers=MCP_HEADERS | {"Authorization": f"Bearer {TOKEN}"},
+    )
+    assert resp.status_code == 200

--- a/tests/test_serve_http.py
+++ b/tests/test_serve_http.py
@@ -60,7 +60,11 @@ def server():
         yield base
     finally:
         proc.terminate()
-        proc.wait(timeout=10)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
 
 
 def test_healthz_is_unauthenticated_and_bare(server):

--- a/tests/test_serve_mode.py
+++ b/tests/test_serve_mode.py
@@ -68,25 +68,21 @@ def test_cli_serve_subcommand_sets_mode_and_flags():
 
     captured = {}
 
-    def fake_run(transport=None):
-        captured["transport"] = transport
+    def fake_serve_http(app):
+        captured["app"] = app
         captured["mode"] = os.environ.get("MONARCH_MCP_MODE")
         captured["host"] = os.environ.get("MONARCH_MCP_HOST")
         captured["port"] = os.environ.get("MONARCH_MCP_PORT")
 
-    def fake_import():
-        class FakeApp:
-            class mcp:
-                run = staticmethod(fake_run)
-        return FakeApp
+    sentinel_app = object()
 
     old_env = {k: os.environ.get(k) for k in
                ("MONARCH_MCP_MODE", "MONARCH_MCP_HOST", "MONARCH_MCP_PORT")}
     try:
         cli.main(["serve", "--host", "0.0.0.0", "--port", "9100"],
-                 _app_loader=fake_import)
+                 _app_loader=lambda: sentinel_app, _serve_http=fake_serve_http)
         assert captured == {
-            "transport": "streamable-http",
+            "app": sentinel_app,
             "mode": "serve",
             "host": "0.0.0.0",
             "port": "9100",
@@ -97,3 +93,41 @@ def test_cli_serve_subcommand_sets_mode_and_flags():
                 os.environ.pop(k, None)
             else:
                 os.environ[k] = v
+
+
+def test_default_serve_http_wraps_app_with_query_token_middleware(monkeypatch):
+    from monarch_mcp_server import cli
+    from monarch_mcp_server.query_token_auth import QueryTokenAuthMiddleware
+
+    captured = {}
+
+    def fake_uvicorn_run(asgi_app, *, host, port, log_level):
+        captured["asgi_app"] = asgi_app
+        captured["host"] = host
+        captured["port"] = port
+        captured["log_level"] = log_level
+
+    monkeypatch.setattr("uvicorn.run", fake_uvicorn_run)
+
+    class FakeSettings:
+        host = "0.0.0.0"
+        port = 9100
+        log_level = "INFO"
+
+    class FakeMcp:
+        settings = FakeSettings()
+
+        @staticmethod
+        def streamable_http_app():
+            return "the-real-asgi-app"
+
+    class FakeApp:
+        mcp = FakeMcp()
+
+    cli._default_serve_http(FakeApp())
+
+    assert isinstance(captured["asgi_app"], QueryTokenAuthMiddleware)
+    assert captured["asgi_app"].app == "the-real-asgi-app"
+    assert captured["host"] == "0.0.0.0"
+    assert captured["port"] == 9100
+    assert captured["log_level"] == "info"

--- a/tests/test_serve_mode.py
+++ b/tests/test_serve_mode.py
@@ -1,0 +1,63 @@
+"""Mode-dependent app construction and tool registration.
+
+Registration happens at import time, so each case runs in a fresh
+interpreter with the mode set via environment variables.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+LIST_TOOLS_SNIPPET = (
+    "import asyncio, json;"
+    "from monarch_mcp_server.app import mcp;"
+    "tools = asyncio.run(mcp.list_tools());"
+    "print(json.dumps(sorted(t.name for t in tools)))"
+)
+
+LOGIN_TOOLS = {
+    "setup_authentication",
+    "monarch_login",
+    "monarch_login_with_token",
+    "monarch_logout",
+    "debug_session_loading",
+}
+
+
+def _tool_names(extra_env):
+    env = os.environ | extra_env
+    out = subprocess.run(
+        [sys.executable, "-c", LIST_TOOLS_SNIPPET],
+        capture_output=True, text=True, env=env, check=True,
+    )
+    return set(json.loads(out.stdout.strip().splitlines()[-1]))
+
+
+def test_stdio_mode_registers_login_tools():
+    names = _tool_names({"MONARCH_MCP_MODE": "stdio"})
+    assert LOGIN_TOOLS <= names
+    assert "check_auth_status" in names
+    assert "get_accounts" in names
+
+
+def test_serve_mode_omits_login_tools():
+    names = _tool_names({
+        "MONARCH_MCP_MODE": "serve",
+        "MONARCH_MCP_AUTH_TOKEN": "x" * 40,
+    })
+    assert LOGIN_TOOLS.isdisjoint(names)
+    assert "check_auth_status" in names
+    assert "get_accounts" in names
+
+
+def test_serve_mode_without_token_fails_fast():
+    env = os.environ | {"MONARCH_MCP_MODE": "serve"}
+    env.pop("MONARCH_MCP_AUTH_TOKEN", None)
+    env.pop("MONARCH_MCP_AUTH_TOKEN_FILE", None)
+    out = subprocess.run(
+        [sys.executable, "-c", "import monarch_mcp_server.app"],
+        capture_output=True, text=True, env=env,
+    )
+    assert out.returncode != 0
+    assert "MONARCH_MCP_AUTH_TOKEN" in out.stderr

--- a/tests/test_serve_mode.py
+++ b/tests/test_serve_mode.py
@@ -61,3 +61,39 @@ def test_serve_mode_without_token_fails_fast():
     )
     assert out.returncode != 0
     assert "MONARCH_MCP_AUTH_TOKEN" in out.stderr
+
+
+def test_cli_serve_subcommand_sets_mode_and_flags():
+    from monarch_mcp_server import cli
+
+    captured = {}
+
+    def fake_run(transport=None):
+        captured["transport"] = transport
+        captured["mode"] = os.environ.get("MONARCH_MCP_MODE")
+        captured["host"] = os.environ.get("MONARCH_MCP_HOST")
+        captured["port"] = os.environ.get("MONARCH_MCP_PORT")
+
+    def fake_import():
+        class FakeApp:
+            class mcp:
+                run = staticmethod(fake_run)
+        return FakeApp
+
+    old_env = {k: os.environ.get(k) for k in
+               ("MONARCH_MCP_MODE", "MONARCH_MCP_HOST", "MONARCH_MCP_PORT")}
+    try:
+        cli.main(["serve", "--host", "0.0.0.0", "--port", "9100"],
+                 _app_loader=fake_import)
+        assert captured == {
+            "transport": "streamable-http",
+            "mode": "serve",
+            "host": "0.0.0.0",
+            "port": "9100",
+        }
+    finally:
+        for k, v in old_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v

--- a/tests/test_setup_page.py
+++ b/tests/test_setup_page.py
@@ -71,7 +71,25 @@ class TestRenderSetupPage:
         cfg = _cfg()
         page = render_setup_page(cfg)
         assert "mcpServers" in page  # HTML-escaped quotes, so check unquoted
-        match = re.search(r'<pre id="v1">(.*?)</pre>', page, re.DOTALL)
+        match = re.search(r'<pre id="v2">(.*?)</pre>', page, re.DOTALL)
         assert match is not None
         parsed = json.loads(html.unescape(match.group(1)))
         assert parsed["mcpServers"]["monarch"]["args"][1] == f"{cfg.issuer_url}/mcp"
+
+    def test_connector_url_block_present_with_token_query_param(self):
+        cfg = _cfg()
+        page = render_setup_page(cfg)
+        expected_url = f"{cfg.issuer_url}/mcp?token={cfg.auth_token}"
+        assert expected_url in page
+        assert "Add custom connector" in page
+        assert "Leave OAuth Client ID/Secret blank" in page
+
+    def test_connector_url_uses_live_token_not_startup_token(self, tmp_path):
+        token_file = tmp_path / "auth_token"
+        token_file.write_text("live-token-" + "z" * 20)
+        cfg = _cfg(auth_token="stale-startup-token", auth_token_file=str(token_file))
+
+        page = render_setup_page(cfg)
+
+        assert f"{cfg.issuer_url}/mcp?token=live-token-" + "z" * 20 in page
+        assert "token=stale-startup-token" not in page

--- a/tests/test_setup_page.py
+++ b/tests/test_setup_page.py
@@ -1,4 +1,4 @@
-"""Tests for the /setup client-config page."""
+"""Tests for the root ("/") client-config page."""
 
 from monarch_mcp_server.config import ServeConfig
 from monarch_mcp_server.setup_page import current_auth_token, render_setup_page

--- a/tests/test_setup_page.py
+++ b/tests/test_setup_page.py
@@ -1,0 +1,77 @@
+"""Tests for the /setup client-config page."""
+
+from monarch_mcp_server.config import ServeConfig
+from monarch_mcp_server.setup_page import current_auth_token, render_setup_page
+
+
+def _cfg(**overrides):
+    defaults = dict(
+        host="0.0.0.0",
+        port=8000,
+        auth_token="startup-token-" + "x" * 20,
+        issuer_url="https://monarch-home.arditti.io",
+        allowed_hosts=["monarch-home.arditti.io"],
+        auth_token_file="",
+    )
+    defaults.update(overrides)
+    return ServeConfig(**defaults)
+
+
+class TestCurrentAuthToken:
+    def test_no_token_file_uses_startup_value(self):
+        cfg = _cfg()
+        assert current_auth_token(cfg) == cfg.auth_token
+
+    def test_token_file_present_reads_live_value(self, tmp_path):
+        token_file = tmp_path / "auth_token"
+        token_file.write_text("rotated-token-" + "y" * 20 + "\n")
+        cfg = _cfg(auth_token_file=str(token_file))
+        assert current_auth_token(cfg) == "rotated-token-" + "y" * 20
+
+    def test_token_file_missing_falls_back_to_startup_value(self, tmp_path):
+        cfg = _cfg(auth_token_file=str(tmp_path / "nope"))
+        assert current_auth_token(cfg) == cfg.auth_token
+
+    def test_token_file_empty_falls_back_to_startup_value(self, tmp_path):
+        token_file = tmp_path / "auth_token"
+        token_file.write_text("   \n")
+        cfg = _cfg(auth_token_file=str(token_file))
+        assert current_auth_token(cfg) == cfg.auth_token
+
+
+class TestRenderSetupPage:
+    def test_contains_live_token_and_url_not_startup_token(self, tmp_path):
+        token_file = tmp_path / "auth_token"
+        token_file.write_text("live-token-" + "z" * 20)
+        cfg = _cfg(auth_token="stale-startup-token", auth_token_file=str(token_file))
+
+        page = render_setup_page(cfg)
+
+        assert "live-token-" + "z" * 20 in page
+        assert "stale-startup-token" not in page
+        assert "https://monarch-home.arditti.io/mcp" in page
+
+    def test_html_escapes_token_special_characters(self):
+        cfg = _cfg(auth_token="tok<en>&\"needs'escaping" + "x" * 10)
+        page = render_setup_page(cfg)
+        assert "<en>" not in page
+        assert "&lt;en&gt;" in page
+
+    def test_claude_code_command_present(self):
+        cfg = _cfg()
+        page = render_setup_page(cfg)
+        assert "claude mcp add --transport http monarch" in page
+        assert cfg.auth_token in page
+
+    def test_desktop_json_block_present_and_valid(self):
+        import html
+        import json
+        import re
+
+        cfg = _cfg()
+        page = render_setup_page(cfg)
+        assert "mcpServers" in page  # HTML-escaped quotes, so check unquoted
+        match = re.search(r'<pre id="v1">(.*?)</pre>', page, re.DOTALL)
+        assert match is not None
+        parsed = json.loads(html.unescape(match.group(1)))
+        assert parsed["mcpServers"]["monarch"]["args"][1] == f"{cfg.issuer_url}/mcp"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12, <3.14"
 
 [[package]]
@@ -175,6 +175,8 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/84/e94227139ee5fb4d600a7a4927f322e1d4aea6fdc50bd3fca8493caba23f/cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4", size = 183178, upload-time = "2024-09-04T20:44:12.232Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ee/fb72c2b48656111c4ef27f0f91da355e130a923473bf5ee75c5643d00cca/cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c", size = 178840, upload-time = "2024-09-04T20:44:13.739Z" },
     { url = "https://files.pythonhosted.org/packages/cc/b6/db007700f67d151abadf508cbfd6a1884f57eab90b1bb985c4c8c02b0f28/cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36", size = 454803, upload-time = "2024-09-04T20:44:15.231Z" },
     { url = "https://files.pythonhosted.org/packages/1a/df/f8d151540d8c200eb1c6fba8cd0dfd40904f1b0682ea705c36e6c2e97ab3/cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5", size = 478850, upload-time = "2024-09-04T20:44:17.188Z" },
     { url = "https://files.pythonhosted.org/packages/28/c0/b31116332a547fd2677ae5b78a2ef662dfc8023d67f41b2a83f7c2aa78b1/cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff", size = 485729, upload-time = "2024-09-04T20:44:18.688Z" },
@@ -182,6 +184,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/d5/da47df7004cb17e4955df6a43d14b3b4ae77737dff8bf7f8f333196717bf/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93", size = 479424, upload-time = "2024-09-04T20:44:21.673Z" },
     { url = "https://files.pythonhosted.org/packages/0b/ac/2a28bcf513e93a219c8a4e8e125534f4f6db03e3179ba1c45e949b76212c/cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3", size = 484568, upload-time = "2024-09-04T20:44:23.245Z" },
     { url = "https://files.pythonhosted.org/packages/d4/38/ca8a4f639065f14ae0f1d9751e70447a261f1a30fa7547a828ae08142465/cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8", size = 488736, upload-time = "2024-09-04T20:44:24.757Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c5/28b2d6f799ec0bdecf44dced2ec5ed43e0eb63097b0f58c293583b406582/cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65", size = 172448, upload-time = "2024-09-04T20:44:26.208Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b9/db34c4755a7bd1cb2d1603ac3863f22bcecbd1ba29e5ee841a4bc510b294/cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903", size = 181976, upload-time = "2024-09-04T20:44:27.578Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f8/dd6c246b148639254dad4d6803eb6a54e8c85c6e11ec9df2cffa87571dbe/cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e", size = 182989, upload-time = "2024-09-04T20:44:28.956Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f1/672d303ddf17c24fc83afd712316fda78dc6fce1cd53011b839483e1ecc8/cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2", size = 178802, upload-time = "2024-09-04T20:44:30.289Z" },
     { url = "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3", size = 454792, upload-time = "2024-09-04T20:44:32.01Z" },
     { url = "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683", size = 478893, upload-time = "2024-09-04T20:44:33.606Z" },
     { url = "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5", size = 485810, upload-time = "2024-09-04T20:44:35.191Z" },
@@ -189,6 +195,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd", size = 479447, upload-time = "2024-09-04T20:44:38.492Z" },
     { url = "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed", size = 484358, upload-time = "2024-09-04T20:44:40.046Z" },
     { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469, upload-time = "2024-09-04T20:44:41.616Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475, upload-time = "2024-09-04T20:44:43.733Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009, upload-time = "2024-09-04T20:44:45.309Z" },
 ]
 
 [[package]]
@@ -230,6 +238,7 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/35/c495bffc2056f2dadb32434f1feedd79abde2a7f8363e1974afa9c33c7e2/cryptography-45.0.7.tar.gz", hash = "sha256:4b1654dfc64ea479c242508eb8c724044f1e964a47d1d1cacc5132292d851971", size = 744980, upload-time = "2025-09-01T11:15:03.146Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/91/925c0ac74362172ae4516000fe877912e33b5983df735ff290c653de4913/cryptography-45.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3be4f21c6245930688bd9e162829480de027f8bf962ede33d4f8ba7d67a00cee", size = 7041105, upload-time = "2025-09-01T11:13:59.684Z" },
     { url = "https://files.pythonhosted.org/packages/fc/63/43641c5acce3a6105cf8bd5baeceeb1846bb63067d26dae3e5db59f1513a/cryptography-45.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:67285f8a611b0ebc0857ced2081e30302909f571a46bfa7a3cc0ad303fe015c6", size = 4205799, upload-time = "2025-09-01T11:14:02.517Z" },
     { url = "https://files.pythonhosted.org/packages/bc/29/c238dd9107f10bfde09a4d1c52fd38828b1aa353ced11f358b5dd2507d24/cryptography-45.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:577470e39e60a6cd7780793202e63536026d9b8641de011ed9d8174da9ca5339", size = 4430504, upload-time = "2025-09-01T11:14:04.522Z" },
     { url = "https://files.pythonhosted.org/packages/62/62/24203e7cbcc9bd7c94739428cd30680b18ae6b18377ae66075c8e4771b1b/cryptography-45.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4bd3e5c4b9682bc112d634f2c6ccc6736ed3635fc3319ac2bb11d768cc5a00d8", size = 4209542, upload-time = "2025-09-01T11:14:06.309Z" },
@@ -239,6 +248,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/e4/b3e68a4ac363406a56cf7b741eeb80d05284d8c60ee1a55cdc7587e2a553/cryptography-45.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b6a0e535baec27b528cb07a119f321ac024592388c5681a5ced167ae98e9fff3", size = 4460397, upload-time = "2025-09-01T11:14:12.924Z" },
     { url = "https://files.pythonhosted.org/packages/22/49/2c93f3cd4e3efc8cb22b02678c1fad691cff9dd71bb889e030d100acbfe0/cryptography-45.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a24ee598d10befaec178efdff6054bc4d7e883f615bfbcd08126a0f4931c83a6", size = 4337244, upload-time = "2025-09-01T11:14:14.431Z" },
     { url = "https://files.pythonhosted.org/packages/04/19/030f400de0bccccc09aa262706d90f2ec23d56bc4eb4f4e8268d0ddf3fb8/cryptography-45.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fa26fa54c0a9384c27fcdc905a2fb7d60ac6e47d14bc2692145f2b3b1e2cfdbd", size = 4568862, upload-time = "2025-09-01T11:14:16.185Z" },
+    { url = "https://files.pythonhosted.org/packages/29/56/3034a3a353efa65116fa20eb3c990a8c9f0d3db4085429040a7eef9ada5f/cryptography-45.0.7-cp311-abi3-win32.whl", hash = "sha256:bef32a5e327bd8e5af915d3416ffefdbe65ed975b646b3805be81b23580b57b8", size = 2936578, upload-time = "2025-09-01T11:14:17.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/61/0ab90f421c6194705a99d0fa9f6ee2045d916e4455fdbb095a9c2c9a520f/cryptography-45.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:3808e6b2e5f0b46d981c24d79648e5c25c35e59902ea4391a0dcb3e667bf7443", size = 3405400, upload-time = "2025-09-01T11:14:18.958Z" },
+    { url = "https://files.pythonhosted.org/packages/63/e8/c436233ddf19c5f15b25ace33979a9dd2e7aa1a59209a0ee8554179f1cc0/cryptography-45.0.7-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bfb4c801f65dd61cedfc61a83732327fafbac55a47282e6f26f073ca7a41c3b2", size = 7021824, upload-time = "2025-09-01T11:14:20.954Z" },
     { url = "https://files.pythonhosted.org/packages/bc/4c/8f57f2500d0ccd2675c5d0cc462095adf3faa8c52294ba085c036befb901/cryptography-45.0.7-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:81823935e2f8d476707e85a78a405953a03ef7b7b4f55f93f7c2d9680e5e0691", size = 4202233, upload-time = "2025-09-01T11:14:22.454Z" },
     { url = "https://files.pythonhosted.org/packages/eb/ac/59b7790b4ccaed739fc44775ce4645c9b8ce54cbec53edf16c74fd80cb2b/cryptography-45.0.7-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3994c809c17fc570c2af12c9b840d7cea85a9fd3e5c0e0491f4fa3c029216d59", size = 4423075, upload-time = "2025-09-01T11:14:24.287Z" },
     { url = "https://files.pythonhosted.org/packages/b8/56/d4f07ea21434bf891faa088a6ac15d6d98093a66e75e30ad08e88aa2b9ba/cryptography-45.0.7-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dad43797959a74103cb59c5dac71409f9c27d34c8a05921341fb64ea8ccb1dd4", size = 4204517, upload-time = "2025-09-01T11:14:25.679Z" },
@@ -248,6 +260,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/fa/1d5745d878048699b8eb87c984d4ccc5da4f5008dfd3ad7a94040caca23a/cryptography-45.0.7-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f3df7b3d0f91b88b2106031fd995802a2e9ae13e02c36c1fc075b43f420f3a17", size = 4449383, upload-time = "2025-09-01T11:14:32.046Z" },
     { url = "https://files.pythonhosted.org/packages/36/8b/fc61f87931bc030598e1876c45b936867bb72777eac693e905ab89832670/cryptography-45.0.7-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd342f085542f6eb894ca00ef70236ea46070c8a13824c6bde0dfdcd36065b9b", size = 4332186, upload-time = "2025-09-01T11:14:33.95Z" },
     { url = "https://files.pythonhosted.org/packages/0b/11/09700ddad7443ccb11d674efdbe9a832b4455dc1f16566d9bd3834922ce5/cryptography-45.0.7-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1993a1bb7e4eccfb922b6cd414f072e08ff5816702a0bdb8941c247a6b1b287c", size = 4561639, upload-time = "2025-09-01T11:14:35.343Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/8f4c1337e9d3b94d8e50ae0b08ad0304a5709d483bfcadfcc77a23dbcb52/cryptography-45.0.7-cp37-abi3-win32.whl", hash = "sha256:18fcf70f243fe07252dcb1b268a687f2358025ce32f9f88028ca5c364b123ef5", size = 2926552, upload-time = "2025-09-01T11:14:36.929Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/ff/026513ecad58dacd45d1d24ebe52b852165a26e287177de1d545325c0c25/cryptography-45.0.7-cp37-abi3-win_amd64.whl", hash = "sha256:7285a89df4900ed3bfaad5679b1e668cb4b38a8de1ccbfc84b05f34512da0a90", size = 3392742, upload-time = "2025-09-01T11:14:38.368Z" },
 ]
 
 [[package]]
@@ -534,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.13.1"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -543,15 +557,18 @@ dependencies = [
     { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
     { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/3c/82c400c2d50afdac4fbefb5b4031fd327e2ad1f23ccef8eee13c5909aa48/mcp-1.13.1.tar.gz", hash = "sha256:165306a8fd7991dc80334edd2de07798175a56461043b7ae907b279794a834c5", size = 438198, upload-time = "2025-08-22T09:22:16.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/3f/d085c7f49ade6d273b185d61ec9405e672b6433f710ea64a90135a8dd445/mcp-1.13.1-py3-none-any.whl", hash = "sha256:c314e7c8bd477a23ba3ef472ee5a32880316c42d03e06dcfa31a1cc7a73b65df", size = 161494, upload-time = "2025-08-22T09:22:14.705Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [package.optional-dependencies]
@@ -598,7 +615,7 @@ requires-dist = [
     { name = "gql", specifier = ">=3.4" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "keyring", specifier = ">=24.0.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.10.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28,<2" },
     { name = "monarchmoneycommunity", specifier = ">=1.4.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
@@ -957,6 +974,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New `serve` subcommand/run mode exposing the server over MCP streamable
  HTTP (in addition to the existing stdio mode — unaffected), authenticated
  with a static bearer token, so it can be deployed on a VPS/Raspberry
  Pi/Docker host and reached remotely behind a reverse proxy or tunnel.
- Docker packaging (`Dockerfile`, `docker-compose.yml`, `.dockerignore`)
  and a Cloudflare Tunnel example for running the server remotely.
- `mcp` upgraded to `>=1.28,<2` so streamable HTTP sessions are bound to
  their credentials (fixes a session-replay gap present in 1.13.1).
- Bearer token verification uses constant-time digest comparison and a
  global failure throttle to resist timing/brute-force attacks; the
  interactive login tools are only registered in stdio mode — credentials
  never flow through an LLM in serve mode.
- `login-cookies` / `login-password` non-interactive subcommands: seed a
  Monarch session from a browser Cookie header or email+password (with
  email-OTP/TOTP support) piped over stdin, for headless hosts where
  `login_setup.py`'s interactive prompts aren't available (e.g. `docker
  exec` from a CI runner). A supplied one-time code now rides the *first*
  login request — a bug where a no-code probe attempt would trigger a
  fresh OTP email and invalidate the code just supplied is fixed.
- `/` (root): an optional self-service copy-paste client-config page —
  Claude Code command, Claude Desktop config JSON, a ready-to-paste
  connector URL, and the raw bearer token. It has no auth of its own, so
  deployers should put it behind their own access control (reverse-proxy
  auth, an identity-aware proxy, etc.) if serving to more than themselves.
- `?token=` query-param bearer-token fallback: Claude's native "Add custom
  connector" UI (web/desktop/mobile) only accepts a URL, not a custom
  header, and leaving its OAuth fields blank triggers a full OAuth
  discovery/dynamic-registration flow this static-token resource server
  doesn't implement. Implemented as a small ASGI middleware wrapping
  FastMCP's app (checked only when no Authorization header is present, so
  an explicit header always wins) — the `mcp` SDK itself is untouched.

## Design docs included

- `docs/superpowers/specs/2026-07-08-remote-http-phase1a-design.md` —
  design spec (reviewed for security, SDK feasibility, and architecture)
- `docs/superpowers/plans/2026-07-08-remote-http-phase1a.md` —
  implementation plan

## Test plan

- [x] 281 tests passing: run-mode resolution, serve config, bearer token
  verifier, HTTP auth-boundary (real subprocess server, real HTTP),
  secure session, login-cookies/login-password (including the OTP-timing
  fix), the setup page, and the query-token middleware (unit + live-server
  integration).
- [x] `scripts/e2e_http.py` — end-to-end check against a running server
  using the real MCP client.
- [x] Manually verified against a real deployment: Docker Compose behind a
  reverse proxy/tunnel, live Monarch login, and the native-connector
  `?token=` flow all confirmed working end to end.