### PR TITLE
Read browser cookie from a config file (fixes #82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,35 @@ Long-lived sessions, supports SSO accounts, and sidesteps Cloudflare CAPTCHA gat
 2. Open DevTools (F12) → Network tab.
 3. Click any request whose Name starts with `graphql` (or any request to `api.monarch.com`).
 4. Scroll to Request Headers, find the `cookie:` header, and copy the full value.
-5. Paste it into the prompt.
+5. Save it to the cookie file for your platform (recommended), then re-run the script — it reads the file automatically:
 
-The script verifies the cookies against the live API before saving them to your system keyring.
+   **macOS / Linux** — `~/.config/monarch-mcp/cookie.txt` (respects `$XDG_CONFIG_HOME`):
+
+   ```bash
+   mkdir -p ~/.config/monarch-mcp
+   # paste the cookie value into the file with your editor, then:
+   chmod 600 ~/.config/monarch-mcp/cookie.txt
+   ```
+
+   **Windows** — `%APPDATA%\monarch-mcp\cookie.txt`:
+
+   ```powershell
+   New-Item -ItemType Directory -Force "$env:APPDATA\monarch-mcp" | Out-Null
+   notepad "$env:APPDATA\monarch-mcp\cookie.txt"   # paste the cookie value, save, close
+   ```
+
+   Files under your user profile are already ACL-restricted to your account on Windows; no `chmod` equivalent is needed for typical single-user machines.
+
+   To use a different location on any platform, set the `MONARCH_MCP_COOKIE_FILE` environment variable to the full path.
+
+   Alternatively, paste the value at the interactive prompt — but note that
+   POSIX terminals silently truncate pasted input at the canonical-mode
+   buffer limit (`MAX_CANON`, 1024 bytes on macOS/Linux), and real Monarch
+   cookie headers are usually longer than that, so the prompt path fails
+   with a confusing auth error for most users. The cookie file has no
+   length limit and survives repo updates.
+
+The script verifies the cookies against the live API before saving them to your system keyring. The cookie file is only read at setup time; the running MCP server uses the keyring session.
 
 #### Option 2: Email and password
 

--- a/login_setup.py
+++ b/login_setup.py
@@ -14,6 +14,7 @@ Supports three auth paths in order of recommendation:
 
 import asyncio
 import getpass
+import os
 import sys
 from pathlib import Path
 
@@ -30,6 +31,52 @@ from monarch_mcp_server.monarch_auth import (
 from monarch_mcp_server.secure_session import secure_session
 
 
+def _default_cookie_file() -> Path:
+    """Resolve the cookie file path for the current platform.
+
+    Override with the MONARCH_MCP_COOKIE_FILE environment variable.
+    Defaults: %APPDATA%\\monarch-mcp\\cookie.txt on Windows,
+    $XDG_CONFIG_HOME/monarch-mcp/cookie.txt (or ~/.config/...) elsewhere.
+    """
+    override = os.environ.get("MONARCH_MCP_COOKIE_FILE")
+    if override:
+        return Path(override).expanduser()
+    if sys.platform == "win32":
+        base = os.environ.get("APPDATA")
+        base_path = Path(base) if base else Path.home() / "AppData" / "Roaming"
+    else:
+        xdg = os.environ.get("XDG_CONFIG_HOME")
+        base_path = Path(xdg) if xdg else Path.home() / ".config"
+    return base_path / "monarch-mcp" / "cookie.txt"
+
+
+COOKIE_FILE = _default_cookie_file()
+
+
+def _read_cookie_string() -> str:
+    """Return the browser cookie string for login.
+
+    Preferred source is COOKIE_FILE. On POSIX terminals, interactive
+    pastes via getpass()/input() are silently truncated at the tty's
+    canonical-mode input buffer (MAX_CANON, 1024 bytes on macOS/Linux),
+    and real Monarch cookie headers routinely exceed that, so pasting at
+    a prompt fails in a confusing way. The file path works identically on
+    Windows, macOS, and Linux and has no length limit.
+    """
+    if COOKIE_FILE.is_file():
+        cookie = COOKIE_FILE.read_text(encoding="utf-8").strip()
+        if cookie:
+            print(f"🔑 Using cookie from {COOKIE_FILE}")
+            return cookie
+    print(f"(No cookie file found at {COOKIE_FILE})")
+    print("⚠️  On macOS/Linux, terminal pastes longer than ~1024 chars are")
+    print("    silently truncated. If login fails below, save the cookie to")
+    print("    the file above and re-run this script (restrict permissions:")
+    print("    chmod 600 on macOS/Linux; on Windows the file inherits your")
+    print("    user-profile ACLs).")
+    return getpass.getpass("Paste the Cookie header value: ").strip()
+
+
 async def _login_with_cookies():
     print("\n📋 To copy the right cookie string:")
     print("  1. Log in to https://app.monarch.com in Chrome or Firefox")
@@ -38,8 +85,10 @@ async def _login_with_cookies():
     print("     (or any request to api.monarch.com)")
     print("  4. Scroll to 'Request Headers' and find the 'cookie:' header")
     print("  5. Copy the full value (a long string of key=value; pairs)")
+    print(f"  6. Save it to {COOKIE_FILE} (recommended),")
+    print("     or paste it at the prompt below")
     print()
-    cookie_string = getpass.getpass("Paste the Cookie header value: ").strip()
+    cookie_string = _read_cookie_string()
     if not cookie_string:
         print("❌ No cookie string provided. Exiting.")
         return None


### PR DESCRIPTION
Interactive pastes via getpass()/input() are silently truncated at the POSIX terminal's canonical-mode input buffer (MAX_CANON, 1024 bytes on macOS/Linux). Real Monarch cookie headers routinely exceed 1 KB, so the paste-at-prompt flow fails with a confusing auth error.

login_setup.py now reads the cookie from a platform-appropriate config file when present, falling back to the interactive prompt with a warning about the truncation limit:

  - macOS/Linux: ~/.config/monarch-mcp/cookie.txt (respects XDG_CONFIG_HOME)
  - Windows: %APPDATA%\monarch-mcp\cookie.txt
  - Any platform: override with MONARCH_MCP_COOKIE_FILE

README updated with per-platform setup instructions. Verified against the live API (get_accounts) on macOS; Windows path resolution covered by mocked-platform checks.