### PR TITLE
Add get_debt_paydown tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 
 ## 🛠️ Available Tools
 
-All 49 registered tools. Required parameters are listed first, optional ones
+All 50 registered tools. Required parameters are listed first, optional ones
 are marked with a trailing question mark. This table is generated from the
 live tool registry and the functions' signatures, so it does not drift.
 
@@ -300,6 +300,7 @@ live tool registry and the functions' signatures, so it does not drift.
 | `get_cashflow` | Get cashflow analysis from Monarch Money | `start_date`?, `end_date`? |
 | `get_cashflow_by_month` | Get spending trends over time, broken down by category and month | `start_date`, `end_date` |
 | `get_category_details` | Get a single category's details including budget amounts for a month | `category_id`, `month`? |
+| `get_debt_paydown` | Get the debt paydown plan and the accounts feeding it | `method`? |
 | `get_merchant` | Get a merchant's details including recurring transaction stream configuration | `merchant_id` |
 | `get_net_worth` | Get net worth history over time | `start_date`?, `end_date`?, `account_type`? |
 | `get_net_worth_by_account_type` | Get net worth breakdown by account type over time | `start_date`, `timeframe`? |

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -77,6 +77,9 @@ from monarch_mcp_server.tools.financial import (  # noqa: F401
     get_net_worth,
     get_net_worth_by_account_type,
 )
+from monarch_mcp_server.tools.debt import (  # noqa: F401
+    get_debt_paydown,
+)
 from monarch_mcp_server.tools.merchants import (  # noqa: F401
     get_merchant,
     update_merchant,

--- a/src/monarch_mcp_server/tools/__init__.py
+++ b/src/monarch_mcp_server/tools/__init__.py
@@ -11,5 +11,6 @@ from monarch_mcp_server.tools import (  # noqa: F401
     categories,
     budgets,
     financial,
+    debt,
     merchants,
 )

--- a/src/monarch_mcp_server/tools/debt.py
+++ b/src/monarch_mcp_server/tools/debt.py
@@ -1,0 +1,130 @@
+"""Debt paydown tools."""
+
+import logging
+from typing import Any, Dict
+
+from gql import gql
+
+from monarch_mcp_server.app import mcp
+from monarch_mcp_server.client import get_monarch_client
+from monarch_mcp_server.helpers import json_success, json_error
+
+logger = logging.getLogger(__name__)
+
+# Debt paydown is not a goal. Monarch's legacy goal system had a "debt" goal
+# type, but the migration to savingsGoals dropped it -- a legacy debt goal
+# comes back from legacyGoalsMigrationData with newGoalId null -- and replaced
+# it with a plan computed over the debt accounts themselves.
+GET_DEBT_PAYDOWN_QUERY = gql("""
+query GetDebtPaydown($input: SavingsCalculatorInput!) {
+  debtAccounts {
+    id
+    displayName
+    displayBalance
+    apr
+    interestRate
+    minimumPayment
+    plannedPayment
+    excludeFromDebtPaydown
+    __typename
+  }
+  debtPaydownPlan(input: $input) {
+    currentDebtPrincipal
+    projectedInterest
+    projectedTotal
+    debtFreeDate
+    adjustedDebtFreeDate
+    adjustedProjectedInterest
+    adjustedProjectedTotal
+    debtAccountProjections {
+      account {
+        id
+        displayName
+        __typename
+      }
+      principal
+      projectedInterest
+      projectedTotal
+      debtFreeDate
+      __typename
+    }
+    __typename
+  }
+}
+""")
+
+
+@mcp.tool()
+async def get_debt_paydown(method: str = "planned") -> str:
+    """
+    Get the debt paydown plan and the accounts feeding it.
+
+    Reports every debt account with its APR, minimum and planned payment, and
+    whether it is excluded from the plan, alongside the projected interest and
+    debt-free date.
+
+    Excluded accounts are called out separately. Excluding a high-APR account
+    quietly shrinks the plan's principal, so the projected debt-free date can
+    look better than reality while the most expensive balance is untouched.
+
+    Args:
+        method: Paydown strategy. "planned" uses the payments configured on
+            each account; Monarch also models avalanche/snowball orderings.
+
+    Returns:
+        JSON with the plan, per-account projections, and any excluded accounts.
+    """
+    try:
+        client = await get_monarch_client()
+        result = await client.gql_call(
+            operation="GetDebtPaydown",
+            graphql_query=GET_DEBT_PAYDOWN_QUERY,
+            variables={"input": {"debtPaydownMethod": method}},
+        )
+
+        accounts = result.get("debtAccounts") or []
+        plan: Dict[str, Any] = result.get("debtPaydownPlan") or {}
+
+        included, excluded = [], []
+        for a in accounts:
+            row = {
+                "account_id": a.get("id"),
+                "name": a.get("displayName"),
+                "balance": a.get("displayBalance"),
+                "apr": a.get("apr"),
+                "minimum_payment": a.get("minimumPayment"),
+                "planned_payment": a.get("plannedPayment"),
+            }
+            (excluded if a.get("excludeFromDebtPaydown") else included).append(row)
+
+        total = sum(a.get("displayBalance") or 0 for a in accounts)
+        excluded_total = sum(r["balance"] or 0 for r in excluded)
+
+        return json_success({
+            "method": method,
+            "total_debt_across_accounts": round(total, 2),
+            "debt_in_plan": plan.get("currentDebtPrincipal"),
+            "debt_excluded_from_plan": round(excluded_total, 2),
+            "projected_interest": plan.get("projectedInterest"),
+            "projected_total": plan.get("projectedTotal"),
+            "debt_free_date": plan.get("debtFreeDate"),
+            "adjusted_debt_free_date": plan.get("adjustedDebtFreeDate"),
+            "excluded_accounts": excluded,
+            "included_accounts": included,
+            "projections": [
+                {
+                    "name": (p.get("account") or {}).get("displayName"),
+                    "principal": p.get("principal"),
+                    "projected_interest": p.get("projectedInterest"),
+                    "debt_free_date": p.get("debtFreeDate"),
+                }
+                for p in (plan.get("debtAccountProjections") or [])
+            ],
+            "note": (
+                "Excluded accounts are not in the plan's principal, interest or "
+                "debt-free date. If a high-APR card is excluded, the projection "
+                "understates both the cost and the payoff time."
+            ),
+        })
+    except Exception as e:
+        return json_error("get_debt_paydown", e)

--- a/tests/test_debt.py
+++ b/tests/test_debt.py
@@ -1,0 +1,82 @@
+"""Tests for debt paydown tools."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from monarch_mcp_server.tools.debt import get_debt_paydown
+
+
+def _acct(**o):
+    a = {"id": "a1", "displayName": "Card", "displayBalance": 1000.0, "apr": 20.0,
+         "interestRate": None, "minimumPayment": 25.0, "plannedPayment": 0.0,
+         "excludeFromDebtPaydown": False}
+    a.update(o)
+    return a
+
+
+def _client(accounts, plan=None):
+    c = AsyncMock()
+    c.gql_call.return_value = {
+        "debtAccounts": accounts,
+        "debtPaydownPlan": plan or {
+            "currentDebtPrincipal": 1000.0, "projectedInterest": 100.0,
+            "projectedTotal": 1100.0, "debtFreeDate": "2028-01-01",
+            "adjustedDebtFreeDate": None, "debtAccountProjections": [],
+        },
+    }
+    return c
+
+
+class TestGetDebtPaydown:
+    """Tests for get_debt_paydown tool."""
+
+    @patch('monarch_mcp_server.tools.debt.get_monarch_client')
+    async def test_reports_plan(self, mock_get_client):
+        mock_get_client.return_value = _client([_acct()])
+
+        data = json.loads(await get_debt_paydown())
+
+        assert data["debt_free_date"] == "2028-01-01"
+        assert data["excluded_accounts"] == []
+        assert data["included_accounts"][0]["apr"] == 20.0
+
+    @patch('monarch_mcp_server.tools.debt.get_monarch_client')
+    async def test_excluded_accounts_are_separated_and_totalled(self, mock_get_client):
+        """An excluded high-APR balance must be visible, not folded into the plan.
+
+        The plan's principal covers only included accounts, so without this the
+        projection silently understates both cost and payoff time.
+        """
+        mock_get_client.return_value = _client([
+            _acct(),
+            _acct(id="a2", displayName="High APR", displayBalance=500.0,
+                  apr=29.5, excludeFromDebtPaydown=True),
+        ])
+
+        data = json.loads(await get_debt_paydown())
+
+        assert data["total_debt_across_accounts"] == 1500.0
+        assert data["debt_in_plan"] == 1000.0
+        assert data["debt_excluded_from_plan"] == 500.0
+        assert data["excluded_accounts"][0]["name"] == "High APR"
+
+    @patch('monarch_mcp_server.tools.debt.get_monarch_client')
+    async def test_method_is_passed_through(self, mock_get_client):
+        client = _client([_acct()])
+        mock_get_client.return_value = client
+
+        await get_debt_paydown(method="avalanche")
+
+        sent = client.gql_call.call_args.kwargs["variables"]["input"]
+        assert sent["debtPaydownMethod"] == "avalanche"
+
+    @patch('monarch_mcp_server.tools.debt.get_monarch_client')
+    async def test_error_handling(self, mock_get_client):
+        c = AsyncMock()
+        c.gql_call.side_effect = Exception("boom")
+        mock_get_client.return_value = c
+
+        data = json.loads(await get_debt_paydown())
+
+        assert data["error"] is True
+        assert data["tool"] == "get_debt_paydown"


### PR DESCRIPTION
## Why

**Debt paydown is not a goal**, which is easy to get wrong. Monarch's legacy goal system had a `debt` goal type, but the migration to `savingsGoals` **dropped it** — a legacy debt goal comes back from `legacyGoalsMigrationData` with `newGoalId: null` — and replaced it with a plan computed over the debt accounts themselves.

So a client reading only `savingsGoals` sees the user's savings targets and **silently misses their debt entirely**.

## What it does

Read-only `get_debt_paydown`, reporting every debt account (APR, minimum payment, planned payment) alongside the plan's projected interest, projected total and debt-free date.

## The part worth reviewing

Accounts flagged `excludeFromDebtPaydown` are reported **separately**, with the excluded balance totalled against the plan's principal.

This matters because `debtPaydownPlan.currentDebtPrincipal` only covers *included* accounts. Excluding a high-APR card makes the projected debt-free date and total interest look better while the most expensive balance goes untouched — a projection that is technically correct and practically misleading. Surfacing `debt_in_plan` next to `total_debt_across_accounts` and `debt_excluded_from_plan` makes that visible without the caller having to know the trap exists.

On the account this was developed against, three of four cards were excluded — including every card with an APR higher than the single card left in the plan.

## Verification

4 unit tests (plan reporting, excluded-account separation and totalling, method pass-through, error handling). `226 passed` — full suite. Exercised against a live account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)