### PR TITLE
Add get_account_sync_health tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 
 ## 🛠️ Available Tools
 
-All 49 registered tools. Required parameters are listed first, optional ones
+All 50 registered tools. Required parameters are listed first, optional ones
 are marked with a trailing question mark. This table is generated from the
 live tool registry and the functions' signatures, so it does not drift.
 
@@ -295,6 +295,7 @@ live tool registry and the functions' signatures, so it does not drift.
 | `delete_transaction_rule` | Delete a transaction rule | `rule_id` |
 | `get_account_balance_history` | Get historical balance data for a specific account | `account_id` |
 | `get_account_holdings` | Get investment holdings for a specific account | `account_id` |
+| `get_account_sync_health` | Report the health of each linked institution connection | `stale_after_days`? |
 | `get_accounts` | Get all financial accounts from Monarch Money | None |
 | `get_budgets` | Get budget information from Monarch Money | `start_date`?, `end_date`? |
 | `get_cashflow` | Get cashflow analysis from Monarch Money | `start_date`?, `end_date`? |

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -77,6 +77,9 @@ from monarch_mcp_server.tools.financial import (  # noqa: F401
     get_net_worth,
     get_net_worth_by_account_type,
 )
+from monarch_mcp_server.tools.sync_health import (  # noqa: F401
+    get_account_sync_health,
+)
 from monarch_mcp_server.tools.merchants import (  # noqa: F401
     get_merchant,
     update_merchant,

--- a/src/monarch_mcp_server/tools/__init__.py
+++ b/src/monarch_mcp_server/tools/__init__.py
@@ -11,5 +11,6 @@ from monarch_mcp_server.tools import (  # noqa: F401
     categories,
     budgets,
     financial,
+    sync_health,
     merchants,
 )

--- a/src/monarch_mcp_server/tools/sync_health.py
+++ b/src/monarch_mcp_server/tools/sync_health.py
@@ -1,0 +1,137 @@
+"""Institution connection health tools."""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from gql import gql
+
+from monarch_mcp_server.app import mcp
+from monarch_mcp_server.client import get_monarch_client
+from monarch_mcp_server.helpers import json_success, json_error
+
+logger = logging.getLogger(__name__)
+
+# Monarch disables GraphQL introspection for non-admin users and masks unknown
+# field errors as a generic "Something went wrong", so this selection set was
+# established field-by-field against the live API. Fields confirmed absent (do
+# not re-add without re-testing): lastUpdateAttemptAt, dataProviderAccountId,
+# dataProviderId, status, errorType.
+GET_CREDENTIALS_QUERY = gql("""
+query GetCredentialSyncHealth {
+  credentials {
+    id
+    updateRequired
+    disconnectedFromDataProviderAt
+    syncDisabledAt
+    syncDisabledReason
+    dataProvider
+    displayLastUpdatedAt
+    institution {
+      id
+      name
+      url
+      __typename
+    }
+    accounts {
+      id
+      displayName
+      __typename
+    }
+    __typename
+  }
+}
+""")
+
+
+def _stale_days(timestamp: Optional[str]) -> Optional[int]:
+    """Whole days since *timestamp*, or None if it cannot be parsed."""
+    if not timestamp:
+        return None
+    try:
+        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - parsed).days
+
+
+@mcp.tool()
+async def get_account_sync_health(stale_after_days: int = 3) -> str:
+    """
+    Report the health of each linked institution connection.
+
+    A broken bank connection fails silently: Monarch keeps serving the last
+    balances it saw and simply stops importing new transactions, so budgets and
+    cashflow drift without any error surfacing. This surfaces connections that
+    need re-authentication, have been disconnected by the data provider, have
+    syncing disabled, or have simply gone stale.
+
+    Args:
+        stale_after_days: Flag a connection whose last successful update is at
+            least this many days old. Defaults to 3.
+
+    Returns:
+        JSON with a `needs_attention` list to act on and the full connection
+        list. `needs_attention` being empty means every institution is syncing.
+    """
+    try:
+        client = await get_monarch_client()
+        result = await client.gql_call(
+            operation="GetCredentialSyncHealth",
+            graphql_query=GET_CREDENTIALS_QUERY,
+            variables={},
+        )
+
+        connections: List[Dict[str, Any]] = []
+        for cred in result.get("credentials") or []:
+            institution = cred.get("institution") or {}
+            stale = _stale_days(cred.get("displayLastUpdatedAt"))
+
+            reasons = []
+            if cred.get("updateRequired"):
+                reasons.append("credentials need re-authentication")
+            if cred.get("disconnectedFromDataProviderAt"):
+                reasons.append("disconnected by the data provider")
+            if cred.get("syncDisabledAt"):
+                reasons.append(
+                    "syncing disabled"
+                    + (f": {cred['syncDisabledReason']}"
+                       if cred.get("syncDisabledReason") else "")
+                )
+            if stale is not None and stale >= stale_after_days:
+                reasons.append(f"no successful update in {stale} days")
+
+            connections.append({
+                "credential_id": cred.get("id"),
+                "institution": institution.get("name"),
+                "institution_url": institution.get("url"),
+                "data_provider": cred.get("dataProvider"),
+                "last_updated": cred.get("displayLastUpdatedAt"),
+                "stale_days": stale,
+                "update_required": bool(cred.get("updateRequired")),
+                "disconnected_at": cred.get("disconnectedFromDataProviderAt"),
+                "sync_disabled_at": cred.get("syncDisabledAt"),
+                "sync_disabled_reason": cred.get("syncDisabledReason"),
+                "needs_attention": bool(reasons),
+                "reasons": reasons,
+                "accounts": [
+                    a.get("displayName") for a in (cred.get("accounts") or [])
+                ],
+            })
+
+        broken = [c for c in connections if c["needs_attention"]]
+        return json_success({
+            "connection_count": len(connections),
+            "needs_attention_count": len(broken),
+            "note": (
+                "A failing connection does not raise an error anywhere in "
+                "Monarch -- it just stops importing transactions, so check "
+                "this before trusting recent spending or cashflow numbers."
+            ),
+            "needs_attention": broken,
+            "connections": connections,
+        })
+    except Exception as e:
+        return json_error("get_account_sync_health", e)

--- a/tests/test_sync_health.py
+++ b/tests/test_sync_health.py
@@ -1,0 +1,112 @@
+"""Tests for institution connection health tools."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+from monarch_mcp_server.tools.sync_health import get_account_sync_health
+
+
+def _iso(days_ago):
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+
+
+def _cred(**overrides):
+    cred = {
+        "id": "cred_1",
+        "updateRequired": False,
+        "disconnectedFromDataProviderAt": None,
+        "syncDisabledAt": None,
+        "syncDisabledReason": None,
+        "dataProvider": "PLAID",
+        "displayLastUpdatedAt": _iso(0),
+        "institution": {"id": "i1", "name": "Test Bank", "url": "https://x"},
+        "accounts": [{"id": "a1", "displayName": "Checking"}],
+    }
+    cred.update(overrides)
+    return cred
+
+
+def _client(creds):
+    c = AsyncMock()
+    c.gql_call.return_value = {"credentials": creds}
+    return c
+
+
+class TestGetAccountSyncHealth:
+    """Tests for get_account_sync_health tool."""
+
+    @patch('monarch_mcp_server.tools.sync_health.get_monarch_client')
+    async def test_healthy_connection(self, mock_get_client):
+        """A freshly-synced connection needs no attention."""
+        mock_get_client.return_value = _client([_cred()])
+
+        data = json.loads(await get_account_sync_health())
+
+        assert data["needs_attention_count"] == 0
+        assert data["connections"][0]["needs_attention"] is False
+
+    @patch('monarch_mcp_server.tools.sync_health.get_monarch_client')
+    async def test_update_required_flagged(self, mock_get_client):
+        """updateRequired means the login needs re-authentication."""
+        mock_get_client.return_value = _client([_cred(updateRequired=True)])
+
+        data = json.loads(await get_account_sync_health())
+
+        assert data["needs_attention_count"] == 1
+        assert "re-authentication" in data["needs_attention"][0]["reasons"][0]
+
+    @patch('monarch_mcp_server.tools.sync_health.get_monarch_client')
+    async def test_stale_connection_flagged(self, mock_get_client):
+        """A connection that simply stopped updating is the silent failure."""
+        mock_get_client.return_value = _client([_cred(displayLastUpdatedAt=_iso(9))])
+
+        data = json.loads(await get_account_sync_health())
+
+        conn = data["needs_attention"][0]
+        assert conn["stale_days"] >= 9
+        assert "no successful update" in conn["reasons"][0]
+
+    @patch('monarch_mcp_server.tools.sync_health.get_monarch_client')
+    async def test_stale_threshold_is_configurable(self, mock_get_client):
+        """A 9-day-old sync is fine if the caller allows 30 days."""
+        mock_get_client.return_value = _client([_cred(displayLastUpdatedAt=_iso(9))])
+
+        data = json.loads(await get_account_sync_health(stale_after_days=30))
+
+        assert data["needs_attention_count"] == 0
+
+    @patch('monarch_mcp_server.tools.sync_health.get_monarch_client')
+    async def test_multiple_reasons_accumulate(self, mock_get_client):
+        """Every failure mode is reported, not just the first."""
+        mock_get_client.return_value = _client([_cred(
+            updateRequired=True,
+            syncDisabledAt=_iso(1), syncDisabledReason="user disabled",
+            displayLastUpdatedAt=_iso(40),
+        )])
+
+        reasons = json.loads(await get_account_sync_health())["needs_attention"][0]["reasons"]
+
+        assert len(reasons) == 3
+        assert any("user disabled" in r for r in reasons)
+
+    @patch('monarch_mcp_server.tools.sync_health.get_monarch_client')
+    async def test_unparseable_timestamp_is_not_fatal(self, mock_get_client):
+        """A bad timestamp yields stale_days=None rather than raising."""
+        mock_get_client.return_value = _client([_cred(displayLastUpdatedAt="nonsense")])
+
+        data = json.loads(await get_account_sync_health())
+
+        assert data["connections"][0]["stale_days"] is None
+
+    @patch('monarch_mcp_server.tools.sync_health.get_monarch_client')
+    async def test_error_handling(self, mock_get_client):
+        """Transport failures are reported as tool errors."""
+        c = AsyncMock()
+        c.gql_call.side_effect = Exception("boom")
+        mock_get_client.return_value = c
+
+        data = json.loads(await get_account_sync_health())
+
+        assert data["error"] is True
+        assert data["tool"] == "get_account_sync_health"


### PR DESCRIPTION
## Why

A broken institution connection **fails silently**. Monarch keeps serving the last balances it saw and simply stops importing transactions, so budgets, cashflow and spending summaries drift without any error surfacing — including through this MCP server, whose existing tools all return happily against stale data.

Nothing currently exposes the `credentials` root query, so a client has no way to tell whether the numbers it is reading are current. An agent asked "how much did I spend last week?" will confidently answer from a feed that stopped updating.

## What it does

Read-only `get_account_sync_health`, reporting per institution:

- `update_required` — the login needs re-authentication
- `disconnected_at` — the data provider dropped the connection
- `sync_disabled_at` / `sync_disabled_reason`
- `stale_days` — days since the last successful update

Results are split into `needs_attention` and the full `connections` list, so the common case is a single field check.

`stale_after_days` is a parameter rather than a constant because a daily Plaid connection and a slow pension provider have very different normal cadences.

## Found on a real account

An MX-backed connection sitting at `updateRequired: true` and **six days stale**, while seven other institutions were current — exactly the case that stays invisible until you go looking for it.

## Notes for reviewers

- Monarch disables GraphQL introspection for non-admin users and masks unknown-field errors as a generic `"Something went wrong"`, so the selection set was established field-by-field against the live API. Fields verified *absent* are listed in a comment above the query so they aren't speculatively re-added: `lastUpdateAttemptAt`, `dataProviderAccountId`, `dataProviderId`, `status`, `errorType`.
- An unparseable `displayLastUpdatedAt` yields `stale_days: None` rather than raising, so one malformed timestamp can't take down the whole report.

## Verification

Exercised against a real account (8 connections, 1 unhealthy) plus 7 unit tests covering each failure mode, threshold configurability, and the unparseable-timestamp path. `229 passed` — full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)