### PR TITLE
Add reorder_transaction_rule tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 
 ## 🛠️ Available Tools
 
-All 49 registered tools. Required parameters are listed first, optional ones
+All 50 registered tools. Required parameters are listed first, optional ones
 are marked with a trailing question mark. This table is generated from the
 live tool registry and the functions' signatures, so it does not drift.
 
@@ -319,6 +319,7 @@ live tool registry and the functions' signatures, so it does not drift.
 | `monarch_login_with_token` | Sign in with a browser copied session token | None |
 | `monarch_logout` | Clear the stored session and drop the cached client | None |
 | `refresh_accounts` | Request account data refresh from financial institutions | `account_ids`? |
+| `reorder_transaction_rule` | Move a transaction rule to a new position in the evaluation order | `rule_id`, `new_order` |
 | `review_recurring_stream` | Set the review status of a recurring transaction stream | `stream_id`, `review_status` |
 | `search_transactions` | Search and filter transactions with comprehensive filtering options | `search`?, `limit`?, `offset`?, `start_date`?, `end_date`?, `category_ids`?, `account_ids`?, `tag_ids`?, `has_attachments`?, `has_notes`?, `hidden_from_reports`?, `is_split`?, `is_recurring`? |
 | `set_budget_amount` | Set or update a budget amount for a category or category group | `amount`, `category_id`?, `category_group_id`?, `start_date`?, `apply_to_future`? |
@@ -533,7 +534,7 @@ tool that is not there.
 }
 ```
 
-This leaves 25 of the 49 tools available, covering everything that reads.
+This leaves 25 of the 50 tools available, covering everything that reads.
 Read only is off by default, so existing setups are unaffected. Note that it
 also removes the login and logout tools, since those change durable state, so
 authenticate with `login_setup.py` before enabling it.
@@ -546,7 +547,7 @@ These tools mutate your Monarch data. The list is every registered tool that wri
 
 **Tags**: `set_transaction_tags`, `add_transaction_tag`, `create_transaction_tag`
 
-**Rules**: `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`
+**Rules**: `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`, `reorder_transaction_rule`
 
 **Categories and budgets**: `create_transaction_category`, `update_category`, `set_budget_amount`
 

--- a/src/monarch_mcp_server/read_only.py
+++ b/src/monarch_mcp_server/read_only.py
@@ -44,6 +44,7 @@ MUTATING_TOOLS: FrozenSet[str] = frozenset(
         "create_transaction_rule",
         "update_transaction_rule",
         "delete_transaction_rule",
+        "reorder_transaction_rule",
         # Categories and budgets
         "create_transaction_category",
         "update_category",

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -56,6 +56,7 @@ from monarch_mcp_server.tools.tags import (  # noqa: F401
 )
 from monarch_mcp_server.tools.rules import (  # noqa: F401
     get_transaction_rules,
+    reorder_transaction_rule,
     create_transaction_rule,
     update_transaction_rule,
     delete_transaction_rule,

--- a/src/monarch_mcp_server/tools/rules.py
+++ b/src/monarch_mcp_server/tools/rules.py
@@ -870,3 +870,77 @@ async def delete_transaction_rule(rule_id: str) -> str:
     except Exception as e:
         return json_error("delete_transaction_rule", e)
 
+
+REORDER_RULE_MUTATION = gql("""
+mutation Web_UpdateRuleOrderMutation($id: ID!, $order: Int!) {
+  updateTransactionRuleOrderV2(id: $id, order: $order) {
+    transactionRules {
+      id
+      order
+      __typename
+    }
+    __typename
+  }
+}
+""")
+
+
+@mcp.tool()
+async def reorder_transaction_rule(rule_id: str, new_order: int) -> str:
+    """
+    Move a transaction rule to a new position in the evaluation order.
+
+    Order is not cosmetic. Every matching rule runs, in order, and a later rule
+    overwrites an earlier one, so position decides which rule wins when two
+    match the same transaction.
+
+    Monarch renumbers the other rules automatically; the full resulting order
+    is returned so the caller can confirm the outcome.
+
+    Args:
+        rule_id: Rule to move (see get_transaction_rules).
+        new_order: Zero-based target position. 0 runs first.
+    """
+    try:
+        if new_order < 0:
+            return json_success({
+                "success": False, "message": "new_order must be 0 or greater",
+            })
+        client = await get_monarch_client()
+
+        current = await client.gql_call(
+            operation="GetTransactionRules",
+            graphql_query=GET_TRANSACTION_RULES_QUERY,
+            variables={},
+        )
+        existing = next(
+            (r for r in current.get("transactionRules") or []
+             if r.get("id") == rule_id),
+            None,
+        )
+        if existing is None:
+            return json_success({
+                "success": False,
+                "message": f"No transaction rule found with id {rule_id}",
+            })
+
+        result = await client.gql_call(
+            operation="Web_UpdateRuleOrderMutation",
+            graphql_query=REORDER_RULE_MUTATION,
+            variables={"id": rule_id, "order": new_order},
+        )
+        payload = result.get("updateTransactionRuleOrderV2") or {}
+        rules = payload.get("transactionRules") or []
+
+        return json_success({
+            "success": True,
+            "rule_id": rule_id,
+            "moved_from": existing.get("order"),
+            "moved_to": new_order,
+            "order": [
+                {"rule_id": r.get("id"), "order": r.get("order")}
+                for r in sorted(rules, key=lambda r: r.get("order") or 0)
+            ],
+        })
+    except Exception as e:
+        return json_error("reorder_transaction_rule", e)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 from monarch_mcp_server.tools.rules import (
     get_transaction_rules,
+    reorder_transaction_rule,
     create_transaction_rule,
     update_transaction_rule,
     delete_transaction_rule,
@@ -797,3 +798,49 @@ class TestAmountCriterionIsNeverSilentlyDropped:
             )
         )
         assert result["success"] is True
+
+
+class TestReorderTransactionRule:
+    """Tests for reorder_transaction_rule tool."""
+
+    @patch('monarch_mcp_server.tools.rules.get_monarch_client')
+    async def test_reorder_success(self, mock_get_client):
+        """Moving a rule returns the resulting order of every rule."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.side_effect = [
+            {"transactionRules": [{"id": "rule_1", "order": 3}]},
+            {"updateTransactionRuleOrderV2": {"transactionRules": [
+                {"id": "rule_1", "order": 0}, {"id": "rule_2", "order": 1},
+            ]}},
+        ]
+        mock_get_client.return_value = mock_client
+
+        data = json.loads(await reorder_transaction_rule("rule_1", 0))
+
+        assert data["success"] is True
+        assert data["moved_from"] == 3
+        assert data["moved_to"] == 0
+        assert data["order"][0] == {"rule_id": "rule_1", "order": 0}
+
+    @patch('monarch_mcp_server.tools.rules.get_monarch_client')
+    async def test_reorder_unknown_rule(self, mock_get_client):
+        """An unknown id fails before the mutation is sent."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {"transactionRules": []}
+        mock_get_client.return_value = mock_client
+
+        data = json.loads(await reorder_transaction_rule("missing", 0))
+
+        assert data["success"] is False
+        assert mock_client.gql_call.call_count == 1
+
+    @patch('monarch_mcp_server.tools.rules.get_monarch_client')
+    async def test_negative_order_rejected(self, mock_get_client):
+        """A negative position is rejected without any API call."""
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        data = json.loads(await reorder_transaction_rule("rule_1", -1))
+
+        assert data["success"] is False
+        mock_client.gql_call.assert_not_called()


### PR DESCRIPTION
## Why

Rule order is not cosmetic. Every matching rule runs **in order**, and a later rule **overwrites** an earlier one — so position decides which rule wins when two rules match the same transaction. There was previously no way to change it from this server.

## Why it needs its own mutation

`UpdateTransactionRuleInput` rejects an `order` field (verified). Monarch uses a dedicated mutation:

```graphql
updateTransactionRuleOrderV2(id: ID!, order: Int!)
```

Note it takes **scalar arguments**, not an input object — which is why guessing at an `UpdateTransactionRuleOrderInput` type finds nothing. It returns the full renumbered rule list.

## Behaviour

- Verifies the rule exists first, so a bad id fails without sending the mutation.
- Rejects a negative position without any API call.
- Returns `moved_from` / `moved_to` plus the resulting order of every rule, so the caller can confirm the outcome instead of re-querying.

## Verification

3 unit tests (success, unknown id, negative order). `225 passed` — full suite. Exercised against a live account using throwaway rules, confirming the swap took effect and that the surrounding real rules were renumbered by Monarch and restored on cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)