### PR TITLE
Expose Institution(Account) Owner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "mcp[cli]>=1.10.0",
-    "monarchmoneycommunity>=1.4.0",
+    "monarchmoneycommunity>=1.5.2",
     "gql>=3.4",
     "keyring>=24.0.0",
     "python-dotenv>=1.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mcp[cli]>=1.10.0
-monarchmoneycommunity>=1.4.0
+monarchmoneycommunity>=1.5.2
 gql>=3.4
 keyring>=24.0.0
 python-dotenv>=1.0.0

--- a/src/monarch_mcp_server/tools/accounts.py
+++ b/src/monarch_mcp_server/tools/accounts.py
@@ -35,7 +35,7 @@ async def get_accounts() -> str:
             account_info = {
                 "id": account.get("id"),
                 "name": account.get("displayName") or account.get("name"),
-                "ownedByUser": account.get("ownedByUser").get("displayName"), # Institution owner, not the Monarch Account Owner.
+                "owned_by_user": (account.get("ownedByUser") or {}).get("displayName"), # Institution owner, not the Monarch Account Owner.
                 "type": (account.get("type") or {}).get("name"),
                 "balance": account.get("currentBalance"),
                 "current_balance": account.get("currentBalance"),

--- a/src/monarch_mcp_server/tools/accounts.py
+++ b/src/monarch_mcp_server/tools/accounts.py
@@ -35,6 +35,7 @@ async def get_accounts() -> str:
             account_info = {
                 "id": account.get("id"),
                 "name": account.get("displayName") or account.get("name"),
+                "ownedByUser": account.get("ownedByUser").get("displayName"), # Institution owner, not the Monarch Account Owner.
                 "type": (account.get("type") or {}).get("name"),
                 "balance": account.get("currentBalance"),
                 "current_balance": account.get("currentBalance"),

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -51,6 +51,13 @@ class TestGetAccounts:
         assert result[0]["current_balance"] == 0
         assert result[0]["display_balance"] == 0
 
+    async def test_handles_null_owned_by_user(self, mock_monarch_client):
+        mock_monarch_client.get_accounts.return_value = {
+            "accounts": [{"id": "acc-3", "ownedByUser": None}]
+        }
+        result = json.loads(await get_accounts())
+        assert result[0]["owned_by_user"] is None
+
     async def test_handles_empty_accounts(self, mock_monarch_client):
         mock_monarch_client.get_accounts.return_value = {"accounts": []}
         result = json.loads(await get_accounts())


### PR DESCRIPTION
Hi,

I am the owner of the downstream `monarchmoneycommunity` in `1.5.2` I recently exposed the feature where Monarch allows you to have specific owners assigned to different financial institutions and you can have I believe it is up to 5 users on one single Monarch Account with their users. 

Sometimes -> Especially with an MCP you want to ask the question "Look at all of XYZ's accounts" this opens the door to that. If you have multiple users on the Monarch account.

So this does that:

1.) Expose the ownedByUser entity
2.) Updates mmc to 1.5.2 so it is usable by this package

<img width="603" height="265" alt="image" src="https://github.com/user-attachments/assets/75f0e564-e5b1-4c6b-9b9d-e6532731cfae" />

