### PR TITLE
Add monarch_whoami tool with plan-gated capability detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 
 ## 🛠️ Available Tools
 
-All 49 registered tools. Required parameters are listed first, optional ones
+All 50 registered tools. Required parameters are listed first, optional ones
 are marked with a trailing question mark. This table is generated from the
 live tool registry and the functions' signatures, so it does not drift.
 
@@ -318,6 +318,7 @@ live tool registry and the functions' signatures, so it does not drift.
 | `monarch_login` | Sign in via a secure form in the client UI | None |
 | `monarch_login_with_token` | Sign in with a browser copied session token | None |
 | `monarch_logout` | Clear the stored session and drop the cached client | None |
+| `monarch_whoami` | Report who is signed in and what the account's plan entitles it to | None |
 | `refresh_accounts` | Request account data refresh from financial institutions | `account_ids`? |
 | `review_recurring_stream` | Set the review status of a recurring transaction stream | `stream_id`, `review_status` |
 | `search_transactions` | Search and filter transactions with comprehensive filtering options | `search`?, `limit`?, `offset`?, `start_date`?, `end_date`?, `category_ids`?, `account_ids`?, `tag_ids`?, `has_attachments`?, `has_notes`?, `hidden_from_reports`?, `is_split`?, `is_recurring`? |

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -19,6 +19,9 @@ from monarch_mcp_server.tools.auth import (  # noqa: F401
     monarch_login_with_token,
     monarch_logout,
 )
+from monarch_mcp_server.tools.identity import (  # noqa: F401
+    monarch_whoami,
+)
 from monarch_mcp_server.tools.accounts import (  # noqa: F401
     get_accounts,
     refresh_accounts,

--- a/src/monarch_mcp_server/tools/__init__.py
+++ b/src/monarch_mcp_server/tools/__init__.py
@@ -2,6 +2,7 @@
 
 from monarch_mcp_server.tools import (  # noqa: F401
     auth,
+    identity,
     accounts,
     transactions,
     summaries,

--- a/src/monarch_mcp_server/tools/identity.py
+++ b/src/monarch_mcp_server/tools/identity.py
@@ -1,0 +1,167 @@
+"""Account identity and subscription tools."""
+
+import logging
+from typing import Any, Dict, List
+
+from gql import gql
+
+from monarch_mcp_server.app import mcp
+from monarch_mcp_server.client import get_monarch_client
+from monarch_mcp_server.helpers import json_success, json_error
+
+logger = logging.getLogger(__name__)
+
+# Monarch disables GraphQL introspection for non-admin users and masks unknown
+# field errors as a generic "Something went wrong", so this selection set was
+# established field-by-field against the live API. Fields confirmed absent:
+# me.household, me.attributionData, subscription.currentPlan,
+# subscription.isEligibleForTrial, subscription.activePromoCode.
+#
+# Deliberately not selected: me.birthday and me.profilePictureUrl. They are
+# personal data an agent has no use for, and this tool's output tends to end up
+# in transcripts.
+WHOAMI_QUERY = gql("""
+query GetWhoAmI {
+  me {
+    id
+    name
+    email
+    timezone
+    hasPassword
+    externalAuthProviderNames
+    __typename
+  }
+  subscription {
+    id
+    entitlements
+    hasPremiumEntitlement
+    isOnFreeTrial
+    billingPeriod
+    currentPeriodEndsAt
+    trialEndsAt
+    willCancelAtPeriodEnd
+    paymentSource
+    nextPaymentAmount
+    __typename
+  }
+}
+""")
+
+
+# Plan-gated features, probed rather than inferred.
+#
+# Deriving availability from entitlement names would be guesswork: the names
+# are not documented and the mapping is not visible from a single account. So
+# each capability is a cheap query that either succeeds or does not, which is
+# the same signal the caller would get by trying to use the feature.
+#
+# To gate another feature, add an entry: the operation name, a probe query, and
+# the root field to read the result from. Keep the probe minimal -- it runs on
+# every whoami call. The operation name is stored rather than read off the
+# parsed query, because gql returns different objects across versions.
+CAPABILITY_PROBES = {
+    "business_entities": (
+        "ProbeBusinessEntities",
+        gql("query ProbeBusinessEntities { businessEntities { id name color } }"),
+        "businessEntities",
+    ),
+}
+
+
+def _trial_entitlements(entitlements: List[str]) -> List[str]:
+    """Entitlements granted by a trial, which will lapse."""
+    return [e for e in entitlements if e.endswith("_trial")]
+
+
+async def _probe_capabilities(client) -> Dict[str, Any]:
+    """Run each capability probe, treating any failure as 'not available'.
+
+    A gated feature is usually absent from the schema entirely rather than
+    returning an empty list, and Monarch masks that as a generic error, so the
+    exception IS the answer here. A probe must never fail the whole tool.
+    """
+    capabilities: Dict[str, Any] = {}
+    for name, (operation, query, root) in CAPABILITY_PROBES.items():
+        try:
+            result = await client.gql_call(
+                operation=operation, graphql_query=query, variables={},
+            )
+            items = result.get(root) or []
+            capabilities[name] = {"available": True, "items": items}
+        except Exception:
+            logger.info("Capability %s unavailable on this account", name)
+            capabilities[name] = {"available": False, "items": []}
+    return capabilities
+
+
+@mcp.tool()
+async def monarch_whoami() -> str:
+    """
+    Report who is signed in and what the account's plan entitles it to.
+
+    Use this before assuming a feature exists. Parts of Monarch's schema are
+    plan-gated: business entities in particular are absent entirely on lower
+    tiers, so a transaction rule's business-entity fields simply will not be
+    there. Their absence is normal, not an error.
+
+    `capabilities` answers that directly. Each entry is probed against the live
+    schema rather than inferred from the plan name, and carries the objects the
+    feature needs -- so `capabilities.business_entities.items` is also where a
+    business-entity id comes from when setting one on a rule.
+
+    `timezone` is worth reading before doing any date arithmetic, since
+    Monarch's dates are rendered in the account's zone.
+
+    Returns:
+        JSON with the signed-in user, the subscription, and an `entitlements`
+        list. Entitlements ending in `_trial` are temporary -- a feature
+        available today may disappear when the trial ends.
+    """
+    try:
+        client = await get_monarch_client()
+        result = await client.gql_call(
+            operation="GetWhoAmI", graphql_query=WHOAMI_QUERY, variables={}
+        )
+
+        capabilities = await _probe_capabilities(client)
+
+        me: Dict[str, Any] = result.get("me") or {}
+        sub: Dict[str, Any] = result.get("subscription") or {}
+        entitlements = sub.get("entitlements") or []
+        trial_only = _trial_entitlements(entitlements)
+
+        return json_success({
+            "user": {
+                "id": me.get("id"),
+                "name": me.get("name"),
+                "email": me.get("email"),
+                "timezone": me.get("timezone"),
+                "has_password": me.get("hasPassword"),
+                "external_auth_providers": me.get("externalAuthProviderNames") or [],
+            },
+            "subscription": {
+                "entitlements": entitlements,
+                "has_premium": sub.get("hasPremiumEntitlement"),
+                "on_free_trial": sub.get("isOnFreeTrial"),
+                "billing_period": sub.get("billingPeriod"),
+                "current_period_ends_at": sub.get("currentPeriodEndsAt"),
+                "trial_ends_at": sub.get("trialEndsAt"),
+                "will_cancel_at_period_end": sub.get("willCancelAtPeriodEnd"),
+                "payment_source": sub.get("paymentSource"),
+                "next_payment_amount": sub.get("nextPaymentAmount"),
+            },
+            "trial_entitlements": trial_only,
+            "capabilities": capabilities,
+            "note": (
+                "Monarch's schema is plan-gated. Treat a missing field -- "
+                "business entities especially -- as this account not having "
+                "that feature, not as a failure."
+                + (
+                    f" Entitlements {trial_only} come from a trial and will "
+                    "lapse, taking their fields with them."
+                    if trial_only else ""
+                )
+            ),
+        })
+    except Exception as e:
+        return json_error("monarch_whoami", e)

--- a/src/monarch_mcp_server/tools/identity.py
+++ b/src/monarch_mcp_server/tools/identity.py
@@ -20,6 +20,18 @@ logger = logging.getLogger(__name__)
 # Deliberately not selected: me.birthday and me.profilePictureUrl. They are
 # personal data an agent has no use for, and this tool's output tends to end up
 # in transcripts.
+#
+# The remaining `me` fields are broader than check_auth_status (which only
+# echoes the MONARCH_EMAIL env var and whether a session exists), and that is
+# deliberate rather than an oversight: this tool's whole purpose is answering
+# "who is signed in", so name/email are the substance of the answer, not
+# incidental exposure. `has_password` and `external_auth_providers` are
+# non-financial account metadata with a real diagnostic use -- distinguishing
+# an SSO-only account from one that also has a password, which matters when
+# choosing a login path in login_setup.py. `id` is Monarch's internal user id,
+# not a secret and not derivable from anything sensitive; nothing downstream in
+# this codebase consumes it today, so it is included only in case a caller
+# needs a stable identifier, not because a feature requires it.
 WHOAMI_QUERY = gql("""
 query GetWhoAmI {
   me {

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,126 @@
+"""Tests for account identity tools."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from monarch_mcp_server.tools.identity import monarch_whoami
+
+
+def _payload(**sub_overrides):
+    sub = {
+        "id": "sub_1",
+        "entitlements": ["premium"],
+        "hasPremiumEntitlement": True,
+        "isOnFreeTrial": False,
+        "billingPeriod": "YEARLY",
+        "currentPeriodEndsAt": "2026-09-10T00:28:55+00:00",
+        "trialEndsAt": None,
+        "willCancelAtPeriodEnd": False,
+        "paymentSource": "STRIPE",
+        "nextPaymentAmount": 144.01,
+    }
+    sub.update(sub_overrides)
+    return {
+        "me": {
+            "id": "u1", "name": "Test User", "email": "t@example.com",
+            "timezone": "America/Chicago", "hasPassword": True,
+            "externalAuthProviderNames": ["google"],
+        },
+        "subscription": sub,
+    }
+
+
+def _client(payload, entities=None, entities_fail=False):
+    """First call is whoami; the second is the business-entity probe."""
+    c = AsyncMock()
+
+    async def side_effect(*a, **kw):
+        if kw.get("operation") == "GetWhoAmI":
+            return payload
+        if entities_fail:
+            raise Exception("Something went wrong")
+        return {"businessEntities": entities or []}
+
+    c.gql_call.side_effect = side_effect
+    return c
+
+
+class TestMonarchWhoami:
+    """Tests for monarch_whoami tool."""
+
+    @patch('monarch_mcp_server.tools.identity.get_monarch_client')
+    async def test_reports_user_and_subscription(self, mock_get_client):
+        mock_get_client.return_value = _client(_payload())
+
+        data = json.loads(await monarch_whoami())
+
+        assert data["user"]["timezone"] == "America/Chicago"
+        assert data["subscription"]["billing_period"] == "YEARLY"
+
+    @patch('monarch_mcp_server.tools.identity.get_monarch_client')
+    async def test_business_entities_available(self, mock_get_client):
+        """A working probe reports the feature and the ids it needs."""
+        mock_get_client.return_value = _client(
+            _payload(), entities=[{"id": "b1", "name": "Acme", "color": "#fff"}])
+
+        caps = json.loads(await monarch_whoami())["capabilities"]
+
+        assert caps["business_entities"]["available"] is True
+        assert caps["business_entities"]["items"][0]["id"] == "b1"
+
+    @patch('monarch_mcp_server.tools.identity.get_monarch_client')
+    async def test_business_entities_gated_off(self, mock_get_client):
+        """On a plan without the feature the probe errors; that IS the answer.
+
+        Monarch removes gated fields from the schema and masks the failure as a
+        generic error, so an exception must be reported as 'not available'
+        rather than failing the whole tool.
+        """
+        mock_get_client.return_value = _client(_payload(), entities_fail=True)
+
+        data = json.loads(await monarch_whoami())
+
+        assert data.get("error") is None
+        assert data["capabilities"]["business_entities"]["available"] is False
+        assert data["capabilities"]["business_entities"]["items"] == []
+
+    @patch('monarch_mcp_server.tools.identity.get_monarch_client')
+    async def test_trial_entitlements_flagged(self, mock_get_client):
+        """A trial-granted feature can disappear, so it is called out."""
+        mock_get_client.return_value = _client(
+            _payload(entitlements=["premium", "premium_plus_trial"]))
+
+        data = json.loads(await monarch_whoami())
+
+        assert data["trial_entitlements"] == ["premium_plus_trial"]
+        assert "lapse" in data["note"]
+
+    @patch('monarch_mcp_server.tools.identity.get_monarch_client')
+    async def test_no_trial_entitlements_no_warning(self, mock_get_client):
+        mock_get_client.return_value = _client(_payload())
+
+        data = json.loads(await monarch_whoami())
+
+        assert data["trial_entitlements"] == []
+        assert "lapse" not in data["note"]
+
+    @patch('monarch_mcp_server.tools.identity.get_monarch_client')
+    async def test_pii_is_not_returned(self, mock_get_client):
+        """birthday and profile picture are deliberately not selected."""
+        mock_get_client.return_value = _client(_payload())
+
+        blob = await monarch_whoami()
+
+        assert "birthday" not in blob
+        assert "profilePictureUrl" not in blob
+
+    @patch('monarch_mcp_server.tools.identity.get_monarch_client')
+    async def test_error_handling(self, mock_get_client):
+        c = AsyncMock()
+        c.gql_call.side_effect = Exception("boom")
+        mock_get_client.return_value = c
+
+        data = json.loads(await monarch_whoami())
+
+        assert data["error"] is True
+        assert data["tool"] == "monarch_whoami"


### PR DESCRIPTION
## Why

Parts of Monarch's schema are **plan-gated**. Business entities are the clearest case: on a lower tier the fields are absent entirely, so a transaction rule's business-entity fields simply are not there.

Nothing exposed which tier the signed-in account is on, so a client had no way to distinguish *"this account doesn't have that feature"* from *"something went wrong"* — and no way to find a business-entity id when the feature does exist.

## Capabilities are probed, not inferred

The obvious implementation maps entitlement names to features. I did not do that, because it would be guesswork: the names are undocumented, and the mapping is not visible from a single account. This one carries `["premium", "premium_plus_trial"]` and has business entities — not enough to conclude which entitlement grants them.

Instead each capability is a cheap query that either succeeds or does not, which is the same signal the caller would get by trying to use the feature. **A probe that raises is reported as unavailable and never fails the tool** — Monarch masks a missing field as a generic error, so the exception *is* the answer.

`CAPABILITY_PROBES` is a table, so other gated features can be added as contributors confirm them:

```python
CAPABILITY_PROBES = {
    "business_entities": (
        "ProbeBusinessEntities",
        gql("query ProbeBusinessEntities { businessEntities { id name color } }"),
        "businessEntities",
    ),
}
```

Each entry carries the objects the feature needs, so `capabilities.business_entities.items` is also where a business-entity id comes from when setting one on a rule.

## Trial entitlements

Entitlements ending in `_trial` are surfaced separately. A feature available today can **disappear when the trial ends**, taking its schema fields with it — worth knowing before building a rule that depends on one.

## Privacy

`me.birthday` and `me.profilePictureUrl` are deliberately not selected. They are personal data an agent has no use for, and this tool's output tends to end up in transcripts. There is a test asserting they don't appear.

## Verification

7 unit tests, including the gated-off path (probe raises → `available: false`, tool still succeeds) and the PII assertion. `229 passed` — full suite. Exercised against a live account with the feature present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)