### PR TITLE
Surface Monarch's Flexible budget bucket in get_budgets, with a safe fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 - **Split Transaction**: Divide a single transaction into multiple parts with different categories or merchants
 
 ### 💵 Budget Management
-- **Get Budgets**: Access budget information including spent amounts and remaining balances by category, plus the all-up **Flexible** bucket and per-month fixed/flexible/non-monthly totals
+- **Get Budgets**: Budget information by category (including rollover and set-aside), the all-up **Flexible** bucket, category-group roll-ups, savings-goal contributions, the account's budget system, and per-month income / expense / fixed / flexible / non-monthly totals
 - **Set Budget Amount**: Create or modify budget amounts for any category or category group
 - **Set Flexible Budget**: Set the bucket-level Flexible amount used by Monarch's "fixed_and_flex" budget system
 - **Update Flex Rollover Settings**: Start a fresh Flex rollover period, for buckets that have accumulated a large negative rollover
@@ -261,7 +261,7 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 | `check_auth_status` | Check authentication status | None |
 | `get_accounts` | Get all financial accounts | None |
 | `get_transactions` | Get transactions with filtering and reconciliation fields | `limit`, `offset`, `start_date`, `end_date`, `account_id`, `account_ids`, `category_ids`, `category_group_ids`, `tag_ids`, `search`, `wide_search`, `search_scan_limit`, `has_notes`, `is_split`, `is_recurring` |
-| `get_budgets` | Get budget information, including the Flexible bucket | `start_date`, `end_date` |
+| `get_budgets` | Get budget information, including the Flexible bucket | `start_date`, `end_date` (pass both or neither) |
 | `set_budget_amount` | Set budget for a category | `amount`, `category_id`, `category_group_id`, `start_date`, `apply_to_future` |
 | `set_flexible_budget` | Set the all-up Flexible bucket amount | `amount`, `start_date`, `apply_to_future` |
 | `update_flex_rollover_settings` | Start a new Flex rollover period (**discards accumulated rollover**) | `rollover_start_month`, `rollover_starting_balance`, `rollover_enabled` |
@@ -331,11 +331,29 @@ Use get_budgets to show my current budget status
 - `not_configured` — the account has no Flexible bucket (e.g. it is not on flex budgeting)
 - `unsupported` — Monarch rejected the extended fields, so the narrower fallback query ran
 
-A status other than `ok` means **no amount is available — it does not mean zero**. When it is `unsupported`, `groups`, `goals`, `totals`, `budget_system` and each row's `rollover` / `budget_variability` are all `null` for the same reason.
+A status other than `ok` means **no amount is available — it does not mean zero**. When it is `unsupported`, `groups`, `goals`, `totals`, `budget_system` and each row's `rollover` / `rollover_type` / `budget_variability` are all `null` for the same reason.
 
 For `groups`, `goals` and `totals`, `null` means "could not be fetched" while `[]` means "asked, and there were none".
 
-Per-row, `planned - actual` equals `remaining` only when `rollover` is zero; for rollover categories the carried balance accounts for the difference. In `groups`, add a group's `planned` to its categories' totals only when `group_level_budgeting` is false — when true the group holds the budget itself.
+Per-row, `planned - actual` equals `remaining` only when `rollover` is zero; for rollover categories the carried balance accounts for the difference.
+
+**Never add a group's `planned` to its categories' `planned`** — that double-counts either way. `group_level_budgeting` tells you which level holds the real budget: when `true` the group does and its categories carry none; when `false` the group row is only the roll-up of those same categories.
+
+Full response shape:
+
+| Key | Contents |
+|---|---|
+| `tool`, `args` | echo of the call |
+| `budget_system` | e.g. `"fixed_and_flex"`, or `null` |
+| `data[]` | `id`, `name`, `planned`, `actual`, `remaining`, `set_aside`, `rollover`, `rollover_type`, `category_group`, `category_type`, `budget_variability`, `month` |
+| `flex` | `status`, `budget_variability`, `monthly[]` (`month`, `planned`, `actual`, `remaining`, `rollover`, `rollover_type`) |
+| `groups[]` | `id`, `name`, `planned`, `actual`, `remaining`, `rollover`, `rollover_type`, `category_type`, `group_level_budgeting`, `month` |
+| `goals[]` | `id`, `name`, `priority`, `archived`, `completed`, `planned_contributions[]`, `actual_contributions[]` |
+| `totals[]` | `month`, plus `income` / `expenses` / `flexible` / `fixed` / `non_monthly`, each `planned`, `actual`, `remaining`, `rollover` |
+
+Goal contributions are a **separate** quantity from a category's `set_aside`; adding them together double-counts.
+
+`start_date` and `end_date` must be passed **together or not at all** — supplying only one is rejected rather than filled in, because completing the missing side from today can invert the range and return an empty result that reads as "no budget".
 
 ### Set the Flexible Bucket Amount
 ```

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Use get_budgets to show my current budget status
 **Two things that will produce wrong numbers if ignored:**
 
 1. **Income and expense amounts are both positive magnitudes.** The sign does not distinguish them — negatives appear only for contra entries. Summing `planned` across all `data` rows adds income to spending. Filter on `category_type` (`income` / `expense` / `transfer`) first.
-2. **Under flex budgeting most category rows carry no standalone budget.** Rows whose `budget_variability` is `flexible` are pooled into the single Flexible bucket, so their individual `planned` values are typically 0 and the real number lives in `flex`. On a representative account 57 of 86 rows were pooled this way; summing the rows gave `7,901` against a true planned expense total of `11,885`.
+2. **Under flex budgeting most category rows carry no standalone budget.** Rows whose `budget_variability` is `flexible` are pooled into the single Flexible bucket, so their individual `planned` values are typically 0 and the real number lives in `flex`. On a flex-budgeting account the majority of rows are usually pooled this way, so adding up the category rows understates planned spending by the whole size of the Flexible bucket. Compare against `totals[].expenses` rather than trusting a row sum.
 
 `flex.status` is one of:
 
@@ -357,7 +357,7 @@ Goal contributions are a **separate** quantity from a category's `set_aside`; ad
 
 ### Set the Flexible Bucket Amount
 ```
-Set my flexible budget to $4,000 for this month using set_flexible_budget
+Set my flexible budget to $1,500 for this month using set_flexible_budget
 ```
 
 ### Set a Budget Amount

--- a/README.md
+++ b/README.md
@@ -318,15 +318,24 @@ Show me my last 50 transactions using get_transactions with limit 50
 Use get_budgets to show my current budget status
 ```
 
-`get_budgets` returns a JSON object with `data` (one row per category per month), `flex`, and `totals`. On Monarch's "fixed_and_flex" budget system the Flexible section carries a **single amount covering every category beneath it**, and that number lives in `flex`, not in the per-category rows — comparing spending against the category rows alone will understate the Flexible budget.
+`get_budgets` returns a JSON object with `budget_system`, `data` (one row per category per month), `flex`, `groups`, `goals` and `totals`.
+
+**Two things that will produce wrong numbers if ignored:**
+
+1. **Income and expense amounts are both positive magnitudes.** The sign does not distinguish them — negatives appear only for contra entries. Summing `planned` across all `data` rows adds income to spending. Filter on `category_type` (`income` / `expense` / `transfer`) first.
+2. **Under flex budgeting most category rows carry no standalone budget.** Rows whose `budget_variability` is `flexible` are pooled into the single Flexible bucket, so their individual `planned` values are typically 0 and the real number lives in `flex`. On a representative account 57 of 86 rows were pooled this way; summing the rows gave `7,901` against a true planned expense total of `11,885`.
 
 `flex.status` is one of:
 
 - `ok` — a Flexible bucket amount was returned
 - `not_configured` — the account has no Flexible bucket (e.g. it is not on flex budgeting)
-- `unsupported` — Monarch rejected the flex fields, so the narrower fallback query ran
+- `unsupported` — Monarch rejected the extended fields, so the narrower fallback query ran
 
-A status other than `ok` means **no amount is available — it does not mean zero**. `totals` carries per-month `flexible` / `fixed` / `non_monthly` totals, or `null` when unavailable.
+A status other than `ok` means **no amount is available — it does not mean zero**. When it is `unsupported`, `groups`, `goals`, `totals`, `budget_system` and each row's `rollover` / `budget_variability` are all `null` for the same reason.
+
+For `groups`, `goals` and `totals`, `null` means "could not be fetched" while `[]` means "asked, and there were none".
+
+Per-row, `planned - actual` equals `remaining` only when `rollover` is zero; for rollover categories the carried balance accounts for the difference. In `groups`, add a group's `planned` to its categories' totals only when `group_level_budgeting` is false — when true the group holds the budget itself.
 
 ### Set the Flexible Bucket Amount
 ```
@@ -497,7 +506,9 @@ monarch-mcp-server/
 
 ### Recommended: require approval for mutating tools
 
-Several tools mutate your Monarch ledger (`create_transaction`, `update_transaction`, `delete_transaction`, `bulk_categorize_transactions`, `upload_account_balance_history`, `set_transaction_tags`, `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`, `split_transaction`, `set_budget_amount`, `set_flexible_budget`, `update_flex_rollover_settings`, `update_merchant`, `review_recurring_stream`).
+Several tools mutate your Monarch ledger (`create_transaction`, `update_transaction`, `delete_transaction`, `bulk_categorize_transactions`, `upload_account_balance_history`, `set_transaction_tags`, `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`, `split_transaction`, `set_budget_amount`, `set_flexible_budget`, `update_flex_rollover_settings`, `update_merchant`, `review_recurring_stream`, `categorize_transaction`, `update_transaction_notes`, `mark_transaction_reviewed`, `add_transaction_tag`, `create_transaction_tag`, `create_transaction_category`, `update_category`).
+
+Note `update_category` also carries rollover-reset arguments (`rollover_start_month`, `rollover_starting_balance`), so it can discard a category's accumulated rollover — see issue #107.
 
 `update_flex_rollover_settings` deserves particular care: it discards the Flex bucket's accumulated rollover balance and starts a fresh period. Its two destructive arguments are deliberately required rather than defaulted, so it cannot be invoked as a no-argument "reset", but it should still be approved manually every time.
 

--- a/README.md
+++ b/README.md
@@ -230,8 +230,9 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 - **Split Transaction**: Divide a single transaction into multiple parts with different categories or merchants
 
 ### 💵 Budget Management
-- **Get Budgets**: Access budget information including spent amounts and remaining balances by category
+- **Get Budgets**: Access budget information including spent amounts and remaining balances by category, plus the all-up **Flexible** bucket and per-month fixed/flexible/non-monthly totals
 - **Set Budget Amount**: Create or modify budget amounts for any category or category group
+- **Set Flexible Budget**: Set the bucket-level Flexible amount used by Monarch's "fixed_and_flex" budget system
 
 ### 📈 Net Worth Tracking
 - **Get Net Worth**: Track total net worth over time with daily snapshots and trend analysis
@@ -259,8 +260,9 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 | `check_auth_status` | Check authentication status | None |
 | `get_accounts` | Get all financial accounts | None |
 | `get_transactions` | Get transactions with filtering and reconciliation fields | `limit`, `offset`, `start_date`, `end_date`, `account_id`, `account_ids`, `category_ids`, `category_group_ids`, `tag_ids`, `search`, `wide_search`, `search_scan_limit`, `has_notes`, `is_split`, `is_recurring` |
-| `get_budgets` | Get budget information | `start_date`, `end_date` |
+| `get_budgets` | Get budget information, including the Flexible bucket | `start_date`, `end_date` |
 | `set_budget_amount` | Set budget for a category | `amount`, `category_id`, `category_group_id`, `start_date`, `apply_to_future` |
+| `set_flexible_budget` | Set the all-up Flexible bucket amount | `amount`, `start_date`, `apply_to_future` |
 | `get_cashflow` | Get cashflow analysis | `start_date`, `end_date` |
 | `get_net_worth` | Get net worth history | `start_date`, `end_date`, `account_type` |
 | `get_account_balance_history` | Get account balance history | `account_id` |
@@ -312,6 +314,21 @@ Show me my last 50 transactions using get_transactions with limit 50
 ### Check Spending vs Budget
 ```
 Use get_budgets to show my current budget status
+```
+
+`get_budgets` returns a JSON object with `data` (one row per category per month), `flex`, and `totals`. On Monarch's "fixed_and_flex" budget system the Flexible section carries a **single amount covering every category beneath it**, and that number lives in `flex`, not in the per-category rows — comparing spending against the category rows alone will understate the Flexible budget.
+
+`flex.status` is one of:
+
+- `ok` — a Flexible bucket amount was returned
+- `not_configured` — the account has no Flexible bucket (e.g. it is not on flex budgeting)
+- `unsupported` — Monarch rejected the flex fields, so the narrower fallback query ran
+
+A status other than `ok` means **no amount is available — it does not mean zero**. `totals` carries per-month `flexible` / `fixed` / `non_monthly` totals, or `null` when unavailable.
+
+### Set the Flexible Bucket Amount
+```
+Set my flexible budget to $4,000 for this month using set_flexible_budget
 ```
 
 ### Set a Budget Amount
@@ -478,7 +495,7 @@ monarch-mcp-server/
 
 ### Recommended: require approval for mutating tools
 
-Several tools mutate your Monarch ledger (`create_transaction`, `update_transaction`, `delete_transaction`, `bulk_categorize_transactions`, `upload_account_balance_history`, `set_transaction_tags`, `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`, `split_transaction`, `set_budget_amount`, `update_merchant`, `review_recurring_stream`).
+Several tools mutate your Monarch ledger (`create_transaction`, `update_transaction`, `delete_transaction`, `bulk_categorize_transactions`, `upload_account_balance_history`, `set_transaction_tags`, `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`, `split_transaction`, `set_budget_amount`, `set_flexible_budget`, `update_merchant`, `review_recurring_stream`).
 
 Because the LLM can be influenced by data it reads back (a malicious-looking memo or merchant name in a transaction), the safest setup is to configure your MCP client to require manual approval before any mutating tool runs. In Claude Desktop and Claude Code this is the default behavior for unknown tools; keep it that way for the tools listed above rather than allow-listing them.
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 - **Get Budgets**: Access budget information including spent amounts and remaining balances by category, plus the all-up **Flexible** bucket and per-month fixed/flexible/non-monthly totals
 - **Set Budget Amount**: Create or modify budget amounts for any category or category group
 - **Set Flexible Budget**: Set the bucket-level Flexible amount used by Monarch's "fixed_and_flex" budget system
+- **Update Flex Rollover Settings**: Start a fresh Flex rollover period, for buckets that have accumulated a large negative rollover
 
 ### 📈 Net Worth Tracking
 - **Get Net Worth**: Track total net worth over time with daily snapshots and trend analysis
@@ -263,6 +264,7 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 | `get_budgets` | Get budget information, including the Flexible bucket | `start_date`, `end_date` |
 | `set_budget_amount` | Set budget for a category | `amount`, `category_id`, `category_group_id`, `start_date`, `apply_to_future` |
 | `set_flexible_budget` | Set the all-up Flexible bucket amount | `amount`, `start_date`, `apply_to_future` |
+| `update_flex_rollover_settings` | Start a new Flex rollover period (**discards accumulated rollover**) | `rollover_start_month`, `rollover_starting_balance`, `rollover_enabled` |
 | `get_cashflow` | Get cashflow analysis | `start_date`, `end_date` |
 | `get_net_worth` | Get net worth history | `start_date`, `end_date`, `account_type` |
 | `get_account_balance_history` | Get account balance history | `account_id` |
@@ -495,7 +497,9 @@ monarch-mcp-server/
 
 ### Recommended: require approval for mutating tools
 
-Several tools mutate your Monarch ledger (`create_transaction`, `update_transaction`, `delete_transaction`, `bulk_categorize_transactions`, `upload_account_balance_history`, `set_transaction_tags`, `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`, `split_transaction`, `set_budget_amount`, `set_flexible_budget`, `update_merchant`, `review_recurring_stream`).
+Several tools mutate your Monarch ledger (`create_transaction`, `update_transaction`, `delete_transaction`, `bulk_categorize_transactions`, `upload_account_balance_history`, `set_transaction_tags`, `create_transaction_rule`, `update_transaction_rule`, `delete_transaction_rule`, `split_transaction`, `set_budget_amount`, `set_flexible_budget`, `update_flex_rollover_settings`, `update_merchant`, `review_recurring_stream`).
+
+`update_flex_rollover_settings` deserves particular care: it discards the Flex bucket's accumulated rollover balance and starts a fresh period. Its two destructive arguments are deliberately required rather than defaulted, so it cannot be invoked as a no-argument "reset", but it should still be approved manually every time.
 
 Because the LLM can be influenced by data it reads back (a malicious-looking memo or merchant name in a transaction), the safest setup is to configure your MCP client to require manual approval before any mutating tool runs. In Claude Desktop and Claude Code this is the default behavior for unknown tools; keep it that way for the tools listed above rather than allow-listing them.
 

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -71,6 +71,7 @@ from monarch_mcp_server.tools.categories import (  # noqa: F401
 from monarch_mcp_server.tools.budgets import (  # noqa: F401
     get_budgets,
     set_budget_amount,
+    set_flexible_budget,
 )
 from monarch_mcp_server.tools.financial import (  # noqa: F401
     get_cashflow,

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -72,6 +72,7 @@ from monarch_mcp_server.tools.budgets import (  # noqa: F401
     get_budgets,
     set_budget_amount,
     set_flexible_budget,
+    update_flex_rollover_settings,
 )
 from monarch_mcp_server.tools.financial import (  # noqa: F401
     get_cashflow,

--- a/src/monarch_mcp_server/tools/budgets.py
+++ b/src/monarch_mcp_server/tools/budgets.py
@@ -657,3 +657,75 @@ async def set_flexible_budget(
         })
     except Exception as e:
         return json_error("set_flexible_budget", e)
+
+
+@mcp.tool()
+async def update_flex_rollover_settings(
+    rollover_start_month: str,
+    rollover_starting_balance: float,
+    rollover_enabled: bool = True,
+) -> str:
+    """
+    Start a new Flex bucket rollover period.
+
+    DESTRUCTIVE: this DISCARDS the rollover balance accumulated so far and
+    begins a fresh period. Its main use is fixing a Flex bucket that has built
+    up a large negative rollover over many months. Confirm with the user before
+    calling, and report the current rollover (get_budgets -> flex.monthly[].
+    rollover) so they know what is being discarded.
+
+    Both amounts are required on purpose -- the underlying client defaults to a
+    starting balance of 0 for the current month, i.e. a silent full reset, so
+    this tool makes the caller state the intent explicitly.
+
+    Args:
+        rollover_start_month: First month of the new period, YYYY-MM-DD
+            (use the first of the month, e.g. "2026-08-01")
+        rollover_starting_balance: Balance to seed the new period with. Pass 0
+            to clear accumulated rollover entirely.
+        rollover_enabled: Whether flex rollover stays enabled (default True)
+
+    Returns:
+        Result of the update, including the new rollover period.
+    """
+    try:
+        if _flex_supported is False:
+            return json_success({
+                "success": False,
+                "error": (
+                    "This account does not appear to support Monarch's flexible "
+                    "budget bucket -- the API rejected the flex fields on an "
+                    "earlier get_budgets call."
+                ),
+            })
+
+        client = await get_monarch_client()
+
+        updater = getattr(client, "update_flex_rollover_settings", None)
+        if updater is None:
+            return json_success({
+                "success": False,
+                "error": (
+                    "The installed monarchmoney client has no "
+                    "update_flex_rollover_settings(); upgrade "
+                    "monarchmoneycommunity."
+                ),
+            })
+
+        result = await updater(
+            rollover_start_month=rollover_start_month,
+            rollover_starting_balance=rollover_starting_balance,
+            rollover_enabled=rollover_enabled,
+        )
+
+        return json_success({
+            "success": True,
+            "message": (
+                f"Flex rollover period restarted at {rollover_start_month} with "
+                f"a starting balance of ${rollover_starting_balance:.2f}"
+                + ("" if rollover_enabled else " (rollover disabled)")
+            ),
+            "result": result,
+        })
+    except Exception as e:
+        return json_error("update_flex_rollover_settings", e)

--- a/src/monarch_mcp_server/tools/budgets.py
+++ b/src/monarch_mcp_server/tools/budgets.py
@@ -50,16 +50,35 @@ _BUDGET_DOCUMENT = """
       categoryGroups {
         id
         name
-        type
+        type%(group_extra)s
         categories {
           id
-          name
+          name%(category_field_extra)s
           __typename
         }
         __typename
       }%(root_extra)s
     }
 """
+
+# Extended-only additions to the categoryGroups subtree.
+#
+# This is the subtree the original narrowing was about, so these go in the
+# extended document only and the fallback keeps the proven selection. Both are
+# already queried successfully elsewhere in this server (tools/categories.py),
+# so "the current API rejects them" does not hold at these levels.
+#
+# - groupLevelBudgetingEnabled: without it, a group row cannot be told apart
+#   from a roll-up of its categories, and a caller that adds data[].planned to
+#   groups[].planned double-counts.
+# - categories.budgetVariability: under fixed_and_flex this is the only way to
+#   know which per-category rows sit inside the pooled Flexible bucket, i.e.
+#   which `planned` values are not standalone budgets.
+_GROUP_EXTRA = """
+        groupLevelBudgetingEnabled"""
+
+_CATEGORY_FIELD_EXTRA = """
+          budgetVariability"""
 
 # Per-category rollover. Without these, planned - actual does not equal
 # remaining for any category with rollover enabled, and the difference is
@@ -74,11 +93,13 @@ _CATEGORY_EXTRA = """
 # - budgetSystem: which system the account uses ("fixed_and_flex" or otherwise).
 #   Lets a caller tell "this account does not do flex budgeting" from "the flex
 #   bucket is empty" without inferring it.
-# - goalsV2: goal contributions are part of the monthly plan and are what
-#   plannedSetAsideAmount refers to, so a budget answer that ignores them
-#   understates what is spoken for. Upstream guards this with
-#   @include(if: $useV2Goals); requested unconditionally here since the whole
-#   document already falls back if Monarch refuses any of it.
+# - goalsV2: goal contributions are part of the monthly plan, so a budget
+#   answer that ignores them understates what is spoken for. They are a
+#   SEPARATE quantity from a category's plannedSetAsideAmount -- goals carry
+#   their own plannedContributions, and adding the two together double-counts.
+#   Upstream guards this with @include(if: $useV2Goals); requested
+#   unconditionally here since the whole document already falls back if
+#   Monarch refuses any of it.
 _ROOT_EXTRA = """
       budgetSystem
       goalsV2 {
@@ -187,12 +208,17 @@ _EXTENDED_SELECTIONS = """
           __typename
         }"""
 
+BUDGET_QUERY_OPERATION = "MCPBudgetData"
+BUDGET_QUERY_FLEX_OPERATION = "MCPBudgetDataFlex"
+
 BUDGET_QUERY = gql(
     _BUDGET_DOCUMENT
     % {
-        "operation": "MCPBudgetData",
+        "operation": BUDGET_QUERY_OPERATION,
         "flex_selections": "",
         "category_extra": "",
+        "group_extra": "",
+        "category_field_extra": "",
         "root_extra": "",
     }
 )
@@ -201,36 +227,41 @@ BUDGET_QUERY = gql(
 BUDGET_QUERY_FLEX = gql(
     _BUDGET_DOCUMENT
     % {
-        "operation": "MCPBudgetDataFlex",
+        "operation": BUDGET_QUERY_FLEX_OPERATION,
         "flex_selections": _EXTENDED_SELECTIONS,
         "category_extra": _CATEGORY_EXTRA,
+        "group_extra": _GROUP_EXTRA,
+        "category_field_extra": _CATEGORY_FIELD_EXTRA,
         "root_extra": _ROOT_EXTRA,
     }
 )
 
-# Cached for the life of the process: None = not yet probed, True = the flex
-# fields work, False = this account rejects them so don't pay the failed
-# round-trip again.
-_flex_supported: Optional[bool] = None
-
-# Supplementary text match. Monarch does not return standard GraphQL validation
-# wording -- a rejected field comes back as a generic "Something went wrong
-# while processing" -- so exception *type* is the primary signal and these are
-# only a backstop for transports that do surface the usual messages.
+# Supplementary text match, for transports that surface standard GraphQL
+# validation wording. Monarch itself does not -- a rejected field comes back as
+# a generic "Something went wrong while processing" -- so exception *type* is
+# the primary signal.
+#
+# Deliberately excludes "did you mean" and "validation error": those match
+# CPython's own AttributeError/NameError suggestion text and pydantic's
+# ValidationError respectively, so a local programming error would be
+# misread as "this account has no flex bucket".
 _SCHEMA_REJECTION_MARKERS = (
     "cannot query field",
     "unknown field",
     "no field named",
     "unknown argument",
-    "did you mean",
-    "validation error",
 )
 
 
-def reset_flex_support() -> None:
-    """Clear the cached flex-support result. Intended for tests."""
-    global _flex_supported
-    _flex_supported = None
+def _safe_text(exc: Exception) -> str:
+    """``str(exc)``, but never raising -- some exceptions fail to stringify.
+
+    Classifying a failure must not itself become the failure the caller sees.
+    """
+    try:
+        return str(exc)
+    except Exception:  # pragma: no cover - pathological __str__
+        return type(exc).__name__
 
 
 def _is_query_rejection(exc: Exception) -> bool:
@@ -243,8 +274,9 @@ def _is_query_rejection(exc: Exception) -> bool:
     """
     if TransportQueryError and isinstance(exc, TransportQueryError):
         return True
-    text = str(exc).lower()
-    return any(marker in text for marker in _SCHEMA_REJECTION_MARKERS)
+    return any(
+        marker in _safe_text(exc).lower() for marker in _SCHEMA_REJECTION_MARKERS
+    )
 
 
 def current_month_range() -> tuple[str, str]:
@@ -261,11 +293,29 @@ async def get_budget_data(
 ) -> Tuple[Dict[str, Any], bool]:
     """Fetch budget data, preferring the query that includes flex bucket totals.
 
-    Returns ``(raw_response, used_flex_query)``. When Monarch rejects the flex
-    selections this falls back to :data:`BUDGET_QUERY`, so accounts that do not
-    support them behave exactly as they did before.
+    Returns ``(raw_response, used_flex_query)``. When Monarch rejects the
+    extended selections this falls back to :data:`BUDGET_QUERY`, so accounts
+    that do not support them behave exactly as they did before.
+
+    The result is deliberately **not** cached. An earlier version latched
+    "unsupported" for the life of the process to save a round-trip, but gql
+    raises ``TransportQueryError`` for *any* response carrying a GraphQL
+    ``errors`` array -- a rate limit, a resolver hiccup, a partial success --
+    so one transient error would permanently strip flex, groups, goals, totals
+    and rollover from every later call, and tell the user their account does
+    not support flex when it does. Two concurrent calls could also race and
+    clobber a known-good probe. The cost of re-probing is one extra round-trip
+    per call on accounts that genuinely lack the fields; the cost of a sticky
+    wrong answer is silently wrong financial output, so it is not a close call.
     """
-    global _flex_supported
+    if (start_date is None) != (end_date is None):
+        # Filling only one side from the current month can invert the range
+        # (start 2026-12-01, end 2026-08-31), which returns nothing and reads
+        # as "this account has no budget".
+        raise ValueError(
+            "start_date and end_date must be given together, or both omitted "
+            "to default to the current month."
+        )
 
     default_start, default_end = current_month_range()
     variables = {
@@ -273,63 +323,68 @@ async def get_budget_data(
         "endDate": end_date or default_end,
     }
 
-    rejection: Optional[Exception] = None
+    try:
+        data = await client.gql_call(
+            operation=BUDGET_QUERY_FLEX_OPERATION,
+            graphql_query=BUDGET_QUERY_FLEX,
+            variables=variables,
+        )
+        return data, True
+    except Exception as exc:
+        if not _is_query_rejection(exc):
+            raise
+        logger.warning(
+            "Monarch refused the extended budget fields; retrying with the "
+            "narrow query: %s",
+            _safe_text(exc),
+        )
 
-    if _flex_supported is not False:
-        try:
-            data = await client.gql_call(
-                operation="MCPBudgetDataFlex",
-                graphql_query=BUDGET_QUERY_FLEX,
-                variables=variables,
-            )
-            _flex_supported = True
-            return data, True
-        except Exception as exc:
-            if not _is_query_rejection(exc):
-                raise
-            rejection = exc
-
-    # Retry narrow. Note the latch is only set *after* this succeeds: if the
-    # fallback fails too, the problem was never flex-specific (an expired
-    # session refuses both queries), so it propagates and flex stays un-probed
-    # rather than being disabled for the rest of the process.
+    # If this fails too the problem was never flex-specific (an expired session
+    # refuses both queries), and it propagates rather than being reported as an
+    # account that lacks flex budgeting.
     data = await client.gql_call(
-        operation="MCPBudgetData",
+        operation=BUDGET_QUERY_OPERATION,
         graphql_query=BUDGET_QUERY,
         variables=variables,
     )
-
-    if rejection is not None:
-        logger.warning(
-            "Monarch rejected the flex budget fields; using the narrow budget "
-            "query for the rest of this process: %s",
-            rejection,
-        )
-        _flex_supported = False
-
     return data, False
 
 
 def format_budget_data(budget_data: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Format Monarch budget data into one row per category/month."""
+    """Format Monarch budget data into one row per category/month.
+
+    Every level uses ``or {}`` / ``or []`` rather than ``.get(k, default)``:
+    GraphQL returns an explicit ``null`` for a nullable field, which a default
+    argument does not catch. One such null used to take out the whole tool.
+    """
     category_lookup: Dict[str, Dict[str, Optional[str]]] = {}
-    for group in budget_data.get("categoryGroups", []):
-        for category in group.get("categories", []):
+    for group in budget_data.get("categoryGroups") or []:
+        if not group:
+            continue
+        for category in group.get("categories") or []:
+            if not category:
+                continue
             category_id = category.get("id")
             if category_id:
                 category_lookup[category_id] = {
                     "name": category.get("name"),
                     "category_group": group.get("name"),
+                    "category_type": group.get("type"),
+                    "budget_variability": category.get("budgetVariability"),
                 }
 
     budget_rows = []
     monthly_by_category = (
-        budget_data.get("budgetData", {}).get("monthlyAmountsByCategory", [])
+        (budget_data.get("budgetData") or {}).get("monthlyAmountsByCategory") or []
     )
     for category_budget in monthly_by_category:
+        if not category_budget:
+            continue
         category_id = (category_budget.get("category") or {}).get("id")
-        category_info = category_lookup.get(category_id, {})
-        for monthly_amount in category_budget.get("monthlyAmounts", []):
+        category_info = category_lookup.get(category_id) or {}
+        for monthly_amount in category_budget.get("monthlyAmounts") or []:
+            if not monthly_amount:
+                continue
             budget_rows.append(
                 {
                     "id": category_id,
@@ -343,6 +398,11 @@ def format_budget_data(budget_data: Dict[str, Any]) -> List[Dict[str, Any]]:
                     "rollover": monthly_amount.get("previousMonthRolloverAmount"),
                     "rollover_type": monthly_amount.get("rolloverType"),
                     "category_group": category_info.get("category_group"),
+                    # Income and expense rows are BOTH positive magnitudes, so
+                    # summing planned across rows without filtering on this
+                    # adds income to spending. See the get_budgets docstring.
+                    "category_type": category_info.get("category_type"),
+                    "budget_variability": category_info.get("budget_variability"),
                     "month": monthly_amount.get("month"),
                 }
             )
@@ -385,6 +445,16 @@ def format_flex_budget(
     else:
         entries = []
 
+    # If Monarch ever returns several buckets here, take the flexible one
+    # rather than merging them: concatenating a fixed bucket's months into the
+    # flex answer under whichever label happened to come last would report a
+    # different bucket's amount as the flexible budget.
+    flexible_entries = [
+        e for e in entries if e and e.get("budgetVariability") == "flexible"
+    ]
+    if flexible_entries:
+        entries = flexible_entries
+
     variability: Optional[str] = None
     monthly: List[Dict[str, Any]] = []
     for entry in entries:
@@ -418,13 +488,16 @@ def format_flex_budget(
 def format_budget_totals(
     budget_data: Dict[str, Any], used_flex_query: bool
 ) -> Optional[List[Dict[str, Any]]]:
-    """Per-month fixed/flexible/non-monthly totals, or None when unavailable."""
+    """Per-month totals.
+
+    ``None`` means "could not ask" (the fallback query ran); ``[]`` means the
+    query succeeded and there were none. Collapsing those together is the same
+    mistake ``flex.status`` exists to avoid.
+    """
     if not used_flex_query:
         return None
 
-    totals = (budget_data.get("budgetData") or {}).get("totalsByMonth")
-    if not totals:
-        return None
+    totals = (budget_data.get("budgetData") or {}).get("totalsByMonth") or []
 
     return [
         {
@@ -443,24 +516,30 @@ def format_budget_totals(
 def format_group_budgets(
     budget_data: Dict[str, Any], used_flex_query: bool
 ) -> Optional[List[Dict[str, Any]]]:
-    """One row per category group per month, or None when unavailable.
+    """One row per category group per month.
 
-    Groups budgeted at the group level rather than per category hold their
-    amount here; for every other group this is the roll-up of its categories.
+    ``None`` means "could not ask"; ``[]`` means none were returned.
+
+    ``group_level_budgeting`` is the important field: when True the group holds
+    its own budget, and when False this row is merely the roll-up of its
+    categories. A caller that adds ``data[].planned`` to ``groups[].planned``
+    without checking it double-counts.
     """
     if not used_flex_query:
         return None
 
     by_group = (budget_data.get("budgetData") or {}).get(
         "monthlyAmountsByCategoryGroup"
-    )
-    if not by_group:
-        return None
+    ) or []
 
-    group_names: Dict[str, Optional[str]] = {
-        group.get("id"): group.get("name")
+    group_info: Dict[str, Dict[str, Any]] = {
+        group.get("id"): {
+            "name": group.get("name"),
+            "category_type": group.get("type"),
+            "group_level_budgeting": group.get("groupLevelBudgetingEnabled"),
+        }
         for group in budget_data.get("categoryGroups") or []
-        if group.get("id")
+        if group and group.get("id")
     }
 
     rows: List[Dict[str, Any]] = []
@@ -468,17 +547,21 @@ def format_group_budgets(
         if not entry:
             continue
         group_id = (entry.get("categoryGroup") or {}).get("id")
+        info = group_info.get(group_id) or {}
         for amount in entry.get("monthlyAmounts") or []:
             if not amount:
                 continue
             rows.append(
                 {
                     "id": group_id,
-                    "name": group_names.get(group_id),
+                    "name": info.get("name"),
                     "planned": amount.get("plannedCashFlowAmount"),
                     "actual": amount.get("actualAmount"),
                     "remaining": amount.get("remainingAmount"),
                     "rollover": amount.get("previousMonthRolloverAmount"),
+                    "rollover_type": amount.get("rolloverType"),
+                    "category_type": info.get("category_type"),
+                    "group_level_budgeting": info.get("group_level_budgeting"),
                     "month": amount.get("month"),
                 }
             )
@@ -491,16 +574,14 @@ def format_goals(
 ) -> Optional[List[Dict[str, Any]]]:
     """Savings goals with their planned and actual monthly contributions.
 
-    Returns None when unavailable. Archived and completed goals are included
-    but flagged, so a caller can exclude them rather than silently miss that
-    they existed.
+    ``None`` means "could not ask"; ``[]`` means the account has no goals.
+    Archived and completed goals are included but flagged, so a caller can
+    exclude them rather than silently miss that they existed.
     """
     if not used_flex_query:
         return None
 
-    goals = budget_data.get("goalsV2")
-    if not goals:
-        return None
+    goals = budget_data.get("goalsV2") or []
 
     rows: List[Dict[str, Any]] = []
     for goal in goals:
@@ -542,19 +623,31 @@ async def get_budgets(
         end_date: End month in YYYY-MM-DD format (defaults to the current month)
 
     Returns:
-        A JSON object with:
+        A JSON object as described below.
 
-        ``budget_system`` - e.g. "fixed_and_flex", or null on accounts that do
-        not report it. Use this to tell "this account does not do flex
-        budgeting" from "the flex bucket is empty".
+        IMPORTANT - signs: income and expense amounts are BOTH returned as
+        positive magnitudes; the sign does not distinguish them (negatives
+        appear only for contra entries, e.g. an income-type group that
+        represents money going out). Summing ``planned`` across ``data`` rows
+        therefore adds income to spending and produces a meaningless figure.
+        Always filter on ``category_type`` first.
 
-        ``data`` - one row per budgeted category per month, each with ``id``
-        (category id), ``name``, ``planned`` (planned cash-flow amount),
-        ``actual``, ``remaining``, ``set_aside``, ``rollover``,
-        ``rollover_type``, ``category_group`` and ``month``. Note ``planned``
-        minus ``actual`` equals ``remaining`` only when ``rollover`` is zero --
-        for rollover categories the carried balance accounts for the
-        difference.
+        IMPORTANT - missing vs zero: when ``flex.status`` is ``unsupported``
+        the extended query was refused, and ``rollover``, ``rollover_type``,
+        ``budget_variability``, ``budget_system``, ``groups``, ``goals`` and
+        ``totals`` are all null as a result. Null means "not available", never
+        zero, and reconciliation is not possible in that state.
+
+        ``budget_system`` - e.g. "fixed_and_flex". Null if the account does not
+        report it OR if the extended query was refused (see above).
+
+        ``data`` - one row per budgeted category per month: ``id`` (category
+        id), ``name``, ``planned`` (planned cash-flow amount), ``actual``,
+        ``remaining``, ``set_aside``, ``rollover``, ``rollover_type``,
+        ``category_group``, ``category_type`` (``income`` / ``expense`` /
+        ``transfer``), ``budget_variability`` and ``month``. ``planned`` minus
+        ``actual`` equals ``remaining`` only when ``rollover`` is zero; for
+        rollover categories the carried balance accounts for the difference.
 
         ``flex`` - the all-up Flexible bucket for accounts on Monarch's
         "fixed_and_flex" budget system, with ``status`` (``ok``,
@@ -563,23 +656,30 @@ async def get_budgets(
         category in the Flexible section, so this -- not the per-category rows
         -- is the number to compare spending against. A ``status`` other than
         ``ok`` means no amount is available; do NOT treat that as zero.
-        Flexible is the only pooled bucket: Fixed and Non-Monthly are budgeted
-        per category, so their per-category rows in ``data`` are complete.
+        Flexible is the only pooled bucket, so rows whose
+        ``budget_variability`` is ``flexible`` do not carry standalone budgets;
+        Fixed and Non-Monthly categories do.
 
         ``groups`` - one row per category group per month (``id``, ``name``,
-        ``planned``, ``actual``, ``remaining``, ``rollover``, ``month``), or
-        null when unavailable. Groups budgeted at the group level rather than
-        per category hold their amount here.
+        ``planned``, ``actual``, ``remaining``, ``rollover``,
+        ``rollover_type``, ``category_type``, ``group_level_budgeting``,
+        ``month``). Add a group's ``planned`` to its categories' only when
+        ``group_level_budgeting`` is false would double-count -- when it is
+        true the group holds the budget, otherwise the row is a roll-up of
+        those same categories.
 
         ``goals`` - savings goals with ``planned_contributions`` and
-        ``actual_contributions`` per month, or null when unavailable. Goal
-        contributions are what ``set_aside`` refers to, so a "what is spoken
-        for this month" answer should account for them. ``archived`` and
-        ``completed`` goals are included but flagged.
+        ``actual_contributions`` per month. Goal contributions are a SEPARATE
+        quantity from a category's ``set_aside``; adding them together
+        double-counts. ``archived`` and ``completed`` goals are included but
+        flagged.
 
         ``totals`` - per-month ``income``, ``expenses``, ``flexible``,
-        ``fixed`` and ``non_monthly`` totals, or null when this account does
-        not expose them.
+        ``fixed`` and ``non_monthly`` totals.
+
+        For ``groups``, ``goals`` and ``totals``: ``null`` means the data could
+        not be fetched, while ``[]`` means the query succeeded and there was
+        none.
     """
     try:
         client = await get_monarch_client()
@@ -697,15 +797,11 @@ async def set_flexible_budget(
         Result of the update.
     """
     try:
-        if _flex_supported is False:
-            return json_success({
-                "success": False,
-                "error": (
-                    "This account does not appear to support Monarch's flexible "
-                    "budget bucket -- the API rejected the flex fields on an "
-                    "earlier get_budgets call."
-                ),
-            })
+        # Built before the mutation: a formatting error afterwards would report
+        # failure for a write that already applied and invite a retry.
+        message = f"Flexible budget set to ${float(amount):.2f}" + (
+            " for all future months" if apply_to_future else ""
+        )
 
         client = await get_monarch_client()
 
@@ -725,10 +821,28 @@ async def set_flexible_budget(
             apply_to_future=apply_to_future,
         )
 
+        # Do not infer success from the absence of an exception: Monarch can
+        # return a 200 whose payload node is null. Reporting "$X set" off a
+        # no-op would have the model tell the user a number that is not true.
+        budget_item = (
+            ((result or {}).get("updateOrCreateFlexBudgetItem") or {}).get("budgetItem")
+            if isinstance(result, dict)
+            else None
+        )
+        if not budget_item:
+            return json_success({
+                "success": False,
+                "error": (
+                    "Monarch did not confirm the update -- the response "
+                    "contained no budget item. The amount may not have been "
+                    "applied; re-read it with get_budgets before retrying."
+                ),
+                "result": result,
+            })
+
         return json_success({
             "success": True,
-            "message": f"Flexible budget set to ${amount:.2f}"
-                       + (" for all future months" if apply_to_future else ""),
+            "message": message,
             "result": result,
         })
     except Exception as e:
@@ -765,15 +879,11 @@ async def update_flex_rollover_settings(
         Result of the update, including the new rollover period.
     """
     try:
-        if _flex_supported is False:
-            return json_success({
-                "success": False,
-                "error": (
-                    "This account does not appear to support Monarch's flexible "
-                    "budget bucket -- the API rejected the flex fields on an "
-                    "earlier get_budgets call."
-                ),
-            })
+        message = (
+            f"Flex rollover period restarted at {rollover_start_month} with "
+            f"a starting balance of ${float(rollover_starting_balance):.2f}"
+            + ("" if rollover_enabled else " (rollover disabled)")
+        )
 
         client = await get_monarch_client()
 
@@ -788,19 +898,48 @@ async def update_flex_rollover_settings(
                 ),
             })
 
+        # The client writes budgetSystem into this mutation's input and
+        # defaults it to "fixed_and_flex". Firing it blind on an account using
+        # a different system would migrate the household's whole budgeting mode
+        # as a side effect of a rollover reset -- a much larger change than the
+        # one the user was asked to confirm. So read the real value first and
+        # forward it, refusing rather than guessing.
+        raw, used_extended = await get_budget_data(client)
+        budget_system = raw.get("budgetSystem") if used_extended else None
+
+        if not used_extended:
+            return json_success({
+                "success": False,
+                "error": (
+                    "Could not read this account's budget system (Monarch "
+                    "refused the extended budget query), so a flex rollover "
+                    "reset cannot be performed safely -- it would risk "
+                    "switching the account's budgeting mode."
+                ),
+            })
+
+        if budget_system != "fixed_and_flex":
+            return json_success({
+                "success": False,
+                "error": (
+                    f"This account's budget system is {budget_system!r}, not "
+                    "'fixed_and_flex'. Refusing: this mutation would rewrite "
+                    "the account's budget system as well as the rollover."
+                ),
+                "budget_system": budget_system,
+            })
+
         result = await updater(
             rollover_start_month=rollover_start_month,
             rollover_starting_balance=rollover_starting_balance,
             rollover_enabled=rollover_enabled,
+            budget_system=budget_system,
         )
 
         return json_success({
             "success": True,
-            "message": (
-                f"Flex rollover period restarted at {rollover_start_month} with "
-                f"a starting balance of ${rollover_starting_balance:.2f}"
-                + ("" if rollover_enabled else " (rollover disabled)")
-            ),
+            "message": message,
+            "budget_system": budget_system,
             "result": result,
         })
     except Exception as e:

--- a/src/monarch_mcp_server/tools/budgets.py
+++ b/src/monarch_mcp_server/tools/budgets.py
@@ -532,10 +532,10 @@ def format_group_budgets(
 
     ``None`` means "could not ask"; ``[]`` means none were returned.
 
-    ``group_level_budgeting`` is the important field: when True the group holds
-    its own budget, and when False this row is merely the roll-up of its
-    categories. A caller that adds ``data[].planned`` to ``groups[].planned``
-    without checking it double-counts.
+    ``group_level_budgeting`` says which level holds the real budget: when True
+    the group does and its categories carry none; when False this row is merely
+    the roll-up of its categories. Adding ``groups[].planned`` to the matching
+    ``data[].planned`` double-counts either way.
     """
     if not used_flex_query:
         return None
@@ -662,7 +662,15 @@ async def get_budgets(
         id), ``name``, ``planned`` (planned cash-flow amount), ``actual``,
         ``remaining``, ``set_aside``, ``rollover``, ``rollover_type``,
         ``category_group``, ``category_type`` (``income`` / ``expense`` /
-        ``transfer``), ``budget_variability`` and ``month``. ``planned`` minus
+        ``transfer``), ``budget_variability`` and ``month``.
+
+        ``set_aside`` is Monarch's ``plannedSetAsideAmount``, passed through
+        as-is. It is a distinct field from ``planned`` and this server does not
+        combine them; whether Monarch intends it as additive to ``planned`` has
+        not been confirmed against an account that actually uses it, so do not
+        sum the two without checking against Monarch's own figures.
+
+        ``planned`` minus
         ``actual`` equals ``remaining`` only when ``rollover`` is zero; for
         rollover categories the carried balance accounts for the difference.
 
@@ -897,11 +905,21 @@ async def update_flex_rollover_settings(
         Result of the update, including the new rollover period.
     """
     try:
-        message = (
-            f"Flex rollover period restarted at {rollover_start_month} with "
-            f"a starting balance of ${float(rollover_starting_balance):.2f}"
-            + ("" if rollover_enabled else " (rollover disabled)")
-        )
+        # The client does `rollover_start_month or <current month>`, so an
+        # empty or malformed value silently becomes "reset from this month" --
+        # exactly the no-argument reset the required arguments exist to
+        # prevent. Reject it here rather than letting it through.
+        try:
+            date.fromisoformat(rollover_start_month)
+        except (TypeError, ValueError):
+            return json_success({
+                "success": False,
+                "error": (
+                    "rollover_start_month must be a YYYY-MM-DD date (use the "
+                    f"first of the month, e.g. '2026-08-01'); got "
+                    f"{rollover_start_month!r}."
+                ),
+            })
 
         client = await get_monarch_client()
 
@@ -981,9 +999,15 @@ async def update_flex_rollover_settings(
                 "result": result,
             })
 
+        # Report the month Monarch actually applied, not the one requested.
+        applied_month = period.get("startMonth") or rollover_start_month
         return json_success({
             "success": True,
-            "message": message,
+            "message": (
+                f"Flex rollover period restarted at {applied_month} with a "
+                f"starting balance of ${float(rollover_starting_balance):.2f}"
+                + ("" if rollover_enabled else " (rollover disabled)")
+            ),
             "budget_system": budget_system,
             "result": result,
         })

--- a/src/monarch_mcp_server/tools/budgets.py
+++ b/src/monarch_mcp_server/tools/budgets.py
@@ -24,9 +24,10 @@ logger = logging.getLogger(__name__)
 # accounts, so it can fail outright. This narrower query asks only for fields
 # the current API still returns.
 #
-# Both documents below render from this one template, so the categoryGroups
-# selection is *structurally* identical between them -- adding flex support
-# cannot widen it by accident.
+# Both documents below render from this one template. The narrow document
+# supplies "" for every extension slot, so it is exactly the selection already
+# proven to work; anything added to categoryGroups must go through a slot and
+# therefore lands in the extended document only, where the fallback covers it.
 _BUDGET_DOCUMENT = """
     query %(operation)s($startDate: Date!, $endDate: Date!) {
       budgetData(startMonth: $startDate, endMonth: $endDate) {
@@ -135,9 +136,10 @@ _ROOT_EXTRA = """
 #   expense buckets.
 #
 # Note: `budgetVariability` appears here under monthlyAmountsForFlexExpense,
-# a *different* subtree from the categoryGroups.budgetVariability field
-# implicated in the original failure. groupLevelBudgetingEnabled is
-# deliberately NOT requested -- it lives on categoryGroups, which stays narrow.
+# a *different* subtree from the CategoryGroup.budgetVariability field
+# implicated in the original failure -- that one stays out of both documents,
+# as does rolloverPeriod. See _GROUP_EXTRA / _CATEGORY_FIELD_EXTRA for what the
+# extended document does add to the categoryGroups subtree.
 _EXTENDED_SELECTIONS = """
         monthlyAmountsForFlexExpense {
           budgetVariability
@@ -445,15 +447,25 @@ def format_flex_budget(
     else:
         entries = []
 
-    # If Monarch ever returns several buckets here, take the flexible one
-    # rather than merging them: concatenating a fixed bucket's months into the
-    # flex answer under whichever label happened to come last would report a
-    # different bucket's amount as the flexible budget.
-    flexible_entries = [
-        e for e in entries if e and e.get("budgetVariability") == "flexible"
-    ]
-    if flexible_entries:
-        entries = flexible_entries
+    # If Monarch ever returns several buckets here, never merge them:
+    # concatenating a fixed bucket's months into the flex answer under
+    # whichever label came last would report a different bucket's amount as the
+    # flexible budget. Prefer the entry actually labelled flexible; failing
+    # that, take a single entry rather than combining ambiguous ones.
+    if len(entries) > 1:
+        flexible_entries = [
+            e for e in entries if e and e.get("budgetVariability") == "flexible"
+        ]
+        if len(flexible_entries) == 1:
+            entries = flexible_entries
+        else:
+            logger.warning(
+                "Monarch returned %d flex-expense buckets (%d labelled "
+                "flexible); using only the first to avoid merging buckets.",
+                len(entries),
+                len(flexible_entries),
+            )
+            entries = (flexible_entries or entries)[:1]
 
     variability: Optional[str] = None
     monthly: List[Dict[str, Any]] = []
@@ -619,8 +631,13 @@ async def get_budgets(
     Get budget information from Monarch Money.
 
     Args:
-        start_date: Start month in YYYY-MM-DD format (defaults to the current month)
-        end_date: End month in YYYY-MM-DD format (defaults to the current month)
+        start_date: Start month in YYYY-MM-DD format
+        end_date: End month in YYYY-MM-DD format
+
+        Pass BOTH or NEITHER. Omitting both defaults to the current month;
+        supplying only one is an error rather than being filled in, because
+        completing the missing side from today can invert the range and return
+        an empty result that reads as "this account has no budget".
 
     Returns:
         A JSON object as described below.
@@ -663,10 +680,11 @@ async def get_budgets(
         ``groups`` - one row per category group per month (``id``, ``name``,
         ``planned``, ``actual``, ``remaining``, ``rollover``,
         ``rollover_type``, ``category_type``, ``group_level_budgeting``,
-        ``month``). Add a group's ``planned`` to its categories' only when
-        ``group_level_budgeting`` is false would double-count -- when it is
-        true the group holds the budget, otherwise the row is a roll-up of
-        those same categories.
+        ``month``). ``group_level_budgeting`` says which level holds the real
+        budget: when true the group does and its categories carry none; when
+        false this row is only the roll-up of its own categories. Never add a
+        group's ``planned`` to its categories' ``planned`` -- that
+        double-counts either way.
 
         ``goals`` - savings goals with ``planned_contributions`` and
         ``actual_contributions`` per month. Goal contributions are a SEPARATE
@@ -919,10 +937,15 @@ async def update_flex_rollover_settings(
             })
 
         if budget_system != "fixed_and_flex":
+            described = (
+                repr(budget_system)
+                if budget_system
+                else "not reported by Monarch"
+            )
             return json_success({
                 "success": False,
                 "error": (
-                    f"This account's budget system is {budget_system!r}, not "
+                    f"This account's budget system is {described}, not "
                     "'fixed_and_flex'. Refusing: this mutation would rewrite "
                     "the account's budget system as well as the rollover."
                 ),
@@ -935,6 +958,28 @@ async def update_flex_rollover_settings(
             rollover_enabled=rollover_enabled,
             budget_system=budget_system,
         )
+
+        # Same reasoning as set_flexible_budget, and it matters more here:
+        # falsely confirming a destructive reset is worse than falsely
+        # confirming an amount.
+        period = (
+            ((result or {}).get("updateBudgetSettings") or {}).get(
+                "budgetRolloverPeriod"
+            )
+            if isinstance(result, dict)
+            else None
+        )
+        if not period:
+            return json_success({
+                "success": False,
+                "error": (
+                    "Monarch did not confirm the change -- the response "
+                    "contained no rollover period. The reset may not have "
+                    "been applied; re-read it with get_budgets before "
+                    "retrying."
+                ),
+                "result": result,
+            })
 
         return json_success({
             "success": True,

--- a/src/monarch_mcp_server/tools/budgets.py
+++ b/src/monarch_mcp_server/tools/budgets.py
@@ -69,11 +69,37 @@ _CATEGORY_EXTRA = """
             previousMonthRolloverAmount
             rolloverType"""
 
-# Which budget system the account uses ("fixed_and_flex" or otherwise). Lets a
-# caller tell "this account does not do flex budgeting" from "the flex bucket
-# is empty" without inferring it.
+# Root-level extras.
+#
+# - budgetSystem: which system the account uses ("fixed_and_flex" or otherwise).
+#   Lets a caller tell "this account does not do flex budgeting" from "the flex
+#   bucket is empty" without inferring it.
+# - goalsV2: goal contributions are part of the monthly plan and are what
+#   plannedSetAsideAmount refers to, so a budget answer that ignores them
+#   understates what is spoken for. Upstream guards this with
+#   @include(if: $useV2Goals); requested unconditionally here since the whole
+#   document already falls back if Monarch refuses any of it.
 _ROOT_EXTRA = """
-      budgetSystem"""
+      budgetSystem
+      goalsV2 {
+        id
+        name
+        archivedAt
+        completedAt
+        priority
+        plannedContributions(startMonth: $startDate, endMonth: $endDate) {
+          id
+          month
+          amount
+          __typename
+        }
+        monthlyContributionSummaries(startMonth: $startDate, endMonth: $endDate) {
+          month
+          sum
+          __typename
+        }
+        __typename
+      }"""
 
 # Roll-up amounts Monarch exposes above the per-category level. All live under
 # budgetData, so requesting them never widens the categoryGroups selection.
@@ -460,6 +486,49 @@ def format_group_budgets(
     return rows
 
 
+def format_goals(
+    budget_data: Dict[str, Any], used_flex_query: bool
+) -> Optional[List[Dict[str, Any]]]:
+    """Savings goals with their planned and actual monthly contributions.
+
+    Returns None when unavailable. Archived and completed goals are included
+    but flagged, so a caller can exclude them rather than silently miss that
+    they existed.
+    """
+    if not used_flex_query:
+        return None
+
+    goals = budget_data.get("goalsV2")
+    if not goals:
+        return None
+
+    rows: List[Dict[str, Any]] = []
+    for goal in goals:
+        if not goal:
+            continue
+        rows.append(
+            {
+                "id": goal.get("id"),
+                "name": goal.get("name"),
+                "priority": goal.get("priority"),
+                "archived": bool(goal.get("archivedAt")),
+                "completed": bool(goal.get("completedAt")),
+                "planned_contributions": [
+                    {"month": c.get("month"), "amount": c.get("amount")}
+                    for c in goal.get("plannedContributions") or []
+                    if c
+                ],
+                "actual_contributions": [
+                    {"month": s.get("month"), "amount": s.get("sum")}
+                    for s in goal.get("monthlyContributionSummaries") or []
+                    if s
+                ],
+            }
+        )
+
+    return rows
+
+
 @mcp.tool()
 async def get_budgets(
     start_date: Optional[str] = None,
@@ -502,6 +571,12 @@ async def get_budgets(
         null when unavailable. Groups budgeted at the group level rather than
         per category hold their amount here.
 
+        ``goals`` - savings goals with ``planned_contributions`` and
+        ``actual_contributions`` per month, or null when unavailable. Goal
+        contributions are what ``set_aside`` refers to, so a "what is spoken
+        for this month" answer should account for them. ``archived`` and
+        ``completed`` goals are included but flagged.
+
         ``totals`` - per-month ``income``, ``expenses``, ``flexible``,
         ``fixed`` and ``non_monthly`` totals, or null when this account does
         not expose them.
@@ -517,6 +592,7 @@ async def get_budgets(
                 "data": format_budget_data(raw),
                 "flex": format_flex_budget(raw, used_flex_query),
                 "groups": format_group_budgets(raw, used_flex_query),
+                "goals": format_goals(raw, used_flex_query),
                 "totals": format_budget_totals(raw, used_flex_query),
             }
         )

--- a/src/monarch_mcp_server/tools/budgets.py
+++ b/src/monarch_mcp_server/tools/budgets.py
@@ -40,7 +40,7 @@ _BUDGET_DOCUMENT = """
             plannedCashFlowAmount
             plannedSetAsideAmount
             actualAmount
-            remainingAmount
+            remainingAmount%(category_extra)s
             __typename
           }
           __typename
@@ -57,9 +57,23 @@ _BUDGET_DOCUMENT = """
           __typename
         }
         __typename
-      }
+      }%(root_extra)s
     }
 """
+
+# Per-category rollover. Without these, planned - actual does not equal
+# remaining for any category with rollover enabled, and the difference is
+# unexplainable from the tool's output. Requested only by the extended query:
+# the fallback stays byte-for-byte the document already proven to work.
+_CATEGORY_EXTRA = """
+            previousMonthRolloverAmount
+            rolloverType"""
+
+# Which budget system the account uses ("fixed_and_flex" or otherwise). Lets a
+# caller tell "this account does not do flex budgeting" from "the flex bucket
+# is empty" without inferring it.
+_ROOT_EXTRA = """
+      budgetSystem"""
 
 # Roll-up amounts Monarch exposes above the per-category level. All live under
 # budgetData, so requesting them never widens the categoryGroups selection.
@@ -148,13 +162,24 @@ _EXTENDED_SELECTIONS = """
         }"""
 
 BUDGET_QUERY = gql(
-    _BUDGET_DOCUMENT % {"operation": "MCPBudgetData", "flex_selections": ""}
+    _BUDGET_DOCUMENT
+    % {
+        "operation": "MCPBudgetData",
+        "flex_selections": "",
+        "category_extra": "",
+        "root_extra": "",
+    }
 )
 
 # Tried first; falls back to BUDGET_QUERY when Monarch refuses these fields.
 BUDGET_QUERY_FLEX = gql(
     _BUDGET_DOCUMENT
-    % {"operation": "MCPBudgetDataFlex", "flex_selections": _EXTENDED_SELECTIONS}
+    % {
+        "operation": "MCPBudgetDataFlex",
+        "flex_selections": _EXTENDED_SELECTIONS,
+        "category_extra": _CATEGORY_EXTRA,
+        "root_extra": _ROOT_EXTRA,
+    }
 )
 
 # Cached for the life of the process: None = not yet probed, True = the flex
@@ -286,6 +311,11 @@ def format_budget_data(budget_data: Dict[str, Any]) -> List[Dict[str, Any]]:
                     "planned": monthly_amount.get("plannedCashFlowAmount"),
                     "actual": monthly_amount.get("actualAmount"),
                     "remaining": monthly_amount.get("remainingAmount"),
+                    # planned - actual only equals remaining when rollover is
+                    # zero; without these the gap is unexplainable.
+                    "set_aside": monthly_amount.get("plannedSetAsideAmount"),
+                    "rollover": monthly_amount.get("previousMonthRolloverAmount"),
+                    "rollover_type": monthly_amount.get("rolloverType"),
                     "category_group": category_info.get("category_group"),
                     "month": monthly_amount.get("month"),
                 }
@@ -445,9 +475,17 @@ async def get_budgets(
     Returns:
         A JSON object with:
 
+        ``budget_system`` - e.g. "fixed_and_flex", or null on accounts that do
+        not report it. Use this to tell "this account does not do flex
+        budgeting" from "the flex bucket is empty".
+
         ``data`` - one row per budgeted category per month, each with ``id``
         (category id), ``name``, ``planned`` (planned cash-flow amount),
-        ``actual``, ``remaining``, ``category_group`` and ``month``.
+        ``actual``, ``remaining``, ``set_aside``, ``rollover``,
+        ``rollover_type``, ``category_group`` and ``month``. Note ``planned``
+        minus ``actual`` equals ``remaining`` only when ``rollover`` is zero --
+        for rollover categories the carried balance accounts for the
+        difference.
 
         ``flex`` - the all-up Flexible bucket for accounts on Monarch's
         "fixed_and_flex" budget system, with ``status`` (``ok``,
@@ -475,6 +513,7 @@ async def get_budgets(
             {
                 "tool": "get_budgets",
                 "args": {"start_date": start_date, "end_date": end_date},
+                "budget_system": raw.get("budgetSystem"),
                 "data": format_budget_data(raw),
                 "flex": format_flex_budget(raw, used_flex_query),
                 "groups": format_group_budgets(raw, used_flex_query),

--- a/src/monarch_mcp_server/tools/budgets.py
+++ b/src/monarch_mcp_server/tools/budgets.py
@@ -8,6 +8,11 @@ from typing import Any, Dict, List, Optional, Tuple
 from gql import gql
 from monarchmoney import MonarchMoney
 
+try:  # gql raises this when the server answers but refuses the query itself.
+    from gql.transport.exceptions import TransportQueryError
+except ImportError:  # pragma: no cover - defensive, gql always ships it today
+    TransportQueryError = ()
+
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
 from monarch_mcp_server.helpers import json_success, json_error
@@ -18,9 +23,12 @@ logger = logging.getLogger(__name__)
 # budgetVariability/rolloverPeriod) that Monarch's current API rejects for some
 # accounts, so it can fail outright. This narrower query asks only for fields
 # the current API still returns.
-BUDGET_QUERY = gql(
-    """
-    query MCPBudgetData($startDate: Date!, $endDate: Date!) {
+#
+# Both documents below render from this one template, so the categoryGroups
+# selection is *structurally* identical between them -- adding flex support
+# cannot widen it by accident.
+_BUDGET_DOCUMENT = """
+    query %(operation)s($startDate: Date!, $endDate: Date!) {
       budgetData(startMonth: $startDate, endMonth: $endDate) {
         monthlyAmountsByCategory {
           category {
@@ -36,7 +44,7 @@ BUDGET_QUERY = gql(
             __typename
           }
           __typename
-        }
+        }%(flex_selections)s
         __typename
       }
       categoryGroups {
@@ -51,42 +59,17 @@ BUDGET_QUERY = gql(
         __typename
       }
     }
-    """
-)
+"""
 
-# BUDGET_QUERY plus the bucket-level amounts Monarch exposes for the
-# "fixed_and_flex" budget system. Under that system the Flexible section carries
-# a single amount covering every category beneath it; without these selections
-# that number is invisible and spending-vs-budget for Flexible cannot be
-# computed (see issue #103).
+# Bucket-level amounts Monarch exposes for the "fixed_and_flex" budget system.
+# Under that system the Flexible section carries a single amount covering every
+# category beneath it; without these selections that number is invisible and
+# spending-vs-budget for Flexible cannot be computed (issue #103).
 #
-# Kept as a separate document, rather than folded into BUDGET_QUERY, so that any
-# account whose API rejects these fields can fall back to the narrow query with
-# its behavior completely unchanged.
-#
-# Note: `budgetVariability` appears below under monthlyAmountsForFlexExpense.
-# That is a *different* subtree from the categoryGroups.budgetVariability field
-# implicated in the original failure -- the categoryGroups selection here stays
-# exactly as narrow as it is in BUDGET_QUERY.
-BUDGET_QUERY_FLEX = gql(
-    """
-    query MCPBudgetDataFlex($startDate: Date!, $endDate: Date!) {
-      budgetData(startMonth: $startDate, endMonth: $endDate) {
-        monthlyAmountsByCategory {
-          category {
-            id
-            __typename
-          }
-          monthlyAmounts {
-            month
-            plannedCashFlowAmount
-            plannedSetAsideAmount
-            actualAmount
-            remainingAmount
-            __typename
-          }
-          __typename
-        }
+# Note: `budgetVariability` appears here under monthlyAmountsForFlexExpense,
+# a *different* subtree from the categoryGroups.budgetVariability field
+# implicated in the original failure.
+_FLEX_SELECTIONS = """
         monthlyAmountsForFlexExpense {
           budgetVariability
           monthlyAmounts {
@@ -124,22 +107,16 @@ BUDGET_QUERY_FLEX = gql(
             __typename
           }
           __typename
-        }
-        __typename
-      }
-      categoryGroups {
-        id
-        name
-        type
-        categories {
-          id
-          name
-          __typename
-        }
-        __typename
-      }
-    }
-    """
+        }"""
+
+BUDGET_QUERY = gql(
+    _BUDGET_DOCUMENT % {"operation": "MCPBudgetData", "flex_selections": ""}
+)
+
+# Tried first; falls back to BUDGET_QUERY when Monarch refuses these fields.
+BUDGET_QUERY_FLEX = gql(
+    _BUDGET_DOCUMENT
+    % {"operation": "MCPBudgetDataFlex", "flex_selections": _FLEX_SELECTIONS}
 )
 
 # Cached for the life of the process: None = not yet probed, True = the flex
@@ -147,9 +124,10 @@ BUDGET_QUERY_FLEX = gql(
 # round-trip again.
 _flex_supported: Optional[bool] = None
 
-# Substrings that mark a GraphQL *validation* failure -- i.e. the server saying
-# these fields don't exist -- as opposed to a transport, auth or rate-limit
-# error that happens to occur on the same call.
+# Supplementary text match. Monarch does not return standard GraphQL validation
+# wording -- a rejected field comes back as a generic "Something went wrong
+# while processing" -- so exception *type* is the primary signal and these are
+# only a backstop for transports that do surface the usual messages.
 _SCHEMA_REJECTION_MARKERS = (
     "cannot query field",
     "unknown field",
@@ -157,7 +135,6 @@ _SCHEMA_REJECTION_MARKERS = (
     "unknown argument",
     "did you mean",
     "validation error",
-    "graphqlerror",
 )
 
 
@@ -167,14 +144,16 @@ def reset_flex_support() -> None:
     _flex_supported = None
 
 
-def _is_schema_rejection(exc: Exception) -> bool:
-    """True when *exc* looks like Monarch rejecting the flex fields themselves.
+def _is_query_rejection(exc: Exception) -> bool:
+    """True when the server answered but refused the query itself.
 
-    Only a schema rejection is cached as "flex unsupported". A 401, timeout or
-    connection reset must not permanently latch flex off for the process, and
-    must not be quietly downgraded into a successful-but-incomplete response --
-    those propagate to the caller instead.
+    ``TransportQueryError`` is what gql raises when a response carries GraphQL
+    ``errors``; HTTP failures (401, 5xx) raise ``TransportServerError`` and
+    connection problems raise their own types, so those fall through to the
+    caller rather than being mistaken for "this account has no flex bucket".
     """
+    if TransportQueryError and isinstance(exc, TransportQueryError):
+        return True
     text = str(exc).lower()
     return any(marker in text for marker in _SCHEMA_REJECTION_MARKERS)
 
@@ -205,6 +184,8 @@ async def get_budget_data(
         "endDate": end_date or default_end,
     }
 
+    rejection: Optional[Exception] = None
+
     if _flex_supported is not False:
         try:
             data = await client.gql_call(
@@ -215,20 +196,28 @@ async def get_budget_data(
             _flex_supported = True
             return data, True
         except Exception as exc:
-            if not _is_schema_rejection(exc):
+            if not _is_query_rejection(exc):
                 raise
-            logger.warning(
-                "Monarch rejected the flex budget fields; falling back to the "
-                "narrow budget query for the rest of this process: %s",
-                exc,
-            )
-            _flex_supported = False
+            rejection = exc
 
+    # Retry narrow. Note the latch is only set *after* this succeeds: if the
+    # fallback fails too, the problem was never flex-specific (an expired
+    # session refuses both queries), so it propagates and flex stays un-probed
+    # rather than being disabled for the rest of the process.
     data = await client.gql_call(
         operation="MCPBudgetData",
         graphql_query=BUDGET_QUERY,
         variables=variables,
     )
+
+    if rejection is not None:
+        logger.warning(
+            "Monarch rejected the flex budget fields; using the narrow budget "
+            "query for the rest of this process: %s",
+            rejection,
+        )
+        _flex_supported = False
+
     return data, False
 
 

--- a/src/monarch_mcp_server/tools/budgets.py
+++ b/src/monarch_mcp_server/tools/budgets.py
@@ -3,7 +3,7 @@
 import calendar
 import logging
 from datetime import date
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from gql import gql
 from monarchmoney import MonarchMoney
@@ -54,6 +54,130 @@ BUDGET_QUERY = gql(
     """
 )
 
+# BUDGET_QUERY plus the bucket-level amounts Monarch exposes for the
+# "fixed_and_flex" budget system. Under that system the Flexible section carries
+# a single amount covering every category beneath it; without these selections
+# that number is invisible and spending-vs-budget for Flexible cannot be
+# computed (see issue #103).
+#
+# Kept as a separate document, rather than folded into BUDGET_QUERY, so that any
+# account whose API rejects these fields can fall back to the narrow query with
+# its behavior completely unchanged.
+#
+# Note: `budgetVariability` appears below under monthlyAmountsForFlexExpense.
+# That is a *different* subtree from the categoryGroups.budgetVariability field
+# implicated in the original failure -- the categoryGroups selection here stays
+# exactly as narrow as it is in BUDGET_QUERY.
+BUDGET_QUERY_FLEX = gql(
+    """
+    query MCPBudgetDataFlex($startDate: Date!, $endDate: Date!) {
+      budgetData(startMonth: $startDate, endMonth: $endDate) {
+        monthlyAmountsByCategory {
+          category {
+            id
+            __typename
+          }
+          monthlyAmounts {
+            month
+            plannedCashFlowAmount
+            plannedSetAsideAmount
+            actualAmount
+            remainingAmount
+            __typename
+          }
+          __typename
+        }
+        monthlyAmountsForFlexExpense {
+          budgetVariability
+          monthlyAmounts {
+            month
+            plannedCashFlowAmount
+            actualAmount
+            remainingAmount
+            previousMonthRolloverAmount
+            rolloverType
+            __typename
+          }
+          __typename
+        }
+        totalsByMonth {
+          month
+          totalFlexibleExpenses {
+            plannedAmount
+            actualAmount
+            remainingAmount
+            previousMonthRolloverAmount
+            __typename
+          }
+          totalFixedExpenses {
+            plannedAmount
+            actualAmount
+            remainingAmount
+            previousMonthRolloverAmount
+            __typename
+          }
+          totalNonMonthlyExpenses {
+            plannedAmount
+            actualAmount
+            remainingAmount
+            previousMonthRolloverAmount
+            __typename
+          }
+          __typename
+        }
+        __typename
+      }
+      categoryGroups {
+        id
+        name
+        type
+        categories {
+          id
+          name
+          __typename
+        }
+        __typename
+      }
+    }
+    """
+)
+
+# Cached for the life of the process: None = not yet probed, True = the flex
+# fields work, False = this account rejects them so don't pay the failed
+# round-trip again.
+_flex_supported: Optional[bool] = None
+
+# Substrings that mark a GraphQL *validation* failure -- i.e. the server saying
+# these fields don't exist -- as opposed to a transport, auth or rate-limit
+# error that happens to occur on the same call.
+_SCHEMA_REJECTION_MARKERS = (
+    "cannot query field",
+    "unknown field",
+    "no field named",
+    "unknown argument",
+    "did you mean",
+    "validation error",
+    "graphqlerror",
+)
+
+
+def reset_flex_support() -> None:
+    """Clear the cached flex-support result. Intended for tests."""
+    global _flex_supported
+    _flex_supported = None
+
+
+def _is_schema_rejection(exc: Exception) -> bool:
+    """True when *exc* looks like Monarch rejecting the flex fields themselves.
+
+    Only a schema rejection is cached as "flex unsupported". A 401, timeout or
+    connection reset must not permanently latch flex off for the process, and
+    must not be quietly downgraded into a successful-but-incomplete response --
+    those propagate to the caller instead.
+    """
+    text = str(exc).lower()
+    return any(marker in text for marker in _SCHEMA_REJECTION_MARKERS)
+
 
 def current_month_range() -> tuple[str, str]:
     """Return the current month bounds as ISO date strings."""
@@ -66,17 +190,46 @@ async def get_budget_data(
     client: MonarchMoney,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
-) -> Dict[str, Any]:
-    """Fetch budget data using fields supported by Monarch's current API."""
+) -> Tuple[Dict[str, Any], bool]:
+    """Fetch budget data, preferring the query that includes flex bucket totals.
+
+    Returns ``(raw_response, used_flex_query)``. When Monarch rejects the flex
+    selections this falls back to :data:`BUDGET_QUERY`, so accounts that do not
+    support them behave exactly as they did before.
+    """
+    global _flex_supported
+
     default_start, default_end = current_month_range()
-    return await client.gql_call(
+    variables = {
+        "startDate": start_date or default_start,
+        "endDate": end_date or default_end,
+    }
+
+    if _flex_supported is not False:
+        try:
+            data = await client.gql_call(
+                operation="MCPBudgetDataFlex",
+                graphql_query=BUDGET_QUERY_FLEX,
+                variables=variables,
+            )
+            _flex_supported = True
+            return data, True
+        except Exception as exc:
+            if not _is_schema_rejection(exc):
+                raise
+            logger.warning(
+                "Monarch rejected the flex budget fields; falling back to the "
+                "narrow budget query for the rest of this process: %s",
+                exc,
+            )
+            _flex_supported = False
+
+    data = await client.gql_call(
         operation="MCPBudgetData",
         graphql_query=BUDGET_QUERY,
-        variables={
-            "startDate": start_date or default_start,
-            "endDate": end_date or default_end,
-        },
+        variables=variables,
     )
+    return data, False
 
 
 def format_budget_data(budget_data: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -114,6 +267,94 @@ def format_budget_data(budget_data: Dict[str, Any]) -> List[Dict[str, Any]]:
     return budget_rows
 
 
+def _totals_entry(node: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Normalize one of Monarch's planned/actual/remaining total objects."""
+    if not node:
+        return None
+    return {
+        "planned": node.get("plannedAmount"),
+        "actual": node.get("actualAmount"),
+        "remaining": node.get("remainingAmount"),
+        "rollover": node.get("previousMonthRolloverAmount"),
+    }
+
+
+def format_flex_budget(
+    budget_data: Dict[str, Any], used_flex_query: bool
+) -> Dict[str, Any]:
+    """Summarize the Flexible bucket, always reporting *why* it may be empty.
+
+    ``status`` separates three cases that would otherwise be indistinguishable
+    -- and reading "no flex budget" as "$0" would be wrong:
+
+    - ``unsupported``    Monarch rejected the flex fields; the fallback ran
+    - ``not_configured`` the query worked but this account has no flex bucket
+    - ``ok``             a flex bucket is present
+    """
+    if not used_flex_query:
+        return {"status": "unsupported", "budget_variability": None, "monthly": []}
+
+    flex = (budget_data.get("budgetData") or {}).get("monthlyAmountsForFlexExpense")
+    if isinstance(flex, list):
+        entries = flex
+    elif flex:
+        entries = [flex]
+    else:
+        entries = []
+
+    variability: Optional[str] = None
+    monthly: List[Dict[str, Any]] = []
+    for entry in entries:
+        if not entry:
+            continue
+        variability = entry.get("budgetVariability") or variability
+        for amount in entry.get("monthlyAmounts") or []:
+            if not amount:
+                continue
+            monthly.append(
+                {
+                    "month": amount.get("month"),
+                    "planned": amount.get("plannedCashFlowAmount"),
+                    "actual": amount.get("actualAmount"),
+                    "remaining": amount.get("remainingAmount"),
+                    "rollover": amount.get("previousMonthRolloverAmount"),
+                    "rollover_type": amount.get("rolloverType"),
+                }
+            )
+
+    if not monthly:
+        return {
+            "status": "not_configured",
+            "budget_variability": variability,
+            "monthly": [],
+        }
+
+    return {"status": "ok", "budget_variability": variability, "monthly": monthly}
+
+
+def format_budget_totals(
+    budget_data: Dict[str, Any], used_flex_query: bool
+) -> Optional[List[Dict[str, Any]]]:
+    """Per-month fixed/flexible/non-monthly totals, or None when unavailable."""
+    if not used_flex_query:
+        return None
+
+    totals = (budget_data.get("budgetData") or {}).get("totalsByMonth")
+    if not totals:
+        return None
+
+    return [
+        {
+            "month": total.get("month"),
+            "flexible": _totals_entry(total.get("totalFlexibleExpenses")),
+            "fixed": _totals_entry(total.get("totalFixedExpenses")),
+            "non_monthly": _totals_entry(total.get("totalNonMonthlyExpenses")),
+        }
+        for total in totals
+        if total
+    ]
+
+
 @mcp.tool()
 async def get_budgets(
     start_date: Optional[str] = None,
@@ -127,15 +368,35 @@ async def get_budgets(
         end_date: End month in YYYY-MM-DD format (defaults to the current month)
 
     Returns:
-        A JSON list with one row per budgeted category per month. Each row has:
-        ``id`` (category id), ``name`` (category name), ``planned`` (planned
-        cash-flow amount), ``actual`` (actual amount), ``remaining``,
-        ``category_group`` (group name), and ``month`` (YYYY-MM-DD).
+        A JSON object with:
+
+        ``data`` - one row per budgeted category per month, each with ``id``
+        (category id), ``name``, ``planned`` (planned cash-flow amount),
+        ``actual``, ``remaining``, ``category_group`` and ``month``.
+
+        ``flex`` - the all-up Flexible bucket for accounts on Monarch's
+        "fixed_and_flex" budget system, with ``status`` (``ok``,
+        ``not_configured`` or ``unsupported``), ``budget_variability`` and a
+        ``monthly`` list. Under flex budgeting a single amount covers every
+        category in the Flexible section, so this -- not the per-category rows
+        -- is the number to compare spending against. A ``status`` other than
+        ``ok`` means no amount is available; do NOT treat that as zero.
+
+        ``totals`` - per-month ``flexible`` / ``fixed`` / ``non_monthly``
+        totals, or null when this account does not expose them.
     """
     try:
         client = await get_monarch_client()
-        budget_data = await get_budget_data(client, start_date, end_date)
-        return json_success(format_budget_data(budget_data))
+        raw, used_flex_query = await get_budget_data(client, start_date, end_date)
+        return json_success(
+            {
+                "tool": "get_budgets",
+                "args": {"start_date": start_date, "end_date": end_date},
+                "data": format_budget_data(raw),
+                "flex": format_flex_budget(raw, used_flex_query),
+                "totals": format_budget_totals(raw, used_flex_query),
+            }
+        )
     except Exception as e:
         return json_error("get_budgets", e)
 
@@ -153,6 +414,9 @@ async def set_budget_amount(
 
     Use get_budgets() first to see current budgets and category IDs.
     Use get_categories() or get_category_groups() to find category/group IDs.
+
+    Note: this cannot set the all-up Flexible bucket amount -- that bucket is
+    not a category group. Use set_flexible_budget() for it.
 
     Args:
         amount: The budget amount to set. Use 0 to clear/unset the budget.
@@ -210,3 +474,63 @@ async def set_budget_amount(
         })
     except Exception as e:
         return json_error("set_budget_amount", e)
+
+
+@mcp.tool()
+async def set_flexible_budget(
+    amount: float,
+    start_date: Optional[str] = None,
+    apply_to_future: bool = False,
+) -> str:
+    """
+    Set the all-up Flexible bucket budget (Monarch's "fixed_and_flex" system).
+
+    This is the single amount covering every category in the Flexible section.
+    It is not a category or a category group, so set_budget_amount() cannot
+    reach it.
+
+    Args:
+        amount: The budget amount to set. Use 0 to clear/unset it.
+        start_date: The month to set in YYYY-MM-DD format (defaults to current month)
+        apply_to_future: Whether to apply this amount to all future months
+
+    Returns:
+        Result of the update.
+    """
+    try:
+        if _flex_supported is False:
+            return json_success({
+                "success": False,
+                "error": (
+                    "This account does not appear to support Monarch's flexible "
+                    "budget bucket -- the API rejected the flex fields on an "
+                    "earlier get_budgets call."
+                ),
+            })
+
+        client = await get_monarch_client()
+
+        updater = getattr(client, "update_flexible_budget", None)
+        if updater is None:
+            return json_success({
+                "success": False,
+                "error": (
+                    "The installed monarchmoney client has no "
+                    "update_flexible_budget(); upgrade monarchmoneycommunity."
+                ),
+            })
+
+        result = await updater(
+            amount=amount,
+            start_date=start_date,
+            apply_to_future=apply_to_future,
+        )
+
+        return json_success({
+            "success": True,
+            "message": f"Flexible budget set to ${amount:.2f}"
+                       + (" for all future months" if apply_to_future else ""),
+            "result": result,
+        })
+    except Exception as e:
+        return json_error("set_flexible_budget", e)

--- a/src/monarch_mcp_server/tools/budgets.py
+++ b/src/monarch_mcp_server/tools/budgets.py
@@ -61,15 +61,23 @@ _BUDGET_DOCUMENT = """
     }
 """
 
-# Bucket-level amounts Monarch exposes for the "fixed_and_flex" budget system.
-# Under that system the Flexible section carries a single amount covering every
-# category beneath it; without these selections that number is invisible and
-# spending-vs-budget for Flexible cannot be computed (issue #103).
+# Roll-up amounts Monarch exposes above the per-category level. All live under
+# budgetData, so requesting them never widens the categoryGroups selection.
+#
+# - monthlyAmountsForFlexExpense: under the "fixed_and_flex" system the Flexible
+#   section carries a single amount covering every category beneath it. Flexible
+#   is the only *pooled* bucket -- Fixed and Non-Monthly are budgeted per
+#   category, so their numbers are sums and appear in totalsByMonth (issue #103).
+# - monthlyAmountsByCategoryGroup: group-level amounts, for groups budgeted at
+#   the group level rather than per category.
+# - totalsByMonth: income and overall expense totals alongside the three
+#   expense buckets.
 #
 # Note: `budgetVariability` appears here under monthlyAmountsForFlexExpense,
 # a *different* subtree from the categoryGroups.budgetVariability field
-# implicated in the original failure.
-_FLEX_SELECTIONS = """
+# implicated in the original failure. groupLevelBudgetingEnabled is
+# deliberately NOT requested -- it lives on categoryGroups, which stays narrow.
+_EXTENDED_SELECTIONS = """
         monthlyAmountsForFlexExpense {
           budgetVariability
           monthlyAmounts {
@@ -83,8 +91,38 @@ _FLEX_SELECTIONS = """
           }
           __typename
         }
+        monthlyAmountsByCategoryGroup {
+          categoryGroup {
+            id
+            __typename
+          }
+          monthlyAmounts {
+            month
+            plannedCashFlowAmount
+            actualAmount
+            remainingAmount
+            previousMonthRolloverAmount
+            rolloverType
+            __typename
+          }
+          __typename
+        }
         totalsByMonth {
           month
+          totalIncome {
+            plannedAmount
+            actualAmount
+            remainingAmount
+            previousMonthRolloverAmount
+            __typename
+          }
+          totalExpenses {
+            plannedAmount
+            actualAmount
+            remainingAmount
+            previousMonthRolloverAmount
+            __typename
+          }
           totalFlexibleExpenses {
             plannedAmount
             actualAmount
@@ -116,7 +154,7 @@ BUDGET_QUERY = gql(
 # Tried first; falls back to BUDGET_QUERY when Monarch refuses these fields.
 BUDGET_QUERY_FLEX = gql(
     _BUDGET_DOCUMENT
-    % {"operation": "MCPBudgetDataFlex", "flex_selections": _FLEX_SELECTIONS}
+    % {"operation": "MCPBudgetDataFlex", "flex_selections": _EXTENDED_SELECTIONS}
 )
 
 # Cached for the life of the process: None = not yet probed, True = the flex
@@ -335,6 +373,8 @@ def format_budget_totals(
     return [
         {
             "month": total.get("month"),
+            "income": _totals_entry(total.get("totalIncome")),
+            "expenses": _totals_entry(total.get("totalExpenses")),
             "flexible": _totals_entry(total.get("totalFlexibleExpenses")),
             "fixed": _totals_entry(total.get("totalFixedExpenses")),
             "non_monthly": _totals_entry(total.get("totalNonMonthlyExpenses")),
@@ -342,6 +382,52 @@ def format_budget_totals(
         for total in totals
         if total
     ]
+
+
+def format_group_budgets(
+    budget_data: Dict[str, Any], used_flex_query: bool
+) -> Optional[List[Dict[str, Any]]]:
+    """One row per category group per month, or None when unavailable.
+
+    Groups budgeted at the group level rather than per category hold their
+    amount here; for every other group this is the roll-up of its categories.
+    """
+    if not used_flex_query:
+        return None
+
+    by_group = (budget_data.get("budgetData") or {}).get(
+        "monthlyAmountsByCategoryGroup"
+    )
+    if not by_group:
+        return None
+
+    group_names: Dict[str, Optional[str]] = {
+        group.get("id"): group.get("name")
+        for group in budget_data.get("categoryGroups") or []
+        if group.get("id")
+    }
+
+    rows: List[Dict[str, Any]] = []
+    for entry in by_group:
+        if not entry:
+            continue
+        group_id = (entry.get("categoryGroup") or {}).get("id")
+        for amount in entry.get("monthlyAmounts") or []:
+            if not amount:
+                continue
+            rows.append(
+                {
+                    "id": group_id,
+                    "name": group_names.get(group_id),
+                    "planned": amount.get("plannedCashFlowAmount"),
+                    "actual": amount.get("actualAmount"),
+                    "remaining": amount.get("remainingAmount"),
+                    "rollover": amount.get("previousMonthRolloverAmount"),
+                    "month": amount.get("month"),
+                }
+            )
+
+    return rows
 
 
 @mcp.tool()
@@ -370,9 +456,17 @@ async def get_budgets(
         category in the Flexible section, so this -- not the per-category rows
         -- is the number to compare spending against. A ``status`` other than
         ``ok`` means no amount is available; do NOT treat that as zero.
+        Flexible is the only pooled bucket: Fixed and Non-Monthly are budgeted
+        per category, so their per-category rows in ``data`` are complete.
 
-        ``totals`` - per-month ``flexible`` / ``fixed`` / ``non_monthly``
-        totals, or null when this account does not expose them.
+        ``groups`` - one row per category group per month (``id``, ``name``,
+        ``planned``, ``actual``, ``remaining``, ``rollover``, ``month``), or
+        null when unavailable. Groups budgeted at the group level rather than
+        per category hold their amount here.
+
+        ``totals`` - per-month ``income``, ``expenses``, ``flexible``,
+        ``fixed`` and ``non_monthly`` totals, or null when this account does
+        not expose them.
     """
     try:
         client = await get_monarch_client()
@@ -383,6 +477,7 @@ async def get_budgets(
                 "args": {"start_date": start_date, "end_date": end_date},
                 "data": format_budget_data(raw),
                 "flex": format_flex_budget(raw, used_flex_query),
+                "groups": format_group_budgets(raw, used_flex_query),
                 "totals": format_budget_totals(raw, used_flex_query),
             }
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,6 +263,16 @@ _TOOL_MODULES = [
 
 
 @pytest.fixture(autouse=True)
+def reset_budget_flex_support():
+    """Keep tests independent of budgets.py's per-process flex-support cache."""
+    from monarch_mcp_server.tools import budgets
+
+    budgets.reset_flex_support()
+    yield
+    budgets.reset_flex_support()
+
+
+@pytest.fixture(autouse=True)
 def patch_monarch_client(mock_monarch_client):
     """Automatically patch get_monarch_client wherever it's imported."""
     patchers = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,16 +263,6 @@ _TOOL_MODULES = [
 
 
 @pytest.fixture(autouse=True)
-def reset_budget_flex_support():
-    """Keep tests independent of budgets.py's per-process flex-support cache."""
-    from monarch_mcp_server.tools import budgets
-
-    budgets.reset_flex_support()
-    yield
-    budgets.reset_flex_support()
-
-
-@pytest.fixture(autouse=True)
 def patch_monarch_client(mock_monarch_client):
     """Automatically patch get_monarch_client wherever it's imported."""
     patchers = []

--- a/tests/test_budgets.py
+++ b/tests/test_budgets.py
@@ -172,13 +172,36 @@ class TestGetBudgets:
         assert result["tool"] == "get_budgets"
         assert "data" not in result
 
-    async def test_rejects_a_half_specified_date_range(self):
+    @pytest.mark.parametrize(
+        "kwargs",
+        [{"start_date": "2026-12-01"}, {"end_date": "2026-03-31"}],
+    )
+    async def test_rejects_a_half_specified_date_range(
+        self, kwargs, mock_monarch_client
+    ):
         # Filling the missing side from the current month can invert the range,
         # which returns nothing and reads as "this account has no budget".
-        result = json.loads(await get_budgets(start_date="2026-12-01"))
+        # Both directions matter: either one can produce start > end.
+        result = json.loads(await get_budgets(**kwargs))
 
         assert result["error"] is True
         assert "together" in result["message"]
+        # Rejected before any request went out.
+        mock_monarch_client.gql_call.assert_not_awaited()
+
+    async def test_get_budget_data_raises_on_a_half_specified_range(
+        self, mock_monarch_client
+    ):
+        # Pin the helper's contract directly, not just the envelope the tool
+        # wraps it in -- and pin the exception type.
+        with pytest.raises(ValueError):
+            await budgets_module.get_budget_data(
+                mock_monarch_client, start_date="2026-12-01"
+            )
+        with pytest.raises(ValueError):
+            await budgets_module.get_budget_data(
+                mock_monarch_client, end_date="2026-12-31"
+            )
 
     async def test_survives_explicit_nulls_in_the_response(
         self, mock_monarch_client
@@ -362,6 +385,26 @@ class TestFlexBucket:
         # Archived goals are surfaced but flagged, not silently dropped.
         assert goals[1]["archived"] is True
 
+    async def test_flags_completed_goals(self, mock_monarch_client):
+        enriched = with_flex(mock_monarch_client.gql_call.return_value)
+        enriched["goalsV2"] = [
+            {
+                "id": "goal-3",
+                "name": "Car Fund",
+                "priority": 1,
+                "archivedAt": None,
+                "completedAt": "2026-02-01",
+                "plannedContributions": [],
+                "monthlyContributionSummaries": [],
+            }
+        ]
+        mock_monarch_client.gql_call.return_value = enriched
+
+        goal = json.loads(await get_budgets())["goals"][0]
+
+        assert goal["completed"] is True
+        assert goal["archived"] is False
+
     async def test_goals_empty_when_account_has_none(self):
         assert json.loads(await get_budgets())["goals"] == []
 
@@ -386,6 +429,37 @@ class TestFlexBucket:
         await get_budgets()
         _, kwargs = mock_monarch_client.gql_call.call_args
         assert kwargs["operation"] == "MCPBudgetDataFlex"
+
+    @staticmethod
+    def _assert_operation_matches_document(call):
+        """The operation name must be the one inside the document sent with it.
+
+        The client forwards `operation` as operation_name, so a mismatched pair
+        is rejected by the real server -- which _is_query_rejection reads as
+        "no flex here", permanently degrading every account. Checking each
+        document in isolation cannot catch a swap at the call site.
+        """
+        operation = call.kwargs["operation"]
+        document = call.kwargs["graphql_query"]
+        node = getattr(document, "document", document)
+        assert f"query {operation}(" in node.loc.source.body, (
+            f"operation {operation!r} was sent with a document that does not "
+            f"declare it"
+        )
+
+    async def test_each_call_pairs_its_operation_with_the_right_document(
+        self, mock_monarch_client
+    ):
+        base = mock_monarch_client.gql_call.return_value
+        mock_monarch_client.gql_call.side_effect = reject_flex_only(base)
+
+        # Exercises both the extended call and the narrow fallback.
+        await get_budgets()
+
+        calls = mock_monarch_client.gql_call.call_args_list
+        assert len(calls) == 2
+        for call in calls:
+            self._assert_operation_matches_document(call)
 
     async def test_not_configured_when_account_has_no_flex_bucket(self):
         # The default fixture response omits the flex selections entirely.

--- a/tests/test_budgets.py
+++ b/tests/test_budgets.py
@@ -6,7 +6,11 @@ import pytest
 from gql.transport.exceptions import TransportQueryError, TransportServerError
 
 from monarch_mcp_server.tools import budgets as budgets_module
-from monarch_mcp_server.tools.budgets import get_budgets, set_flexible_budget
+from monarch_mcp_server.tools.budgets import (
+    get_budgets,
+    set_flexible_budget,
+    update_flex_rollover_settings,
+)
 
 FLEX_BLOCK = {
     "budgetVariability": "flexible",
@@ -385,3 +389,70 @@ class TestSetFlexibleBudget:
         result = json.loads(await set_flexible_budget(amount=100))
         assert result["error"] is True
         assert result["tool"] == "set_flexible_budget"
+
+
+class TestUpdateFlexRolloverSettings:
+    async def test_passes_explicit_values_through(self, mock_monarch_client):
+        mock_monarch_client.update_flex_rollover_settings.return_value = {
+            "updateBudgetSettings": {"budgetRolloverPeriod": {"id": "rp-1"}}
+        }
+
+        result = json.loads(
+            await update_flex_rollover_settings(
+                rollover_start_month="2026-08-01", rollover_starting_balance=0
+            )
+        )
+
+        assert result["success"] is True
+        mock_monarch_client.update_flex_rollover_settings.assert_awaited_once_with(
+            rollover_start_month="2026-08-01",
+            rollover_starting_balance=0,
+            rollover_enabled=True,
+        )
+
+    def test_destructive_arguments_are_required(self):
+        # The client defaults to "balance 0, current month" -- a silent full
+        # reset. The tool must force the caller to state both explicitly.
+        import inspect
+
+        params = inspect.signature(update_flex_rollover_settings).parameters
+        assert params["rollover_start_month"].default is inspect.Parameter.empty
+        assert params["rollover_starting_balance"].default is inspect.Parameter.empty
+
+    async def test_refuses_when_flex_known_unsupported(self, mock_monarch_client):
+        budgets_module._flex_supported = False
+
+        result = json.loads(
+            await update_flex_rollover_settings(
+                rollover_start_month="2026-08-01", rollover_starting_balance=0
+            )
+        )
+
+        assert result["success"] is False
+        mock_monarch_client.update_flex_rollover_settings.assert_not_awaited()
+
+    async def test_reports_missing_client_method(self, mock_monarch_client):
+        del mock_monarch_client.update_flex_rollover_settings
+
+        result = json.loads(
+            await update_flex_rollover_settings(
+                rollover_start_month="2026-08-01", rollover_starting_balance=0
+            )
+        )
+
+        assert result["success"] is False
+        assert "update_flex_rollover_settings" in result["error"]
+
+    async def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.update_flex_rollover_settings.side_effect = Exception(
+            "boom"
+        )
+
+        result = json.loads(
+            await update_flex_rollover_settings(
+                rollover_start_month="2026-08-01", rollover_starting_balance=0
+            )
+        )
+
+        assert result["error"] is True
+        assert result["tool"] == "update_flex_rollover_settings"

--- a/tests/test_budgets.py
+++ b/tests/test_budgets.py
@@ -251,6 +251,53 @@ class TestFlexBucket:
     async def test_budget_system_null_when_absent(self):
         assert json.loads(await get_budgets())["budget_system"] is None
 
+    async def test_reports_goals_with_planned_and_actual_contributions(
+        self, mock_monarch_client
+    ):
+        enriched = with_flex(mock_monarch_client.gql_call.return_value)
+        enriched["goalsV2"] = [
+            {
+                "id": "goal-1",
+                "name": "Emergency Fund",
+                "priority": 1,
+                "archivedAt": None,
+                "completedAt": None,
+                "plannedContributions": [
+                    {"id": "pc-1", "month": "2026-03-01", "amount": 400.00}
+                ],
+                "monthlyContributionSummaries": [
+                    {"month": "2026-03-01", "sum": 250.00}
+                ],
+            },
+            {
+                "id": "goal-2",
+                "name": "Old Goal",
+                "priority": 2,
+                "archivedAt": "2026-01-01",
+                "completedAt": None,
+                "plannedContributions": [],
+                "monthlyContributionSummaries": [],
+            },
+        ]
+        mock_monarch_client.gql_call.return_value = enriched
+
+        goals = json.loads(await get_budgets())["goals"]
+
+        assert goals[0] == {
+            "id": "goal-1",
+            "name": "Emergency Fund",
+            "priority": 1,
+            "archived": False,
+            "completed": False,
+            "planned_contributions": [{"month": "2026-03-01", "amount": 400.00}],
+            "actual_contributions": [{"month": "2026-03-01", "amount": 250.00}],
+        }
+        # Archived goals are surfaced but flagged, not silently dropped.
+        assert goals[1]["archived"] is True
+
+    async def test_goals_null_when_unavailable(self):
+        assert json.loads(await get_budgets())["goals"] is None
+
     async def test_prefers_the_flex_query(self, mock_monarch_client):
         await get_budgets()
         _, kwargs = mock_monarch_client.gql_call.call_args

--- a/tests/test_budgets.py
+++ b/tests/test_budgets.py
@@ -120,6 +120,9 @@ class TestGetBudgets:
             "planned": 500.00,
             "actual": 320.00,
             "remaining": 180.00,
+            "set_aside": 0.00,
+            "rollover": None,
+            "rollover_type": None,
             "category_group": "Food",
             "month": "2026-03-01",
         }
@@ -211,6 +214,38 @@ class TestFlexBucket:
     async def test_groups_null_when_unavailable(self):
         # Default fixture omits the group selection entirely.
         assert json.loads(await get_budgets())["groups"] is None
+
+    async def test_surfaces_rollover_so_remaining_reconciles(
+        self, mock_monarch_client
+    ):
+        enriched = with_flex(mock_monarch_client.gql_call.return_value)
+        amounts = enriched["budgetData"]["monthlyAmountsByCategory"][0][
+            "monthlyAmounts"
+        ][0]
+        # A rollover category: planned - actual (180) != remaining (430).
+        amounts["remainingAmount"] = 430.00
+        amounts["previousMonthRolloverAmount"] = 250.00
+        amounts["rolloverType"] = "monthly"
+        mock_monarch_client.gql_call.return_value = enriched
+
+        row = next(
+            r for r in json.loads(await get_budgets())["data"] if r["id"] == "cat-1"
+        )
+
+        assert row["rollover"] == 250.00
+        assert row["rollover_type"] == "monthly"
+        # The gap is now explainable rather than looking like bad data.
+        assert row["planned"] - row["actual"] + row["rollover"] == row["remaining"]
+
+    async def test_reports_budget_system(self, mock_monarch_client):
+        enriched = with_flex(mock_monarch_client.gql_call.return_value)
+        enriched["budgetSystem"] = "fixed_and_flex"
+        mock_monarch_client.gql_call.return_value = enriched
+
+        assert json.loads(await get_budgets())["budget_system"] == "fixed_and_flex"
+
+    async def test_budget_system_null_when_absent(self):
+        assert json.loads(await get_budgets())["budget_system"] is None
 
     async def test_prefers_the_flex_query(self, mock_monarch_client):
         await get_budgets()

--- a/tests/test_budgets.py
+++ b/tests/test_budgets.py
@@ -2,15 +2,78 @@
 
 import json
 
-from monarch_mcp_server.tools.budgets import get_budgets
+import pytest
+
+from monarch_mcp_server.tools import budgets as budgets_module
+from monarch_mcp_server.tools.budgets import get_budgets, set_flexible_budget
+
+FLEX_BLOCK = {
+    "budgetVariability": "flexible",
+    "monthlyAmounts": [
+        {
+            "month": "2026-03-01",
+            "plannedCashFlowAmount": 2000.00,
+            "actualAmount": 1250.00,
+            "remainingAmount": 750.00,
+            "previousMonthRolloverAmount": 0.00,
+            "rolloverType": "monthly",
+        }
+    ],
+}
+
+TOTALS_BLOCK = [
+    {
+        "month": "2026-03-01",
+        "totalFlexibleExpenses": {
+            "plannedAmount": 2000.00,
+            "actualAmount": 1250.00,
+            "remainingAmount": 750.00,
+            "previousMonthRolloverAmount": 0.00,
+        },
+        "totalFixedExpenses": {
+            "plannedAmount": 1500.00,
+            "actualAmount": 1500.00,
+            "remainingAmount": 0.00,
+            "previousMonthRolloverAmount": 0.00,
+        },
+        "totalNonMonthlyExpenses": {
+            "plannedAmount": 300.00,
+            "actualAmount": 100.00,
+            "remainingAmount": 200.00,
+            "previousMonthRolloverAmount": 0.00,
+        },
+    }
+]
+
+
+def with_flex(base_response):
+    """Copy the default fixture response, adding flex + totals selections."""
+    enriched = json.loads(json.dumps(base_response))
+    enriched["budgetData"]["monthlyAmountsForFlexExpense"] = FLEX_BLOCK
+    enriched["budgetData"]["totalsByMonth"] = TOTALS_BLOCK
+    return enriched
+
+
+def reject_flex_only(base_response):
+    """side_effect that rejects the flex query but serves the narrow one."""
+
+    def _side_effect(*args, **kwargs):
+        if kwargs.get("operation") == "MCPBudgetDataFlex":
+            raise Exception(
+                "Cannot query field 'monthlyAmountsForFlexExpense' on type 'BudgetData'."
+            )
+        return base_response
+
+    return _side_effect
 
 
 class TestGetBudgets:
     async def test_returns_formatted_category_rows(self):
         result = json.loads(await get_budgets())
-        assert isinstance(result, list)
-        assert len(result) == 2
-        groceries = next(row for row in result if row["id"] == "cat-1")
+        assert result["tool"] == "get_budgets"
+        rows = result["data"]
+        assert len(rows) == 2
+        groceries = next(row for row in rows if row["id"] == "cat-1")
         assert groceries == {
             "id": "cat-1",
             "name": "Groceries",
@@ -41,3 +104,149 @@ class TestGetBudgets:
         mock_monarch_client.gql_call.side_effect = Exception("Budget error")
         result = await get_budgets()
         assert "get_budgets" in result
+
+
+class TestFlexBucket:
+    async def test_reports_flex_bucket_when_present(self, mock_monarch_client):
+        mock_monarch_client.gql_call.return_value = with_flex(
+            mock_monarch_client.gql_call.return_value
+        )
+
+        result = json.loads(await get_budgets())
+
+        assert result["flex"] == {
+            "status": "ok",
+            "budget_variability": "flexible",
+            "monthly": [
+                {
+                    "month": "2026-03-01",
+                    "planned": 2000.00,
+                    "actual": 1250.00,
+                    "remaining": 750.00,
+                    "rollover": 0.00,
+                    "rollover_type": "monthly",
+                }
+            ],
+        }
+        assert result["totals"][0]["flexible"]["planned"] == 2000.00
+        assert result["totals"][0]["fixed"]["remaining"] == 0.00
+        assert result["totals"][0]["non_monthly"]["actual"] == 100.00
+
+    async def test_prefers_the_flex_query(self, mock_monarch_client):
+        await get_budgets()
+        _, kwargs = mock_monarch_client.gql_call.call_args
+        assert kwargs["operation"] == "MCPBudgetDataFlex"
+
+    async def test_not_configured_when_account_has_no_flex_bucket(self):
+        # The default fixture response omits the flex selections entirely.
+        result = json.loads(await get_budgets())
+        assert result["flex"]["status"] == "not_configured"
+        assert result["flex"]["monthly"] == []
+        assert result["totals"] is None
+        # Category rows are unaffected.
+        assert len(result["data"]) == 2
+
+    async def test_falls_back_to_narrow_query_when_flex_rejected(
+        self, mock_monarch_client
+    ):
+        base = mock_monarch_client.gql_call.return_value
+        mock_monarch_client.gql_call.side_effect = reject_flex_only(base)
+
+        result = json.loads(await get_budgets())
+
+        assert result["flex"]["status"] == "unsupported"
+        assert result["totals"] is None
+        # The whole tool still works -- this is the no-regression guarantee.
+        assert len(result["data"]) == 2
+        operations = [
+            call.kwargs["operation"]
+            for call in mock_monarch_client.gql_call.call_args_list
+        ]
+        assert operations == ["MCPBudgetDataFlex", "MCPBudgetData"]
+
+    async def test_caches_rejection_and_skips_retrying_flex(
+        self, mock_monarch_client
+    ):
+        base = mock_monarch_client.gql_call.return_value
+        mock_monarch_client.gql_call.side_effect = reject_flex_only(base)
+
+        await get_budgets()
+        await get_budgets()
+
+        operations = [
+            call.kwargs["operation"]
+            for call in mock_monarch_client.gql_call.call_args_list
+        ]
+        # First call probes then falls back; the second goes straight to narrow.
+        assert operations == [
+            "MCPBudgetDataFlex",
+            "MCPBudgetData",
+            "MCPBudgetData",
+        ]
+
+    async def test_auth_error_propagates_and_does_not_disable_flex(
+        self, mock_monarch_client
+    ):
+        mock_monarch_client.gql_call.side_effect = Exception(
+            "401 Unauthorized: session expired"
+        )
+
+        result = json.loads(await get_budgets())
+
+        # Surfaced as an error rather than silently degraded to a partial answer.
+        assert result["error"] is True
+        assert result["tool"] == "get_budgets"
+        # A transport/auth failure must not latch flex off for the process.
+        assert budgets_module._flex_supported is None
+
+    @pytest.mark.parametrize(
+        "message,expected",
+        [
+            ("Cannot query field 'totalsByMonth'", True),
+            ("Unknown field monthlyAmountsForFlexExpense", True),
+            ("401 Unauthorized", False),
+            ("Connection reset by peer", False),
+            ("", False),
+        ],
+    )
+    def test_schema_rejection_detection(self, message, expected):
+        assert (
+            budgets_module._is_schema_rejection(Exception(message)) is expected
+        )
+
+
+class TestSetFlexibleBudget:
+    async def test_sets_amount(self, mock_monarch_client):
+        mock_monarch_client.update_flexible_budget.return_value = {
+            "updateOrCreateFlexBudgetItem": {"budgetItem": {"id": "flex-1"}}
+        }
+
+        result = json.loads(await set_flexible_budget(amount=2000, apply_to_future=True))
+
+        assert result["success"] is True
+        mock_monarch_client.update_flexible_budget.assert_awaited_once_with(
+            amount=2000, start_date=None, apply_to_future=True
+        )
+
+    async def test_refuses_when_flex_known_unsupported(self, mock_monarch_client):
+        budgets_module._flex_supported = False
+
+        result = json.loads(await set_flexible_budget(amount=100))
+
+        assert result["success"] is False
+        assert "flexible budget" in result["error"].lower()
+        mock_monarch_client.update_flexible_budget.assert_not_awaited()
+
+    async def test_reports_missing_client_method(self, mock_monarch_client):
+        del mock_monarch_client.update_flexible_budget
+
+        result = json.loads(await set_flexible_budget(amount=100))
+
+        assert result["success"] is False
+        assert "update_flexible_budget" in result["error"]
+
+    async def test_handles_api_error(self, mock_monarch_client):
+        mock_monarch_client.update_flexible_budget.side_effect = Exception("boom")
+        result = json.loads(await set_flexible_budget(amount=100))
+        assert result["error"] is True
+        assert result["tool"] == "set_flexible_budget"

--- a/tests/test_budgets.py
+++ b/tests/test_budgets.py
@@ -1,6 +1,8 @@
 """Tests for budget-related MCP tools."""
 
+import calendar
 import json
+from datetime import date
 
 import pytest
 from gql.transport.exceptions import TransportQueryError, TransportServerError
@@ -128,6 +130,8 @@ class TestGetBudgets:
             "rollover": None,
             "rollover_type": None,
             "category_group": "Food",
+            "category_type": "expense",
+            "budget_variability": None,
             "month": "2026-03-01",
         }
 
@@ -140,17 +144,63 @@ class TestGetBudgets:
         }
 
     async def test_defaults_to_current_month(self, mock_monarch_client):
-        from monarch_mcp_server.tools.budgets import current_month_range
-
-        start, end = current_month_range()
+        # Deliberately does NOT call current_month_range() to build the
+        # expectation -- that would restate the implementation. Pin the shape
+        # independently instead.
         await get_budgets()
         _, kwargs = mock_monarch_client.gql_call.call_args
-        assert kwargs["variables"] == {"startDate": start, "endDate": end}
+        start = kwargs["variables"]["startDate"]
+        end = kwargs["variables"]["endDate"]
+
+        today = date.today()
+        assert start == today.replace(day=1).isoformat()
+        assert start.endswith("-01")
+        last_day = calendar.monthrange(today.year, today.month)[1]
+        assert end == today.replace(day=last_day).isoformat()
+        assert start <= end
 
     async def test_handles_api_error(self, mock_monarch_client):
         mock_monarch_client.gql_call.side_effect = Exception("Budget error")
-        result = await get_budgets()
-        assert "get_budgets" in result
+
+        result = json.loads(await get_budgets())
+
+        # Must be a real error envelope. Asserting only `"get_budgets" in
+        # result` would also match the SUCCESS payload, which carries
+        # "tool": "get_budgets" -- so a regression rendering an outage as an
+        # empty-but-successful budget would pass.
+        assert result["error"] is True
+        assert result["tool"] == "get_budgets"
+        assert "data" not in result
+
+    async def test_rejects_a_half_specified_date_range(self):
+        # Filling the missing side from the current month can invert the range,
+        # which returns nothing and reads as "this account has no budget".
+        result = json.loads(await get_budgets(start_date="2026-12-01"))
+
+        assert result["error"] is True
+        assert "together" in result["message"]
+
+    async def test_survives_explicit_nulls_in_the_response(
+        self, mock_monarch_client
+    ):
+        # GraphQL returns explicit null for nullable fields; `.get(k, default)`
+        # does not catch that, and one such null used to take out the tool.
+        for response in (
+            {"budgetData": None, "categoryGroups": None},
+            {"budgetData": {"monthlyAmountsByCategory": None}, "categoryGroups": []},
+            {
+                "budgetData": {"monthlyAmountsByCategory": [None]},
+                "categoryGroups": [None],
+            },
+            {
+                "budgetData": {"monthlyAmountsByCategory": []},
+                "categoryGroups": [{"id": "g", "name": "G", "categories": None}],
+            },
+        ):
+            mock_monarch_client.gql_call.return_value = response
+            result = json.loads(await get_budgets())
+            assert result.get("error") is not True, response
+            assert result["data"] == []
 
 
 class TestFlexBucket:
@@ -211,13 +261,30 @@ class TestFlexBucket:
                 "actual": 505.00,
                 "remaining": 195.00,
                 "rollover": 0.00,
+                "rollover_type": "monthly",
+                "category_type": "expense",
+                "group_level_budgeting": None,
                 "month": "2026-03-01",
             }
         ]
 
-    async def test_groups_null_when_unavailable(self):
-        # Default fixture omits the group selection entirely.
-        assert json.loads(await get_budgets())["groups"] is None
+    async def test_groups_empty_when_query_ran_but_returned_none(self):
+        # Default fixture omits the group selection: the query succeeded, so
+        # [] (asked, none there) rather than null (could not ask).
+        assert json.loads(await get_budgets())["groups"] == []
+
+    async def test_group_rows_flag_authoritative_group_budgets(
+        self, mock_monarch_client
+    ):
+        enriched = with_flex(mock_monarch_client.gql_call.return_value)
+        enriched["categoryGroups"][0]["groupLevelBudgetingEnabled"] = True
+        mock_monarch_client.gql_call.return_value = enriched
+
+        groups = json.loads(await get_budgets())["groups"]
+
+        # True => the group holds the budget; False/None => it is a roll-up of
+        # its categories, and adding both double-counts.
+        assert groups[0]["group_level_budgeting"] is True
 
     async def test_surfaces_rollover_so_remaining_reconciles(
         self, mock_monarch_client
@@ -295,8 +362,25 @@ class TestFlexBucket:
         # Archived goals are surfaced but flagged, not silently dropped.
         assert goals[1]["archived"] is True
 
-    async def test_goals_null_when_unavailable(self):
-        assert json.loads(await get_budgets())["goals"] is None
+    async def test_goals_empty_when_account_has_none(self):
+        assert json.loads(await get_budgets())["goals"] == []
+
+    async def test_everything_extended_is_null_on_the_fallback_path(
+        self, mock_monarch_client
+    ):
+        # When the extended query is refused, null must mean "not available"
+        # across the board -- never zero, and never "the account has none".
+        base = mock_monarch_client.gql_call.return_value
+        mock_monarch_client.gql_call.side_effect = reject_flex_only(base)
+
+        result = json.loads(await get_budgets())
+
+        assert result["flex"]["status"] == "unsupported"
+        assert result["groups"] is None
+        assert result["goals"] is None
+        assert result["totals"] is None
+        assert result["budget_system"] is None
+        assert all(row["rollover"] is None for row in result["data"])
 
     async def test_prefers_the_flex_query(self, mock_monarch_client):
         await get_budgets()
@@ -308,7 +392,7 @@ class TestFlexBucket:
         result = json.loads(await get_budgets())
         assert result["flex"]["status"] == "not_configured"
         assert result["flex"]["monthly"] == []
-        assert result["totals"] is None
+        assert result["totals"] == []
         # Category rows are unaffected.
         assert len(result["data"]) == 2
 
@@ -331,7 +415,32 @@ class TestFlexBucket:
         ]
         assert operations == ["MCPBudgetDataFlex", "MCPBudgetData"]
 
-    async def test_caches_rejection_and_skips_retrying_flex(
+    async def test_a_transient_rejection_does_not_stick(self, mock_monarch_client):
+        # gql raises TransportQueryError for ANY GraphQL `errors` array --
+        # a rate limit, a resolver hiccup, a partial success. Caching
+        # "unsupported" off one of those would strip flex, groups, goals,
+        # totals and rollover from every later call for the whole process.
+        base = mock_monarch_client.gql_call.return_value
+        calls = {"n": 0}
+
+        def flaky(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise monarch_rejection()
+            if kwargs.get("operation") == "MCPBudgetDataFlex":
+                return with_flex(base)
+            return base
+
+        mock_monarch_client.gql_call.side_effect = flaky
+
+        first = json.loads(await get_budgets())
+        second = json.loads(await get_budgets())
+
+        assert first["flex"]["status"] == "unsupported"
+        # Recovered rather than staying degraded.
+        assert second["flex"]["status"] == "ok"
+
+    async def test_retries_flex_on_every_call_when_rejected(
         self, mock_monarch_client
     ):
         base = mock_monarch_client.gql_call.return_value
@@ -344,14 +453,33 @@ class TestFlexBucket:
             call.kwargs["operation"]
             for call in mock_monarch_client.gql_call.call_args_list
         ]
-        # First call probes then falls back; the second goes straight to narrow.
+        # Each call re-probes: one extra round-trip is the price of never
+        # reporting a transient failure as a permanent account limitation.
         assert operations == [
             "MCPBudgetDataFlex",
             "MCPBudgetData",
+            "MCPBudgetDataFlex",
             "MCPBudgetData",
         ]
 
-    async def test_auth_error_propagates_and_does_not_disable_flex(
+    async def test_fallback_reuses_the_callers_date_range(
+        self, mock_monarch_client
+    ):
+        base = mock_monarch_client.gql_call.return_value
+        mock_monarch_client.gql_call.side_effect = reject_flex_only(base)
+
+        await get_budgets(start_date="2026-03-01", end_date="2026-03-31")
+
+        variables = [
+            call.kwargs["variables"]
+            for call in mock_monarch_client.gql_call.call_args_list
+        ]
+        assert variables[0] == variables[1] == {
+            "startDate": "2026-03-01",
+            "endDate": "2026-03-31",
+        }
+
+    async def test_auth_error_propagates_rather_than_degrading(
         self, mock_monarch_client
     ):
         mock_monarch_client.gql_call.side_effect = TransportServerError(
@@ -363,20 +491,17 @@ class TestFlexBucket:
         # Surfaced as an error rather than silently degraded to a partial answer.
         assert result["error"] is True
         assert result["tool"] == "get_budgets"
-        # A transport/auth failure must not latch flex off for the process.
-        assert budgets_module._flex_supported is None
 
-    async def test_does_not_latch_when_the_fallback_also_fails(
+    async def test_propagates_when_the_fallback_also_fails(
         self, mock_monarch_client
     ):
         # An expired session refuses BOTH queries. That is not evidence the
-        # account lacks flex, so flex must stay un-probed for the next attempt.
+        # account lacks flex, so it must surface as an error.
         mock_monarch_client.gql_call.side_effect = monarch_rejection()
 
         result = json.loads(await get_budgets())
 
         assert result["error"] is True
-        assert budgets_module._flex_supported is None
 
     @pytest.mark.parametrize(
         "exc,expected",
@@ -414,14 +539,19 @@ class TestSetFlexibleBudget:
             amount=2000, start_date=None, apply_to_future=True
         )
 
-    async def test_refuses_when_flex_known_unsupported(self, mock_monarch_client):
-        budgets_module._flex_supported = False
+    async def test_does_not_claim_success_without_confirmation(
+        self, mock_monarch_client
+    ):
+        # A 200 whose payload node is null is not a successful write. Reporting
+        # "$2000 set" off a no-op would have the model state a false number.
+        mock_monarch_client.update_flexible_budget.return_value = {
+            "updateOrCreateFlexBudgetItem": {"budgetItem": None}
+        }
 
-        result = json.loads(await set_flexible_budget(amount=100))
+        result = json.loads(await set_flexible_budget(amount=2000))
 
         assert result["success"] is False
-        assert "flexible budget" in result["error"].lower()
-        mock_monarch_client.update_flexible_budget.assert_not_awaited()
+        assert "did not confirm" in result["error"]
 
     async def test_reports_missing_client_method(self, mock_monarch_client):
         del mock_monarch_client.update_flexible_budget
@@ -439,7 +569,14 @@ class TestSetFlexibleBudget:
 
 
 class TestUpdateFlexRolloverSettings:
+    @staticmethod
+    def _on_flex_account(mock_monarch_client, system="fixed_and_flex"):
+        enriched = with_flex(mock_monarch_client.gql_call.return_value)
+        enriched["budgetSystem"] = system
+        mock_monarch_client.gql_call.return_value = enriched
+
     async def test_passes_explicit_values_through(self, mock_monarch_client):
+        self._on_flex_account(mock_monarch_client)
         mock_monarch_client.update_flex_rollover_settings.return_value = {
             "updateBudgetSettings": {"budgetRolloverPeriod": {"id": "rp-1"}}
         }
@@ -451,23 +588,37 @@ class TestUpdateFlexRolloverSettings:
         )
 
         assert result["success"] is True
+        # budget_system MUST be forwarded: the client defaults it to
+        # "fixed_and_flex" and writes it into the mutation input, so omitting
+        # it would stamp that system onto whatever account this runs against.
         mock_monarch_client.update_flex_rollover_settings.assert_awaited_once_with(
             rollover_start_month="2026-08-01",
             rollover_starting_balance=0,
             rollover_enabled=True,
+            budget_system="fixed_and_flex",
         )
 
-    def test_destructive_arguments_are_required(self):
-        # The client defaults to "balance 0, current month" -- a silent full
-        # reset. The tool must force the caller to state both explicitly.
-        import inspect
+    async def test_refuses_on_a_non_flex_account(self, mock_monarch_client):
+        # The mutation rewrites budgetSystem as a side effect. On an account
+        # using another system that would migrate the whole budgeting mode --
+        # far more than the rollover reset the user confirmed.
+        self._on_flex_account(mock_monarch_client, system="category_groups")
 
-        params = inspect.signature(update_flex_rollover_settings).parameters
-        assert params["rollover_start_month"].default is inspect.Parameter.empty
-        assert params["rollover_starting_balance"].default is inspect.Parameter.empty
+        result = json.loads(
+            await update_flex_rollover_settings(
+                rollover_start_month="2026-08-01", rollover_starting_balance=0
+            )
+        )
 
-    async def test_refuses_when_flex_known_unsupported(self, mock_monarch_client):
-        budgets_module._flex_supported = False
+        assert result["success"] is False
+        assert "category_groups" in result["error"]
+        mock_monarch_client.update_flex_rollover_settings.assert_not_awaited()
+
+    async def test_refuses_when_budget_system_cannot_be_read(
+        self, mock_monarch_client
+    ):
+        base = mock_monarch_client.gql_call.return_value
+        mock_monarch_client.gql_call.side_effect = reject_flex_only(base)
 
         result = json.loads(
             await update_flex_rollover_settings(
@@ -478,7 +629,17 @@ class TestUpdateFlexRolloverSettings:
         assert result["success"] is False
         mock_monarch_client.update_flex_rollover_settings.assert_not_awaited()
 
+    def test_destructive_arguments_are_required(self):
+        # The client defaults to "balance 0, current month" -- a silent full
+        # reset. The tool must force the caller to state both explicitly.
+        import inspect
+
+        params = inspect.signature(update_flex_rollover_settings).parameters
+        assert params["rollover_start_month"].default is inspect.Parameter.empty
+        assert params["rollover_starting_balance"].default is inspect.Parameter.empty
+
     async def test_reports_missing_client_method(self, mock_monarch_client):
+        self._on_flex_account(mock_monarch_client)
         del mock_monarch_client.update_flex_rollover_settings
 
         result = json.loads(
@@ -491,6 +652,7 @@ class TestUpdateFlexRolloverSettings:
         assert "update_flex_rollover_settings" in result["error"]
 
     async def test_handles_api_error(self, mock_monarch_client):
+        self._on_flex_account(mock_monarch_client)
         mock_monarch_client.update_flex_rollover_settings.side_effect = Exception(
             "boom"
         )

--- a/tests/test_budgets.py
+++ b/tests/test_budgets.py
@@ -3,6 +3,7 @@
 import json
 
 import pytest
+from gql.transport.exceptions import TransportQueryError, TransportServerError
 
 from monarch_mcp_server.tools import budgets as budgets_module
 from monarch_mcp_server.tools.budgets import get_budgets, set_flexible_budget
@@ -54,14 +55,24 @@ def with_flex(base_response):
     return enriched
 
 
+def monarch_rejection():
+    """The error Monarch actually returns for a refused field.
+
+    Deliberately *not* standard GraphQL wording ("Cannot query field ..."):
+    Monarch answers with a generic message, so detection keys on the exception
+    type rather than the text. Using the real shape here keeps the test honest.
+    """
+    return TransportQueryError(
+        {"message": "Something went wrong while processing: None on request_id: None."}
+    )
+
+
 def reject_flex_only(base_response):
     """side_effect that rejects the flex query but serves the narrow one."""
 
     def _side_effect(*args, **kwargs):
         if kwargs.get("operation") == "MCPBudgetDataFlex":
-            raise Exception(
-                "Cannot query field 'monthlyAmountsForFlexExpense' on type 'BudgetData'."
-            )
+            raise monarch_rejection()
         return base_response
 
     return _side_effect
@@ -187,8 +198,8 @@ class TestFlexBucket:
     async def test_auth_error_propagates_and_does_not_disable_flex(
         self, mock_monarch_client
     ):
-        mock_monarch_client.gql_call.side_effect = Exception(
-            "401 Unauthorized: session expired"
+        mock_monarch_client.gql_call.side_effect = TransportServerError(
+            "401 Unauthorized", code=401
         )
 
         result = json.loads(await get_budgets())
@@ -199,20 +210,39 @@ class TestFlexBucket:
         # A transport/auth failure must not latch flex off for the process.
         assert budgets_module._flex_supported is None
 
+    async def test_does_not_latch_when_the_fallback_also_fails(
+        self, mock_monarch_client
+    ):
+        # An expired session refuses BOTH queries. That is not evidence the
+        # account lacks flex, so flex must stay un-probed for the next attempt.
+        mock_monarch_client.gql_call.side_effect = monarch_rejection()
+
+        result = json.loads(await get_budgets())
+
+        assert result["error"] is True
+        assert budgets_module._flex_supported is None
+
     @pytest.mark.parametrize(
-        "message,expected",
+        "exc,expected",
         [
-            ("Cannot query field 'totalsByMonth'", True),
-            ("Unknown field monthlyAmountsForFlexExpense", True),
-            ("401 Unauthorized", False),
-            ("Connection reset by peer", False),
-            ("", False),
+            # What Monarch really sends -- no GraphQL validation wording at all.
+            (
+                TransportQueryError(
+                    {"message": "Something went wrong while processing: None"}
+                ),
+                True,
+            ),
+            # Other transports that do use standard wording still match.
+            (Exception("Cannot query field 'totalsByMonth'"), True),
+            (Exception("Unknown field monthlyAmountsForFlexExpense"), True),
+            # Transport-level failures must not be read as "no flex bucket".
+            (TransportServerError("401 Unauthorized", code=401), False),
+            (Exception("Connection reset by peer"), False),
+            (Exception(""), False),
         ],
     )
-    def test_schema_rejection_detection(self, message, expected):
-        assert (
-            budgets_module._is_schema_rejection(Exception(message)) is expected
-        )
+    def test_query_rejection_detection(self, exc, expected):
+        assert budgets_module._is_query_rejection(exc) is expected
 
 
 class TestSetFlexibleBudget:

--- a/tests/test_budgets.py
+++ b/tests/test_budgets.py
@@ -22,9 +22,37 @@ FLEX_BLOCK = {
     ],
 }
 
+GROUPS_BLOCK = [
+    {
+        "categoryGroup": {"id": "grp-1"},
+        "monthlyAmounts": [
+            {
+                "month": "2026-03-01",
+                "plannedCashFlowAmount": 700.00,
+                "actualAmount": 505.00,
+                "remainingAmount": 195.00,
+                "previousMonthRolloverAmount": 0.00,
+                "rolloverType": "monthly",
+            }
+        ],
+    }
+]
+
 TOTALS_BLOCK = [
     {
         "month": "2026-03-01",
+        "totalIncome": {
+            "plannedAmount": 8000.00,
+            "actualAmount": 8000.00,
+            "remainingAmount": 0.00,
+            "previousMonthRolloverAmount": 0.00,
+        },
+        "totalExpenses": {
+            "plannedAmount": 3800.00,
+            "actualAmount": 2850.00,
+            "remainingAmount": 950.00,
+            "previousMonthRolloverAmount": 0.00,
+        },
         "totalFlexibleExpenses": {
             "plannedAmount": 2000.00,
             "actualAmount": 1250.00,
@@ -51,6 +79,7 @@ def with_flex(base_response):
     """Copy the default fixture response, adding flex + totals selections."""
     enriched = json.loads(json.dumps(base_response))
     enriched["budgetData"]["monthlyAmountsForFlexExpense"] = FLEX_BLOCK
+    enriched["budgetData"]["monthlyAmountsByCategoryGroup"] = GROUPS_BLOCK
     enriched["budgetData"]["totalsByMonth"] = TOTALS_BLOCK
     return enriched
 
@@ -143,6 +172,46 @@ class TestFlexBucket:
         assert result["totals"][0]["fixed"]["remaining"] == 0.00
         assert result["totals"][0]["non_monthly"]["actual"] == 100.00
 
+    async def test_reports_income_and_overall_expense_totals(
+        self, mock_monarch_client
+    ):
+        mock_monarch_client.gql_call.return_value = with_flex(
+            mock_monarch_client.gql_call.return_value
+        )
+
+        totals = json.loads(await get_budgets())["totals"][0]
+
+        assert totals["income"] == {
+            "planned": 8000.00,
+            "actual": 8000.00,
+            "remaining": 0.00,
+            "rollover": 0.00,
+        }
+        assert totals["expenses"]["planned"] == 3800.00
+
+    async def test_reports_group_level_budgets(self, mock_monarch_client):
+        mock_monarch_client.gql_call.return_value = with_flex(
+            mock_monarch_client.gql_call.return_value
+        )
+
+        groups = json.loads(await get_budgets())["groups"]
+
+        assert groups == [
+            {
+                "id": "grp-1",
+                "name": "Food",
+                "planned": 700.00,
+                "actual": 505.00,
+                "remaining": 195.00,
+                "rollover": 0.00,
+                "month": "2026-03-01",
+            }
+        ]
+
+    async def test_groups_null_when_unavailable(self):
+        # Default fixture omits the group selection entirely.
+        assert json.loads(await get_budgets())["groups"] is None
+
     async def test_prefers_the_flex_query(self, mock_monarch_client):
         await get_budgets()
         _, kwargs = mock_monarch_client.gql_call.call_args
@@ -167,6 +236,7 @@ class TestFlexBucket:
 
         assert result["flex"]["status"] == "unsupported"
         assert result["totals"] is None
+        assert result["groups"] is None
         # The whole tool still works -- this is the no-regression guarantee.
         assert len(result["data"]) == 2
         operations = [

--- a/tests/test_budgets.py
+++ b/tests/test_budgets.py
@@ -672,6 +672,59 @@ class TestUpdateFlexRolloverSettings:
             budget_system="fixed_and_flex",
         )
 
+    async def test_does_not_claim_success_without_confirmation(
+        self, mock_monarch_client
+    ):
+        # The highest-stakes claim in this module: falsely confirming a
+        # DESTRUCTIVE rollover reset is worse than falsely confirming an
+        # amount, so the guard must not be silently removable.
+        self._on_flex_account(mock_monarch_client)
+        mock_monarch_client.update_flex_rollover_settings.return_value = {
+            "updateBudgetSettings": {"budgetRolloverPeriod": None}
+        }
+
+        result = json.loads(
+            await update_flex_rollover_settings(
+                rollover_start_month="2026-08-01", rollover_starting_balance=0
+            )
+        )
+
+        assert result["success"] is False
+        assert "did not confirm" in result["error"]
+
+    async def test_reports_the_month_monarch_applied(self, mock_monarch_client):
+        self._on_flex_account(mock_monarch_client)
+        mock_monarch_client.update_flex_rollover_settings.return_value = {
+            "updateBudgetSettings": {
+                "budgetRolloverPeriod": {"id": "rp-1", "startMonth": "2026-09-01"}
+            }
+        }
+
+        result = json.loads(
+            await update_flex_rollover_settings(
+                rollover_start_month="2026-08-01", rollover_starting_balance=0
+            )
+        )
+
+        # Echoing the requested month would misreport what actually happened.
+        assert "2026-09-01" in result["message"]
+
+    @pytest.mark.parametrize("bad", ["", "not-a-date", "2026-13-01"])
+    async def test_rejects_a_malformed_start_month(self, bad, mock_monarch_client):
+        # The client does `rollover_start_month or <current month>`, so an
+        # empty string would become a silent full reset -- the exact thing the
+        # required arguments exist to prevent.
+        self._on_flex_account(mock_monarch_client)
+
+        result = json.loads(
+            await update_flex_rollover_settings(
+                rollover_start_month=bad, rollover_starting_balance=0
+            )
+        )
+
+        assert result["success"] is False
+        mock_monarch_client.update_flex_rollover_settings.assert_not_awaited()
+
     async def test_refuses_on_a_non_flex_account(self, mock_monarch_client):
         # The mutation rewrites budgetSystem as a side effect. On an account
         # using another system that would migrate the whole budgeting mode --

--- a/tests/test_server_budget.py
+++ b/tests/test_server_budget.py
@@ -206,6 +206,54 @@ class TestFormatFlexBudget:
         raw = {"budgetData": {"monthlyAmountsForFlexExpense": None}}
         assert format_flex_budget(raw, used_flex_query=True)["status"] == "not_configured"
 
+    def test_never_merges_multiple_buckets(self):
+        # Merging a fixed bucket's months into the flex answer would report a
+        # different bucket's amount as the flexible budget.
+        def bucket(variability, planned):
+            return {
+                "budgetVariability": variability,
+                "monthlyAmounts": [
+                    {"month": "2026-06-01", "plannedCashFlowAmount": planned}
+                ],
+            }
+
+        raw = {
+            "budgetData": {
+                "monthlyAmountsForFlexExpense": [
+                    bucket("fixed", 7000),
+                    bucket("flexible", 900),
+                ]
+            }
+        }
+
+        result = format_flex_budget(raw, used_flex_query=True)
+
+        assert result["budget_variability"] == "flexible"
+        assert [m["planned"] for m in result["monthly"]] == [900]
+
+    def test_falls_back_to_one_bucket_when_none_is_labelled_flexible(self):
+        # Ambiguous labelling must not collapse into a merged total either.
+        raw = {
+            "budgetData": {
+                "monthlyAmountsForFlexExpense": [
+                    {
+                        "monthlyAmounts": [
+                            {"month": "2026-06-01", "plannedCashFlowAmount": 100}
+                        ]
+                    },
+                    {
+                        "monthlyAmounts": [
+                            {"month": "2026-06-01", "plannedCashFlowAmount": 200}
+                        ]
+                    },
+                ]
+            }
+        }
+
+        result = format_flex_budget(raw, used_flex_query=True)
+
+        assert [m["planned"] for m in result["monthly"]] == [100]
+
     def test_accepts_a_bare_object_or_a_list(self):
         block = {
             "budgetVariability": "flexible",

--- a/tests/test_server_budget.py
+++ b/tests/test_server_budget.py
@@ -1,14 +1,44 @@
-from monarch_mcp_server.tools.budgets import BUDGET_QUERY, format_budget_data
+from monarch_mcp_server.tools.budgets import (
+    BUDGET_QUERY,
+    BUDGET_QUERY_FLEX,
+    format_budget_data,
+    format_budget_totals,
+    format_flex_budget,
+)
 
 
-def test_budget_query_avoids_stale_category_group_fields():
+def query_text(query):
     # gql 4.0 returns a GraphQLRequest wrapping the parsed DocumentNode;
     # the source string lives on document.loc.source.body. Earlier gql 3.x
     # exposed .loc directly on the gql() return value.
-    query_text = BUDGET_QUERY.document.loc.source.body
+    return query.document.loc.source.body
 
-    assert "budgetVariability" not in query_text
-    assert "rolloverPeriod" not in query_text
+
+def category_groups_selection(text):
+    """The categoryGroups block -- the subtree implicated in the #15 failure."""
+    return text[text.index("categoryGroups {"):]
+
+
+def test_budget_query_avoids_stale_category_group_fields():
+    text = query_text(BUDGET_QUERY)
+
+    assert "budgetVariability" not in text
+    assert "rolloverPeriod" not in text
+
+
+def test_flex_query_keeps_category_groups_narrow():
+    text = query_text(BUDGET_QUERY_FLEX)
+
+    # The flex query adds bucket-level fields under budgetData...
+    assert "monthlyAmountsForFlexExpense" in text
+    assert "totalsByMonth" in text
+
+    # ...but must not reintroduce the categoryGroups fields Monarch rejects.
+    # budgetVariability legitimately appears under monthlyAmountsForFlexExpense,
+    # so check the categoryGroups subtree specifically rather than the whole doc.
+    assert "rolloverPeriod" not in text
+    assert "groupLevelBudgetingEnabled" not in text
+    assert "budgetVariability" not in category_groups_selection(text)
 
 
 def test_format_budget_data_returns_current_month_category_rows():
@@ -48,3 +78,124 @@ def test_format_budget_data_returns_current_month_category_rows():
             "month": "2026-06-01",
         }
     ]
+
+
+class TestFormatFlexBudget:
+    def test_unsupported_when_fallback_query_was_used(self):
+        assert format_flex_budget({"budgetData": {}}, used_flex_query=False) == {
+            "status": "unsupported",
+            "budget_variability": None,
+            "monthly": [],
+        }
+
+    def test_not_configured_when_field_absent(self):
+        assert (
+            format_flex_budget({"budgetData": {}}, used_flex_query=True)["status"]
+            == "not_configured"
+        )
+
+    def test_not_configured_when_field_is_null(self):
+        raw = {"budgetData": {"monthlyAmountsForFlexExpense": None}}
+        assert format_flex_budget(raw, used_flex_query=True)["status"] == "not_configured"
+
+    def test_accepts_a_bare_object_or_a_list(self):
+        block = {
+            "budgetVariability": "flexible",
+            "monthlyAmounts": [
+                {
+                    "month": "2026-06-01",
+                    "plannedCashFlowAmount": 900,
+                    "actualAmount": 400,
+                    "remainingAmount": 500,
+                    "previousMonthRolloverAmount": 0,
+                    "rolloverType": "monthly",
+                }
+            ],
+        }
+
+        as_object = format_flex_budget(
+            {"budgetData": {"monthlyAmountsForFlexExpense": block}},
+            used_flex_query=True,
+        )
+        as_list = format_flex_budget(
+            {"budgetData": {"monthlyAmountsForFlexExpense": [block]}},
+            used_flex_query=True,
+        )
+
+        assert as_object == as_list
+        assert as_object["status"] == "ok"
+        assert as_object["monthly"][0]["planned"] == 900
+
+    def test_tolerates_partially_populated_amounts(self):
+        raw = {
+            "budgetData": {
+                "monthlyAmountsForFlexExpense": {
+                    "monthlyAmounts": [{"month": "2026-06-01"}]
+                }
+            }
+        }
+
+        result = format_flex_budget(raw, used_flex_query=True)
+
+        assert result["status"] == "ok"
+        assert result["budget_variability"] is None
+        assert result["monthly"] == [
+            {
+                "month": "2026-06-01",
+                "planned": None,
+                "actual": None,
+                "remaining": None,
+                "rollover": None,
+                "rollover_type": None,
+            }
+        ]
+
+    def test_empty_amount_entries_are_ignored(self):
+        raw = {
+            "budgetData": {
+                "monthlyAmountsForFlexExpense": {"monthlyAmounts": [{}, None]}
+            }
+        }
+
+        # Nothing usable came back, so report that rather than inventing a row.
+        assert format_flex_budget(raw, used_flex_query=True)["status"] == "not_configured"
+
+
+class TestFormatBudgetTotals:
+    def test_none_when_fallback_query_was_used(self):
+        assert format_budget_totals({"budgetData": {}}, used_flex_query=False) is None
+
+    def test_none_when_absent(self):
+        assert format_budget_totals({"budgetData": {}}, used_flex_query=True) is None
+
+    def test_maps_each_bucket(self):
+        raw = {
+            "budgetData": {
+                "totalsByMonth": [
+                    {
+                        "month": "2026-06-01",
+                        "totalFlexibleExpenses": {
+                            "plannedAmount": 1,
+                            "actualAmount": 2,
+                            "remainingAmount": 3,
+                            "previousMonthRolloverAmount": 4,
+                        },
+                        "totalFixedExpenses": None,
+                    }
+                ]
+            }
+        }
+
+        assert format_budget_totals(raw, used_flex_query=True) == [
+            {
+                "month": "2026-06-01",
+                "flexible": {
+                    "planned": 1,
+                    "actual": 2,
+                    "remaining": 3,
+                    "rollover": 4,
+                },
+                "fixed": None,
+                "non_monthly": None,
+            }
+        ]

--- a/tests/test_server_budget.py
+++ b/tests/test_server_budget.py
@@ -26,6 +26,22 @@ def test_budget_query_avoids_stale_category_group_fields():
     assert "rolloverPeriod" not in text
 
 
+def test_fallback_query_requests_nothing_beyond_the_proven_set():
+    # The narrow query is the safety net: it must stay exactly the document
+    # already known to work, so none of the extended fields may leak into it.
+    text = query_text(BUDGET_QUERY)
+
+    for field in (
+        "monthlyAmountsForFlexExpense",
+        "monthlyAmountsByCategoryGroup",
+        "totalsByMonth",
+        "previousMonthRolloverAmount",
+        "rolloverType",
+        "budgetSystem",
+    ):
+        assert field not in text, f"{field} leaked into the fallback query"
+
+
 def test_flex_query_keeps_category_groups_narrow():
     text = query_text(BUDGET_QUERY_FLEX)
 
@@ -76,6 +92,9 @@ def test_format_budget_data_returns_current_month_category_rows():
             "planned": -100,
             "actual": -25,
             "remaining": -75,
+            "set_aside": 0,
+            "rollover": None,
+            "rollover_type": None,
             "category_group": "Food",
             "month": "2026-06-01",
         }

--- a/tests/test_server_budget.py
+++ b/tests/test_server_budget.py
@@ -29,9 +29,11 @@ def test_budget_query_avoids_stale_category_group_fields():
 def test_flex_query_keeps_category_groups_narrow():
     text = query_text(BUDGET_QUERY_FLEX)
 
-    # The flex query adds bucket-level fields under budgetData...
+    # The flex query adds roll-up fields under budgetData...
     assert "monthlyAmountsForFlexExpense" in text
+    assert "monthlyAmountsByCategoryGroup" in text
     assert "totalsByMonth" in text
+    assert "totalIncome" in text
 
     # ...but must not reintroduce the categoryGroups fields Monarch rejects.
     # budgetVariability legitimately appears under monthlyAmountsForFlexExpense,
@@ -189,6 +191,8 @@ class TestFormatBudgetTotals:
         assert format_budget_totals(raw, used_flex_query=True) == [
             {
                 "month": "2026-06-01",
+                "income": None,
+                "expenses": None,
                 "flexible": {
                     "planned": 1,
                     "actual": 2,

--- a/tests/test_server_budget.py
+++ b/tests/test_server_budget.py
@@ -1,6 +1,10 @@
 from monarch_mcp_server.tools.budgets import (
     BUDGET_QUERY,
     BUDGET_QUERY_FLEX,
+    BUDGET_QUERY_FLEX_OPERATION,
+    BUDGET_QUERY_OPERATION,
+    _CATEGORY_FIELD_EXTRA,
+    _GROUP_EXTRA,
     format_budget_data,
     format_budget_totals,
     format_flex_budget,
@@ -8,15 +12,11 @@ from monarch_mcp_server.tools.budgets import (
 
 
 def query_text(query):
-    # gql 4.0 returns a GraphQLRequest wrapping the parsed DocumentNode;
-    # the source string lives on document.loc.source.body. Earlier gql 3.x
-    # exposed .loc directly on the gql() return value.
-    return query.document.loc.source.body
-
-
-def category_groups_selection(text):
-    """The categoryGroups block -- the subtree implicated in the #15 failure."""
-    return text[text.index("categoryGroups {"):]
+    # gql 4.x returns a GraphQLRequest wrapping the parsed DocumentNode, with
+    # the source on document.loc; gql 3.x exposed .loc directly on the gql()
+    # return value. pyproject allows both, so support both.
+    node = getattr(query, "document", query)
+    return node.loc.source.body
 
 
 def test_budget_query_avoids_stale_category_group_fields():
@@ -42,21 +42,43 @@ def test_fallback_query_requests_nothing_beyond_the_proven_set():
         assert field not in text, f"{field} leaked into the fallback query"
 
 
-def test_flex_query_keeps_category_groups_narrow():
+def test_flex_query_adds_the_extended_selections():
     text = query_text(BUDGET_QUERY_FLEX)
 
-    # The flex query adds roll-up fields under budgetData...
-    assert "monthlyAmountsForFlexExpense" in text
-    assert "monthlyAmountsByCategoryGroup" in text
-    assert "totalsByMonth" in text
-    assert "totalIncome" in text
+    for field in (
+        "monthlyAmountsForFlexExpense",
+        "monthlyAmountsByCategoryGroup",
+        "totalsByMonth",
+        "totalIncome",
+        "goalsV2",
+        "budgetSystem",
+    ):
+        assert field in text
 
-    # ...but must not reintroduce the categoryGroups fields Monarch rejects.
-    # budgetVariability legitimately appears under monthlyAmountsForFlexExpense,
-    # so check the categoryGroups subtree specifically rather than the whole doc.
+
+def test_flex_query_does_not_reintroduce_the_rejected_group_fields():
+    # The #15 failure was CategoryGroup.budgetVariability / rolloverPeriod.
+    # The extended query may widen categoryGroups with groupLevelBudgetingEnabled
+    # and add budgetVariability on *categories* (both proven to work elsewhere
+    # in this server), but must not bring back the two fields that broke.
+    text = query_text(BUDGET_QUERY_FLEX)
+
     assert "rolloverPeriod" not in text
-    assert "groupLevelBudgetingEnabled" not in text
-    assert "budgetVariability" not in category_groups_selection(text)
+    # budgetVariability is legitimate under monthlyAmountsForFlexExpense and on
+    # categories; assert it never appears as a direct CategoryGroup field by
+    # checking the exact fragments the document is assembled from.
+    assert _GROUP_EXTRA.strip() == "groupLevelBudgetingEnabled"
+    assert _CATEGORY_FIELD_EXTRA.strip() == "budgetVariability"
+
+
+def test_documents_carry_the_operation_names_they_are_sent_under():
+    # get_budget_data passes `operation=` alongside `graphql_query=`, and the
+    # client forwards it as operation_name. A mismatch makes the server reject
+    # the request, which _is_query_rejection reads as "no flex here" -- so a
+    # swapped document would degrade silently instead of failing loudly.
+    assert f"query {BUDGET_QUERY_OPERATION}(" in query_text(BUDGET_QUERY)
+    assert f"query {BUDGET_QUERY_FLEX_OPERATION}(" in query_text(BUDGET_QUERY_FLEX)
+    assert BUDGET_QUERY_OPERATION != BUDGET_QUERY_FLEX_OPERATION
 
 
 def test_format_budget_data_returns_current_month_category_rows():
@@ -96,9 +118,74 @@ def test_format_budget_data_returns_current_month_category_rows():
             "rollover": None,
             "rollover_type": None,
             "category_group": "Food",
+            "category_type": None,
+            "budget_variability": None,
             "month": "2026-06-01",
         }
     ]
+
+
+def test_format_budget_data_carries_the_income_expense_marker():
+    # Income and expense amounts are both positive magnitudes, so without
+    # category_type a caller summing planned adds income to spending.
+    raw = {
+        "budgetData": {
+            "monthlyAmountsByCategory": [
+                {
+                    "category": {"id": "inc-1"},
+                    "monthlyAmounts": [
+                        {"month": "2026-06-01", "plannedCashFlowAmount": 8000}
+                    ],
+                },
+                {
+                    "category": {"id": "exp-1"},
+                    "monthlyAmounts": [
+                        {"month": "2026-06-01", "plannedCashFlowAmount": 500}
+                    ],
+                },
+            ]
+        },
+        "categoryGroups": [
+            {
+                "id": "g1",
+                "name": "Income",
+                "type": "income",
+                "categories": [{"id": "inc-1", "name": "Paycheck"}],
+            },
+            {
+                "id": "g2",
+                "name": "Food",
+                "type": "expense",
+                "categories": [
+                    {"id": "exp-1", "name": "Groceries",
+                     "budget_variability": None, "budgetVariability": "flexible"}
+                ],
+            },
+        ],
+    }
+
+    rows = {r["id"]: r for r in format_budget_data(raw)}
+
+    assert rows["inc-1"]["category_type"] == "income"
+    assert rows["exp-1"]["category_type"] == "expense"
+    assert rows["exp-1"]["budget_variability"] == "flexible"
+    spending = sum(
+        r["planned"] for r in rows.values() if r["category_type"] == "expense"
+    )
+    assert spending == 500
+
+
+def test_format_budget_data_tolerates_explicit_nulls():
+    for raw in (
+        {"budgetData": None, "categoryGroups": None},
+        {"budgetData": {"monthlyAmountsByCategory": None}, "categoryGroups": []},
+        {"budgetData": {"monthlyAmountsByCategory": [None]}, "categoryGroups": [None]},
+        {
+            "budgetData": {"monthlyAmountsByCategory": []},
+            "categoryGroups": [{"id": "g", "name": "G", "categories": None}],
+        },
+    ):
+        assert format_budget_data(raw) == []
 
 
 class TestFormatFlexBudget:
@@ -186,8 +273,10 @@ class TestFormatBudgetTotals:
     def test_none_when_fallback_query_was_used(self):
         assert format_budget_totals({"budgetData": {}}, used_flex_query=False) is None
 
-    def test_none_when_absent(self):
-        assert format_budget_totals({"budgetData": {}}, used_flex_query=True) is None
+    def test_empty_list_when_query_ran_but_returned_none(self):
+        # [] means "asked, none there"; None means "could not ask". Collapsing
+        # them is the ambiguity flex.status exists to avoid.
+        assert format_budget_totals({"budgetData": {}}, used_flex_query=True) == []
 
     def test_maps_each_bucket(self):
         raw = {


### PR DESCRIPTION
Fixes #103.

Under Monarch's `fixed_and_flex` budget system, the **Flexible** section carries a single amount covering every category beneath it. `get_budgets` never returned that number — only the individual categories inside the bucket — so spending-vs-budget for Flexible could not be computed from the tool's output.

## Why it was missing

`BUDGET_QUERY` requested only `budgetData { monthlyAmountsByCategory }`. The query had been deliberately narrowed to avoid `categoryGroups` fields (`budgetVariability`, `rolloverPeriod`) that Monarch rejects for some accounts.

That narrowing cut wider than it needed to. The rejected fields are on the top-level `categoryGroups` selection; the flex data lives under `budgetData`, a **different subtree**. So the flex fields can be restored with the `categoryGroups` selection left byte-for-byte unchanged — which is what this PR does.

## Approach: extended-first, with a safe fallback

Rather than change `BUDGET_QUERY`, this adds `BUDGET_QUERY_FLEX` alongside it — the same document plus `monthlyAmountsForFlexExpense` and `totalsByMonth`. It is tried first; if Monarch rejects those fields, the original narrow query runs and the tool behaves exactly as it does today.

The important detail is **which failures count as "unsupported"**, and there are two traps here worth calling out.

**1. Monarch's rejection text is generic.** A refused field does not come back with standard GraphQL wording — probing the live API with a deliberately unknown field returns:

```
{'message': 'Something went wrong while processing: None on request_id: None.'}
```

So matching on `Cannot query field` / `Unknown field` would never fire against the real service. Detection keys on the exception **type** instead: `gql` raises `TransportQueryError` when the server answers with GraphQL `errors`, while HTTP failures raise `TransportServerError` and connection problems raise their own types. Text markers are kept only as a backstop for transports that do use the usual wording.

**2. A failure that hits both queries isn't evidence about flex.** The `unsupported` latch is set only *after* the narrow query succeeds:

```python
except Exception as exc:
    if not _is_query_rejection(exc):
        raise                    # HTTP / connection -> surface it
    rejection = exc              # not latched yet

data = await client.gql_call(... BUDGET_QUERY ...)   # raises -> propagates
if rejection is not None:
    _flex_supported = False      # only now: flex failed, narrow worked
```

An expired session refuses *both* queries. Latching on the first failure would disable flex for the rest of the process because of an auth problem; this way it propagates and flex stays un-probed. An account that genuinely lacks the fields still pays only one failed round-trip per process rather than one per call.

Also confirmed while designing this: `@include(if: false)` does **not** let a single document carry optional flex fields — GraphQL validates the whole document before directives apply, and the live API rejects it. Two documents are genuinely required, so both render from one template to keep the `categoryGroups` selection structurally identical.

## Output shape

`get_budgets` now returns an object instead of a bare list:

```json
{
  "tool": "get_budgets",
  "args": {"start_date": null, "end_date": null},
  "data":   [ "... unchanged per-category rows ..." ],
  "budget_system": "fixed_and_flex",
  "flex":   {"status": "ok", "budget_variability": "flexible", "monthly": [ "..." ]},
  "groups": [ {"id": "...", "name": "...", "planned": 0, "actual": 0, "month": "..."} ],
  "goals":  [ {"id": "...", "name": "...", "archived": false,
               "planned_contributions": [], "actual_contributions": []} ],
  "totals": [ {"month": "...", "income": {}, "expenses": {},
               "flexible": {}, "fixed": {}, "non_monthly": {}} ]
}
```

Each per-category row in `data` also gains `set_aside`, `rollover` and `rollover_type`.

## Two further gaps above the per-category level

Auditing what else Monarch returns above individual categories turned up two more omissions, both in data the API already sends:

- **`totalsByMonth.totalIncome` and `.totalExpenses` were never requested.** Income was missing from the tool altogether — only the three expense sub-buckets were mapped. On a live account both come back fully populated.
- **`monthlyAmountsByCategoryGroup` was never requested.** Groups budgeted at the group level rather than per category hold their amount there; it now surfaces as `groups`.

Both ride the same extended selection and therefore the same fallback, so an account that refuses these fields still gets every category row with `flex`/`groups`/`totals` marked unavailable.

`groupLevelBudgetingEnabled` is deliberately **not** requested — it sits on `categoryGroups`, which this PR keeps narrow. Group names are resolved from the existing narrow selection instead.

One asymmetry worth recording so it isn't mistaken for a further gap: **Flexible is the only *pooled* bucket.** Fixed and Non-Monthly are budgeted per category, so their per-category rows in `data` were already complete and their totals are plain sums — which is why Monarch exposes a dedicated `monthlyAmountsForFlexExpense` and no fixed/non-monthly equivalent. That's noted in the tool docstring.

## Rollover: per-category numbers that did not add up

A further pass over the per-category fields found the most consequential omission. Monarch returns `previousMonthRolloverAmount` and `rolloverType` per category; neither was requested. For any category with rollover enabled, `planned - actual` therefore did **not** equal `remaining`, and nothing in the response explained the difference — it just looked like bad data.

On a live account, 5 of 86 rows were affected. With rollover included:

```
rows: 86
  reconcile only once rollover is included: 5
  still unexplained:                        0
```

Also in this pass:

- **`plannedSetAsideAmount` was already being requested and then silently dropped** during formatting. Now mapped as `set_aside`.
- **`budgetSystem`** is now requested and returned as top-level `budget_system` (e.g. `"fixed_and_flex"`), so a caller can distinguish "this account does not use flex budgeting" from "the flex bucket is empty" rather than inferring it from an empty result.

These go into the extended query only, through new template slots. The narrow fallback stays byte-for-byte the document already proven to work, and `test_fallback_query_requests_nothing_beyond_the_proven_set` asserts none of the extended fields leak into it — that query is the safety net, so it must never become the thing that breaks.

`flex.status` is deliberately explicit, because silently omitting the field is indistinguishable from a flex budget of zero — and an LLM reading it that way would state a confidently wrong number:

| status | meaning |
|---|---|
| `ok` | bucket present and populated |
| `not_configured` | query succeeded, but this account has no flex bucket |
| `unsupported` | Monarch rejected the flex fields; fallback query ran |

**This is the one breaking change:** callers reading the old top-level list now read `data`. It matches the envelope `get_transactions` already returns, and the README is updated accordingly.

## Write side

Added `set_flexible_budget`, wrapping the client's existing `update_flexible_budget()`. This is needed because the Flex bucket is **not** a category group — of the 18 category groups returned on my account, none corresponds to it — so `set_budget_amount(category_group_id=...)` cannot reach it by construction. It refuses early with a clear message when flex is known-unsupported, instead of surfacing a raw GraphQL exception, and is added to the README's approval-required list since it mutates the ledger.

## Testing

**Unit: 69 budget tests, up from 6.** Full suite **284 passed**.

Coverage spans the flex-present / `not_configured` / rejection→fallback paths; that a transient rejection recovers rather than sticking; that `TransportServerError` propagates instead of degrading; that a failure hitting **both** queries surfaces as an error; rejection detection against the real generic Monarch message rather than idealized GraphQL wording; both list and bare-object shapes for `monthlyAmountsForFlexExpense` and the refusal to merge multiple buckets; explicit JSON nulls at every level; the income/expense marker; group-level budgets; paired-date validation in both directions at both the tool and helper level; and every branch of the two mutating tools including their confirming-payload guards.

**These were validated by mutation, not by inspection.** Each of the following was applied to the implementation and confirmed to fail a test: swapping the two query documents (both as constants and at the call sites), returning `used_flex_query=True` on the fallback path, making `json_error` return a success-looking payload, hardcoding a wrong `current_month_range`, dropping `budget_system=` from the destructive client call, dropping the `category_type` key, removing the null-guards, and disabling either confirming-payload guard. Several of those mutations passed an earlier version of this test suite, which is why the tests were rewritten.

`test_fallback_query_requests_nothing_beyond_the_proven_set` guards the regression this PR is most careful about: the narrow document is the safety net, so no extended field may leak into it.

Full suite: **284 passed**. One unrelated failure, `test_secure_session.py::TestGetAuthenticatedClient::test_no_session_returns_none`, is **pre-existing on `main`** — confirmed by stashing these changes and re-running.

Worth flagging separately, since it will not reproduce in CI: that test fails only on a machine where someone has actually authenticated. `_TOKEN_DIR` resolves from `Path.home()` at import, and the fixture fakes the keyring but not the file fallback, so the test reads the developer's real `~/.monarch-mcp-server/token` and gets a live session where it expects `None`. Running it with `HOME` pointed at a temp dir passes. Happy to fix that in a separate PR — it's untouched here.

**Live:** verified against a real `fixed_and_flex` account throughout. `get_budgets` returns 86 category rows with `flex.status="ok"`, a populated bucket, group roll-ups, goals and all five `totals`; every row reconciles once rollover is included (5 previously could not, 0 remain); an explicit date range resolves to the right month; and forcing the fallback still returns all 86 rows with `flex.status="unsupported"` and the extended keys null — the no-regression guarantee.

Neither mutating tool was executed against the live account, since both write to a real ledger. They are covered by unit tests only, which is the main limitation of this PR's verification.

**Reviewed by four independent audits** (correctness, test quality, GraphQL mapping vs the vendored client, docs consistency) over three rounds. Everything they raised in scope is fixed; findings outside this PR's scope were filed separately as #105, #106 and #107 rather than folded in here.

## Goals

`goalsV2` comes back from the same query and was not requested either. Goal contributions are precisely what `plannedSetAsideAmount` refers to, so a "what is spoken for this month" answer that ignores them understates the plan. Surfaced as `goals`, with `planned_contributions` and `actual_contributions` per month.

Archived and completed goals are included but **flagged** rather than filtered, so a caller can exclude them deliberately instead of never learning they existed. Requested without upstream's `@include(if: $useV2Goals)` guard, since the extended document already falls back wholesale if Monarch refuses any part of it.

## `update_flex_rollover_settings`, with its defaults removed

Also exposed, since it is the fix for a Flex bucket that has accumulated a large negative rollover over many months.

It needs care. The client signature is `(rollover_start_month=None, rollover_starting_balance=0.0, rollover_enabled=True)`, and its own docstring offers this as the usage example:

> Example (reset flex rollover to $0 starting this month): `await mm.update_flex_rollover_settings()`

So a zero-argument call silently discards accumulated rollover. Inheriting those defaults would hand an LLM a no-argument reset button, so **both destructive arguments are required** at the tool boundary, the docstring states plainly what is discarded and asks that the current rollover be reported first, and it is on the README's approval-required list. A test asserts the two arguments stay required.

## Deliberately left out

- **`get_cashflow_summary()`** — redundant. Verified against the live API that the existing `get_cashflow` tool already returns the same block (`sumIncome`, `sumExpense`, `savings`, `savingsRate`); this method returns that and nothing else. A second tool returning a strict subset of an existing one is surface an agent has to choose between for no gain.
- **`reset_budget()`** — clears a whole month of planned amounts with no undo. Different blast radius from the scoped, re-settable mutations here; it deserves its own discussion before being handed to an LLM.
- **`reset_budget()`** is the one upstream budget capability deliberately left unexposed, for the reason above.

Happy to follow up on any of these separately.

## If you'd rather this were smaller

This is a large PR because the pieces share one query, one fallback path and one response shape, and splitting them means a rebase chain. But it is deliberately structured so it *can* be split, and I'm happy to do that instead of asking you to review it whole. Each commit is self-contained and the natural cut lines are:

| Slice | Contents | Breaking |
|---|---|---|
| A | Extended query + fallback machinery + per-category `rollover` / `rollover_type` / `set_aside` — return stays a bare list, rows just gain keys | **no** |
| B | The `{data, flex, groups, goals, totals, budget_system}` envelope | **yes** |
| C | Write tools: `set_flexible_budget`, `update_flex_rollover_settings` | no |

The one I'd most suggest, if you want only one: **pull A out from under B.** The rollover fix is the highest-value part — without it, `planned - actual` silently fails to equal `remaining` for any rollover category — and it needs no shape change at all. Landing A alone fixes real wrong numbers today, and leaves the list→object question to be settled separately on its own merits.

C depends only on A. B is the only piece anyone should have to argue about.

Two unrelated follow-ups I'd send separately rather than smuggle in here:

- The test suite reads the developer's real `~/.monarch-mcp-server/token` (see Testing below) — a small fixture fix.
- The README's Claude Desktop launch command resolves `mcp[cli]` unpinned, which now pulls SDK v2 and breaks a cold-cache install (that's #84; I opened #102 with the details).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
