### PR TITLE
Cap mcp[cli] < 2.0.0 to prevent startup crash under mcp 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.12,<3.14"
 dependencies = [
-    "mcp[cli]>=1.10.0",
+    "mcp[cli]>=1.10.0,<2.0.0",
     "monarchmoneycommunity>=1.4.0",
     "gql>=3.4",
     "keyring>=24.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mcp[cli]>=1.10.0
+mcp[cli]>=1.10.0,<2.0.0
 monarchmoneycommunity>=1.4.0
 gql>=3.4
 keyring>=24.0.0

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12, <3.14"
 
 [[package]]
@@ -598,7 +598,7 @@ requires-dist = [
     { name = "gql", specifier = ">=3.4" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "keyring", specifier = ">=24.0.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.10.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.10.0,<2.0.0" },
     { name = "monarchmoneycommunity", specifier = ">=1.4.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },


### PR DESCRIPTION
## Problem

The server fails to start under Claude Desktop with:

```
File ".../src/monarch_mcp_server/app.py", line 5, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

The MCP Python SDK released **`mcp 2.0.0` on 2026-07-28**, which **removed the `mcp.server.fastmcp` module** (`app.py`, `auth.py`, and `tools/auth.py` all import from it).

`pyproject.toml`/`requirements.txt` pin `mcp[cli]>=1.10.0` with **no upper bound**. The documented Claude Desktop launch —

```
uv run --with mcp[cli] --with-editable <dir> mcp run .../server.py
```

— builds a fresh, unpinned environment and resolves `mcp` to the newest match (`2.0.0`), so the import crashes before the server can serve. Claude Desktop surfaces this as the server disconnecting.

## Fix

Cap `mcp[cli]>=1.10.0,<2.0.0` in `pyproject.toml` and `requirements.txt`, and refresh `uv.lock` (resolves to `mcp 1.13.1`, which still ships `mcp.server.fastmcp`).

## Verification

Reproduced the exact Claude Desktop launch path against this branch:

```
uv run --with 'mcp[cli]' --with-editable . python -c "import mcp.server.fastmcp; import monarch_mcp_server.server"
# resolved mcp: 1.13.1
# OK: server.py import chain loads, mcp.server.fastmcp present, cap holds
```

No `ModuleNotFoundError`. A proper migration to the mcp 2.0 API can follow separately; this restores startup in the meantime.