### PR TITLE
fix: report cookie-mode sessions as authenticated in auth status tools

### DIFF
--- a/src/monarch_mcp_server/tools/auth.py
+++ b/src/monarch_mcp_server/tools/auth.py
@@ -62,15 +62,33 @@ async def monarch_logout() -> str:
     return await auth.logout()
 
 
+def _describe_session(session: dict | None) -> str:
+    """Summarize a stored session without leaking credential values.
+
+    A cookie-mode session carries no token, so probing for a token alone
+    reports a false negative on sessions that authenticate fine.
+    """
+    if not session:
+        return "❌ No Monarch session found in secure storage"
+
+    auth_mode = session.get("auth_mode", "token")
+    credentials = []
+    if session.get("cookies"):
+        credentials.append("cookies")
+    if session.get("token"):
+        credentials.append("token")
+
+    return (
+        f"✅ Session found in secure storage (auth_mode={auth_mode}, "
+        f"credentials: {', '.join(credentials)})"
+    )
+
+
 @mcp.tool()
 async def check_auth_status() -> str:
     """Check if already authenticated with Monarch Money."""
     try:
-        token = secure_session.load_token()
-        if token:
-            status = "✅ Authentication token found in secure keyring storage\n"
-        else:
-            status = "❌ No authentication token found in keyring\n"
+        status = _describe_session(secure_session.load_session()) + "\n"
 
         email = os.getenv("MONARCH_EMAIL")
         if email:
@@ -87,12 +105,15 @@ async def check_auth_status() -> str:
 
 @mcp.tool()
 async def debug_session_loading() -> str:
-    """Debug keyring session loading issues."""
+    """Debug session loading issues."""
     try:
-        token = secure_session.load_token()
-        if token:
-            return "✅ Token found in keyring."
-        return "❌ No token found in keyring. Run login_setup.py to authenticate."
+        session = secure_session.load_session()
+        if session:
+            return _describe_session(session) + "."
+        return (
+            "❌ No Monarch session found in secure storage. "
+            "Run login_setup.py to authenticate."
+        )
     except Exception as e:
         logger.exception("Keyring access failed")
         return f"❌ Keyring access failed: {type(e).__name__}: {e}"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -111,33 +111,52 @@ class TestLogout:
 
 
 class TestDebugSessionLoading:
-    def test_no_token_message(self):
+    def test_no_session_message(self):
         from monarch_mcp_server.tools import auth as tools_auth
 
         with patch(
-            "monarch_mcp_server.tools.auth.secure_session.load_token",
+            "monarch_mcp_server.tools.auth.secure_session.load_session",
             return_value=None,
         ):
             result = asyncio.run(tools_auth.debug_session_loading())
-        assert "No token" in result
+        assert "No Monarch session" in result
 
     def test_token_present_does_not_leak_length(self):
         from monarch_mcp_server.tools import auth as tools_auth
 
         with patch(
-            "monarch_mcp_server.tools.auth.secure_session.load_token",
-            return_value="a-secret-token-value",
+            "monarch_mcp_server.tools.auth.secure_session.load_session",
+            return_value={"token": "a-secret-token-value", "auth_mode": "token"},
         ):
             result = asyncio.run(tools_auth.debug_session_loading())
-        assert "Token found" in result
+        assert "Session found" in result
+        assert "auth_mode=token" in result
         assert "length" not in result.lower()
         assert "a-secret-token-value" not in result
+
+    def test_cookie_session_reports_authenticated(self):
+        """Cookie-mode sessions carry no token; they must not read as missing."""
+        from monarch_mcp_server.tools import auth as tools_auth
+
+        with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_session",
+            return_value={
+                "cookies": {"session_id": "s3cr3t", "csrftoken": "c5rf"},
+                "auth_mode": "cookie",
+            },
+        ):
+            result = asyncio.run(tools_auth.debug_session_loading())
+        assert "Session found" in result
+        assert "auth_mode=cookie" in result
+        assert "cookies" in result
+        assert "s3cr3t" not in result
+        assert "c5rf" not in result
 
     def test_keyring_failure_omits_traceback(self):
         from monarch_mcp_server.tools import auth as tools_auth
 
         with patch(
-            "monarch_mcp_server.tools.auth.secure_session.load_token",
+            "monarch_mcp_server.tools.auth.secure_session.load_session",
             side_effect=RuntimeError("keyring backend unavailable"),
         ):
             result = asyncio.run(tools_auth.debug_session_loading())
@@ -146,6 +165,33 @@ class TestDebugSessionLoading:
         assert "keyring backend unavailable" in result
         assert "Traceback" not in result
         assert 'File "' not in result
+
+
+class TestCheckAuthStatus:
+    def test_cookie_session_reports_authenticated(self):
+        from monarch_mcp_server.tools import auth as tools_auth
+
+        with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_session",
+            return_value={
+                "cookies": {"session_id": "s3cr3t"},
+                "auth_mode": "cookie",
+            },
+        ):
+            result = asyncio.run(tools_auth.check_auth_status())
+        assert "Session found" in result
+        assert "auth_mode=cookie" in result
+        assert "s3cr3t" not in result
+
+    def test_no_session_reports_missing(self):
+        from monarch_mcp_server.tools import auth as tools_auth
+
+        with patch(
+            "monarch_mcp_server.tools.auth.secure_session.load_session",
+            return_value=None,
+        ):
+            result = asyncio.run(tools_auth.check_auth_status())
+        assert "No Monarch session" in result
 
 
 class TestElicitNotSupported:


### PR DESCRIPTION
## Problem

After #73 added cookie auth, `check_auth_status` and `debug_session_loading` report **not authenticated** for cookie-mode sessions that authenticate fine.

Reproduced on a working install: `get_accounts` returns live data, while the diagnostic tools say:

```
❌ No authentication token found in keyring
```

The tools whose job is to answer "am I authenticated?" give the wrong answer for the auth mode #73 just introduced.

## Root cause

Both tools called `secure_session.load_token()`, which returns only the `token` field of the stored session blob:

```python
def load_token(self) -> Optional[str]:
    session = self.load_session()
    ...
    token = session.get("token")
```

A cookie-mode session has no token. That isn't incidental — upstream's `login_with_cookies()` only calls `set_cookies()` and never assigns one:

```python
async def login_with_cookies(self, cookie_string, save_session=True, verify=True) -> None:
    cookies = self._parse_cookie_string(cookie_string)
    self.set_cookies(cookies)
    ...
```

So `save_authenticated_session()` persists `{"cookies": {...}, "auth_mode": "cookie"}` with `token=None`, and every cookie session is a guaranteed false negative.

`secure_session.load_session()` already handles this correctly — it treats *either* a token or cookies as a valid session (`secure_session.py:200`). Only the two status tools were left probing for a token.

## Fix

Both tools now read the full session via `load_session()` and report `auth_mode` plus which credentials are present, via a shared `_describe_session()` helper:

```
✅ Session found in secure storage (auth_mode=cookie, credentials: cookies)
```

No change to authentication behavior — this is reporting only.

## Notes

- Credential values are never included in the output; only their presence by name. Existing tests asserting no token leakage are preserved and extended to cookies.
- `debug_session_loading`'s exception path is unchanged.
- Message text changed from "No authentication token found in keyring" to "No Monarch session found in secure storage" — more accurate now that a session may be cookies, a token, or both, and that storage may be the file fallback rather than a keyring.

## Testing

- Added cookie-mode coverage for both tools, plus a `TestCheckAuthStatus` class (`check_auth_status` previously had none).
- Existing tests repointed from patching `load_token` to `load_session`.
- Full suite: **225 passed**.
- Verified end-to-end against a real cookie-mode session in the macOS keychain — correctly reports `auth_mode=cookie`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
