### PR TITLE
fix: support mcp 2.x, which renamed FastMCP to MCPServer

### DIFF
--- a/src/monarch_mcp_server/app.py
+++ b/src/monarch_mcp_server/app.py
@@ -2,7 +2,10 @@
 
 import logging
 
-from mcp.server.fastmcp import FastMCP
+try:  # mcp >= 2.0 renamed FastMCP to MCPServer
+    from mcp.server.mcpserver import MCPServer as FastMCP
+except ImportError:  # mcp < 2.0
+    from mcp.server.fastmcp import FastMCP
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/src/monarch_mcp_server/auth.py
+++ b/src/monarch_mcp_server/auth.py
@@ -6,7 +6,10 @@ the protocol — they never appear in tool arguments or the model's context.
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import Context
+try:  # mcp >= 2.0
+    from mcp.server.mcpserver import Context
+except ImportError:  # mcp < 2.0
+    from mcp.server.fastmcp import Context
 from monarchmoney import MonarchMoney, RequireMFAException
 from pydantic import BaseModel, Field
 

--- a/src/monarch_mcp_server/tools/auth.py
+++ b/src/monarch_mcp_server/tools/auth.py
@@ -3,7 +3,10 @@
 import logging
 import os
 
-from mcp.server.fastmcp import Context
+try:  # mcp >= 2.0
+    from mcp.server.mcpserver import Context
+except ImportError:  # mcp < 2.0
+    from mcp.server.fastmcp import Context
 
 from monarch_mcp_server import auth
 from monarch_mcp_server.app import mcp

--- a/tests/test_mcp_compat.py
+++ b/tests/test_mcp_compat.py
@@ -1,0 +1,30 @@
+"""Regression tests for mcp 1.x / 2.x import compatibility.
+
+mcp 2.0 renamed FastMCP to MCPServer and moved Context alongside it. The
+package supports both, so guard that here: a plain rename would silently
+break the other major, which is how the original breakage happened.
+"""
+
+
+def test_app_exposes_server_instance():
+    """The server instance imports and registers tools on either mcp major."""
+    from monarch_mcp_server.app import mcp
+
+    assert mcp is not None
+    assert hasattr(mcp, "tool")
+    assert hasattr(mcp, "run")
+
+
+def test_context_is_importable():
+    """Context resolves on either mcp major."""
+    from monarch_mcp_server import auth
+
+    assert auth.Context is not None
+
+
+async def test_tools_are_registered():
+    """Tool registration survives the import indirection."""
+    from monarch_mcp_server.app import mcp
+
+    tools = await mcp.list_tools()
+    assert len(tools) > 0


### PR DESCRIPTION
## Problem

`pyproject.toml` declares an unbounded dependency:

```toml
"mcp[cli]>=1.10.0",
```

`mcp` 2.0 renamed `FastMCP` to `MCPServer` and moved `Context` to `mcp.server.mcpserver`. A fresh install now resolves `mcp` 2.x, and every entry point dies at import:

```
File "monarch_mcp_server/app.py", line 5, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

Nothing needs to change on the user's side to hit this — it started the moment `mcp` 2.0.0 published.

### Why it is easy to misdiagnose

MCP clients surface this only as a closed connection. In my case the client reported:

```
McpError: Connection closed
```

and parked the server, so the tools silently disappeared with no indication that the cause was an import error. It only became visible by running the `uvx` command by hand.

Reproduce:

```bash
uvx --from git+https://github.com/robcerda/monarch-mcp-server monarch-mcp-server
```

## Fix

Import the new path with a fallback to the old one, in the three affected modules:

```python
try:  # mcp >= 2.0 renamed FastMCP to MCPServer
    from mcp.server.mcpserver import MCPServer as FastMCP
except ImportError:  # mcp < 2.0
    from mcp.server.fastmcp import FastMCP
```

I deliberately avoided a straight rename: that fixes 2.x while breaking every 1.x user. This keeps both majors working, so it needs no coordinated release and no dependency bound change.

`MCPServer` provides the same `.tool` decorator and `.run()`, so all 50 `@mcp.tool` registrations are untouched.

## Verification

Ran against both majors:

| `mcp` | tools registered | result |
| --- | --- | --- |
| 2.0.0 | 49 | server starts |
| 1.29.0 | 49 | server starts |

Existing suite: `221 passed, 1 failed` — identical before and after this change. The failure is `tests/test_secure_session.py::TestGetAuthenticatedClient::test_no_session_returns_none`, which fails on an unmodified checkout too, so it is pre-existing and unrelated. Happy to look at it separately if useful.

Also added `tests/test_mcp_compat.py` (3 tests, passing on both majors) so a future import change cannot silently reintroduce this.

## Alternative

If you would rather not carry the shim, capping the dependency (`"mcp[cli]>=1.10.0,<2"`) fixes installs immediately and is a one-line change. I went with the shim so 2.x users are supported rather than pinned back, but happy to switch if you prefer.