### PR TITLE
Fix delete_transaction_rule reporting successful deletions as failures

### DIFF
--- a/src/monarch_mcp_server/tools/rules.py
+++ b/src/monarch_mcp_server/tools/rules.py
@@ -421,19 +421,21 @@ async def delete_transaction_rule(rule_id: str) -> str:
             variables={"id": rule_id},
         )
 
-        # Monarch's deleteTransactionRule can return a payload where the
-        # `deleted` flag is absent/null even when the deletion succeeded, which
-        # previously produced a false "Unknown error". Treat an explicit errors
-        # payload (or deleted == False) as failure; otherwise the mutation was
-        # accepted and the rule is gone.
+        # Monarch's deleteTransactionRule returns an unreliable `deleted` flag:
+        # verified against the live API, it comes back `false` even when the rule
+        # was in fact removed (and it is sometimes absent entirely). Trusting it
+        # made every successful deletion report failure.
+        #
+        # A genuine failure does not arrive in this payload at all -- deleting a
+        # non-existent rule raises TransportQueryError ("Not found") from the
+        # GraphQL layer, which the except block below turns into an error result.
+        # So the only in-payload failure signal worth honouring is an explicit
+        # `errors` object.
         delete_result = result.get("deleteTransactionRule") or {}
 
         errors = delete_result.get("errors")
         if errors:
             return json_success({"success": False, "errors": errors})
-
-        if delete_result.get("deleted") is False:
-            return json_success({"success": False, "message": "Rule was not deleted"})
 
         return json_success({"success": True, "message": "Rule deleted successfully"})
     except Exception as e:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -365,3 +365,21 @@ class TestDeleteTransactionRule:
         data = json.loads(result)
         assert data["success"] is True
         assert "deleted" in data["message"].lower()
+
+    @patch('monarch_mcp_server.tools.rules.get_monarch_client')
+    async def test_delete_rule_success_with_false_deleted_flag(self, mock_get_client):
+        """Monarch returns `deleted: false` with no errors even when the rule
+        was successfully removed (verified against the live API). The flag must
+        not be treated as a failure signal, or every real deletion is reported
+        as having failed."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "deleteTransactionRule": {"deleted": False, "errors": None}
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await delete_transaction_rule(rule_id="rule_123")
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert "deleted" in data["message"].lower()


### PR DESCRIPTION
## Problem

`delete_transaction_rule` returns `{"success": false, "message": "Rule was not deleted"}` for deletions that actually succeed.

Monarch's `deleteTransactionRule` mutation returns `deleted: false` with no errors even when the rule *was* removed. The current guard treats that flag as authoritative:

```python
if delete_result.get("deleted") is False:
    return json_success({"success": False, "message": "Rule was not deleted"})
```

This is more than cosmetic — the tool reports a completed destructive operation as not having happened, which invites the caller to retry or to act on state they believe is still present.

## Verification against the live API

Deleted four real rules. Every call returned `deleted: false`; all four were genuinely gone, confirmed by re-querying the rule list (the IDs were absent) and by the total count dropping from 322 to 318.

Genuine failures never reach that branch. Deleting a non-existent rule raises `TransportQueryError` from the GraphQL layer:

```
gql.transport.exceptions.TransportQueryError:
{'message': 'Not found', 'path': ['deleteTransactionRule']}
```

which the surrounding `except Exception` already turns into an error result.

## Change

Drop the `deleted` check. The explicit `errors` payload check is left in place as the only trustworthy in-payload failure signal.

## Tests

`test_delete_rule_not_found` passed before and after because it mocks `deleted: false` *together with* an errors object, so the errors branch catches it first — the real-world shape was never covered.

Added `test_delete_rule_success_with_false_deleted_flag` for `deleted: false` + `errors: None`. It fails before this change and passes after. Full suite: 223 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTJGjJh4qNHBGWdZW3UDPo