### PR TITLE
fix: bound get_cashflow and get_spending_summary response sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 | `get_transactions` | Get transactions with filtering and reconciliation fields | `limit`, `offset`, `start_date`, `end_date`, `account_id`, `account_ids`, `category_ids`, `category_group_ids`, `tag_ids`, `search`, `wide_search`, `search_scan_limit`, `has_notes`, `is_split`, `is_recurring` |
 | `get_budgets` | Get budget information | `start_date`, `end_date` |
 | `set_budget_amount` | Set budget for a category | `amount`, `category_id`, `category_group_id`, `start_date`, `apply_to_future` |
-| `get_cashflow` | Get cashflow analysis | `start_date`, `end_date` |
+| `get_cashflow` | Get cashflow analysis | `start_date`, `end_date`, `limit` |
 | `get_net_worth` | Get net worth history | `start_date`, `end_date`, `account_type` |
 | `get_account_balance_history` | Get account balance history | `account_id` |
 | `get_net_worth_by_account_type` | Get net worth by account type | `start_date`, `timeframe` |

--- a/src/monarch_mcp_server/helpers.py
+++ b/src/monarch_mcp_server/helpers.py
@@ -2,9 +2,56 @@
 
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+# Monarch's aggregate queries return every bucket they have — a full year runs to
+# hundreds of categories and thousands of merchants, which overflows the MCP
+# response limit. Rows are only trimmed when a response would actually exceed the
+# budget, stepping down this ladder of per-breakdown caps until it fits.
+MAX_RESPONSE_CHARS = 45_000
+LIMIT_LADDER = (100, 50, 20, 10, 5)
+
+
+def strip_typenames(value: Any) -> Any:
+    """Recursively drop GraphQL ``__typename`` keys from a payload."""
+    if isinstance(value, dict):
+        return {k: strip_typenames(v) for k, v in value.items() if k != "__typename"}
+    if isinstance(value, list):
+        return [strip_typenames(item) for item in value]
+    return value
+
+
+def breakdown(rows: List[Dict[str, Any]], limit: Optional[int]) -> Dict[str, Any]:
+    """Wrap ranked ``rows`` so any cap applied is visible to the caller."""
+    capped = rows[:limit] if limit else rows
+    return {
+        "total": len(rows),
+        "returned": len(capped),
+        "truncated": len(capped) < len(rows),
+        "rows": capped,
+    }
+
+
+def render_within_budget(
+    render: Callable[[Optional[int]], str], limit: Optional[int]
+) -> str:
+    """Render the largest response that fits under ``MAX_RESPONSE_CHARS``.
+
+    ``render`` takes the per-breakdown cap to apply (None for no cap) and returns
+    the serialized response. An explicit *limit* is honoured as-is — including 0,
+    which means "never trim" — and otherwise the cap steps down the ladder only
+    as far as it must.
+    """
+    if limit is not None:
+        return render(limit or None)
+
+    for applied in (None, *LIMIT_LADDER):
+        rendered = render(applied)
+        if len(rendered) <= MAX_RESPONSE_CHARS:
+            return rendered
+    return rendered
 
 
 def format_exception(exc: Exception) -> str:

--- a/src/monarch_mcp_server/tools/financial.py
+++ b/src/monarch_mcp_server/tools/financial.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime as dt
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
@@ -10,17 +10,59 @@ from monarch_mcp_server.helpers import json_success, json_error
 
 logger = logging.getLogger(__name__)
 
+# Upstream returns every aggregate bucket it has, and a busy month runs to well
+# over a hundred merchants. Stripping the GraphQL noise gets most ranges under
+# the MCP response ceiling on its own, so only trim rows when the response would
+# actually overflow. Ladder of per-breakdown caps to try, largest first.
+MAX_CASHFLOW_RESPONSE_CHARS = 45_000
+_CASHFLOW_LIMIT_LADDER = (100, 50, 20, 10, 5)
+
+_CASHFLOW_AGGREGATE_KEYS = ("byCategory", "byCategoryGroup", "byMerchant", "summary")
+
+
+def _strip_typenames(value: Any) -> Any:
+    """Recursively drop GraphQL ``__typename`` keys from a payload."""
+    if isinstance(value, dict):
+        return {k: _strip_typenames(v) for k, v in value.items() if k != "__typename"}
+    if isinstance(value, list):
+        return [_strip_typenames(item) for item in value]
+    return value
+
+
+def _breakdown(rows: List[Dict[str, Any]], limit: Optional[int]) -> Dict[str, Any]:
+    """Wrap ranked ``rows`` so any cap applied is visible to the caller."""
+    capped = rows[:limit] if limit else rows
+    return {
+        "total": len(rows),
+        "returned": len(capped),
+        "truncated": len(capped) < len(rows),
+        "rows": capped,
+    }
+
 
 @mcp.tool()
 async def get_cashflow(
-    start_date: Optional[str] = None, end_date: Optional[str] = None
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    limit: Optional[int] = None,
 ) -> str:
     """
     Get cashflow analysis from Monarch Money.
 
+    Returns overall income, expenses, savings and savings rate for the period,
+    plus breakdowns by category, category group, and merchant, each ranked by
+    absolute cash flow.
+
+    Every row is returned when the response fits. Only if it would overflow the
+    MCP response limit are the smallest rows trimmed, and each breakdown reports
+    its true total so nothing is dropped silently.
+
     Args:
         start_date: Start date in YYYY-MM-DD format
         end_date: End date in YYYY-MM-DD format
+        limit: Optional hard cap on rows per breakdown. Leave unset to return
+               everything that fits. Use 0 to disable trimming entirely — a wide
+               date range can then exceed the response limit.
     """
     try:
         client = await get_monarch_client()
@@ -32,7 +74,94 @@ async def get_cashflow(
             filters["end_date"] = end_date
 
         cashflow = await client.get_cashflow(**filters)
-        return json_success(cashflow)
+
+        # Be forgiving if upstream ever changes shape: pass the payload through
+        # rather than silently reporting an empty cashflow.
+        if not any(key in cashflow for key in _CASHFLOW_AGGREGATE_KEYS):
+            return json_success(_strip_typenames(cashflow))
+
+        by_category: List[Dict[str, Any]] = []
+        for item in cashflow.get("byCategory", []):
+            cat = item.get("groupBy", {}).get("category") or {}
+            group = cat.get("group") or {}
+            by_category.append(
+                {
+                    "category": cat.get("name"),
+                    "category_id": cat.get("id"),
+                    "icon": cat.get("icon"),
+                    "group_id": group.get("id"),
+                    "group_type": group.get("type"),
+                    "sum": item.get("summary", {}).get("sum", 0),
+                }
+            )
+        by_category.sort(key=lambda x: abs(x.get("sum") or 0), reverse=True)
+
+        by_category_group: List[Dict[str, Any]] = []
+        for item in cashflow.get("byCategoryGroup", []):
+            grp = item.get("groupBy", {}).get("categoryGroup") or {}
+            by_category_group.append(
+                {
+                    "group": grp.get("name"),
+                    "group_id": grp.get("id"),
+                    "group_type": grp.get("type"),
+                    "sum": item.get("summary", {}).get("sum", 0),
+                }
+            )
+        by_category_group.sort(key=lambda x: abs(x.get("sum") or 0), reverse=True)
+
+        by_merchant: List[Dict[str, Any]] = []
+        for item in cashflow.get("byMerchant", []):
+            merch = item.get("groupBy", {}).get("merchant") or {}
+            summary = item.get("summary", {})
+            by_merchant.append(
+                {
+                    "merchant": merch.get("name"),
+                    "merchant_id": merch.get("id"),
+                    "income": summary.get("sumIncome", 0),
+                    "expense": summary.get("sumExpense", 0),
+                }
+            )
+        # Rank on total flow, not expense alone: a payroll or transfer merchant
+        # can be the largest line in the period and must survive the cap.
+        by_merchant.sort(
+            key=lambda x: abs(x.get("income") or 0) + abs(x.get("expense") or 0),
+            reverse=True,
+        )
+
+        overall: Dict[str, Any] = {}
+        summary_items = cashflow.get("summary", [])
+        if summary_items:
+            s = summary_items[0].get("summary", {})
+            overall = {
+                "total_income": s.get("sumIncome", 0),
+                "total_expenses": s.get("sumExpense", 0),
+                "savings": s.get("savings", 0),
+                "savings_rate": s.get("savingsRate", 0),
+            }
+
+        def render(applied: Optional[int]) -> str:
+            return json_success(
+                {
+                    "period": {"start_date": start_date, "end_date": end_date},
+                    "limit": applied,
+                    **overall,
+                    "by_category": _breakdown(by_category, applied),
+                    "by_category_group": _breakdown(by_category_group, applied),
+                    "by_merchant": _breakdown(by_merchant, applied),
+                }
+            )
+
+        # An explicit limit is the caller's call, including 0 for "never trim".
+        if limit is not None:
+            return render(limit or None)
+
+        # Otherwise return everything, stepping the cap down only far enough to
+        # fit under the response ceiling.
+        for applied in (None, *_CASHFLOW_LIMIT_LADDER):
+            rendered = render(applied)
+            if len(rendered) <= MAX_CASHFLOW_RESPONSE_CHARS:
+                return rendered
+        return rendered
     except Exception as e:
         return json_error("get_cashflow", e)
 
@@ -80,29 +209,31 @@ async def get_net_worth(
 
         snapshots = result.get("aggregateSnapshots", [])
 
-        formatted: Dict[str, Any] = {
-            "snapshot_count": len(snapshots),
-            "snapshots": []
-        }
+        formatted: Dict[str, Any] = {"snapshot_count": len(snapshots), "snapshots": []}
 
         if snapshots:
-            values = [s.get("balance", 0) for s in snapshots if s.get("balance") is not None]
+            values = [
+                s.get("balance", 0) for s in snapshots if s.get("balance") is not None
+            ]
             if values:
                 formatted["current_net_worth"] = values[-1] if values else 0
                 formatted["earliest_net_worth"] = values[0] if values else 0
                 formatted["change"] = values[-1] - values[0] if len(values) > 1 else 0
                 formatted["change_percent"] = (
                     ((values[-1] - values[0]) / values[0] * 100)
-                    if values[0] != 0 and len(values) > 1 else 0
+                    if values[0] != 0 and len(values) > 1
+                    else 0
                 )
                 formatted["highest"] = max(values)
                 formatted["lowest"] = min(values)
 
         for snapshot in snapshots[-365:]:
-            formatted["snapshots"].append({
-                "date": snapshot.get("date"),
-                "net_worth": snapshot.get("balance"),
-            })
+            formatted["snapshots"].append(
+                {
+                    "date": snapshot.get("date"),
+                    "net_worth": snapshot.get("balance"),
+                }
+            )
 
         return json_success(formatted)
     except Exception as e:
@@ -136,10 +267,9 @@ async def get_net_worth_by_account_type(
     """
     try:
         if timeframe not in ("month", "year"):
-            return json_success({
-                "success": False,
-                "error": "timeframe must be 'month' or 'year'"
-            })
+            return json_success(
+                {"success": False, "error": "timeframe must be 'month' or 'year'"}
+            )
 
         client = await get_monarch_client()
         result = await client.get_account_snapshots_by_type(
@@ -154,7 +284,7 @@ async def get_net_worth_by_account_type(
         formatted: Dict[str, Any] = {
             "timeframe": timeframe,
             "start_date": start_date,
-            "account_types": []
+            "account_types": [],
         }
 
         # Group flat rows by accountType, preserving order of first appearance.
@@ -164,14 +294,18 @@ async def get_net_worth_by_account_type(
             if atype is None:
                 continue
             entry = grouped.setdefault(atype, {"type": atype, "snapshots": []})
-            entry["snapshots"].append({
-                "month": row.get("month"),
-                "balance": row.get("balance"),
-            })
+            entry["snapshots"].append(
+                {
+                    "month": row.get("month"),
+                    "balance": row.get("balance"),
+                }
+            )
 
         for type_info in grouped.values():
             if type_info["snapshots"]:
-                type_info["current_balance"] = type_info["snapshots"][-1].get("balance", 0)
+                type_info["current_balance"] = type_info["snapshots"][-1].get(
+                    "balance", 0
+                )
             formatted["account_types"].append(type_info)
 
         total = sum(

--- a/src/monarch_mcp_server/tools/financial.py
+++ b/src/monarch_mcp_server/tools/financial.py
@@ -6,38 +6,17 @@ from typing import Any, Dict, List, Optional
 
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
-from monarch_mcp_server.helpers import json_success, json_error
+from monarch_mcp_server.helpers import (
+    breakdown,
+    json_error,
+    json_success,
+    render_within_budget,
+    strip_typenames,
+)
 
 logger = logging.getLogger(__name__)
 
-# Upstream returns every aggregate bucket it has, and a busy month runs to well
-# over a hundred merchants. Stripping the GraphQL noise gets most ranges under
-# the MCP response ceiling on its own, so only trim rows when the response would
-# actually overflow. Ladder of per-breakdown caps to try, largest first.
-MAX_CASHFLOW_RESPONSE_CHARS = 45_000
-_CASHFLOW_LIMIT_LADDER = (100, 50, 20, 10, 5)
-
 _CASHFLOW_AGGREGATE_KEYS = ("byCategory", "byCategoryGroup", "byMerchant", "summary")
-
-
-def _strip_typenames(value: Any) -> Any:
-    """Recursively drop GraphQL ``__typename`` keys from a payload."""
-    if isinstance(value, dict):
-        return {k: _strip_typenames(v) for k, v in value.items() if k != "__typename"}
-    if isinstance(value, list):
-        return [_strip_typenames(item) for item in value]
-    return value
-
-
-def _breakdown(rows: List[Dict[str, Any]], limit: Optional[int]) -> Dict[str, Any]:
-    """Wrap ranked ``rows`` so any cap applied is visible to the caller."""
-    capped = rows[:limit] if limit else rows
-    return {
-        "total": len(rows),
-        "returned": len(capped),
-        "truncated": len(capped) < len(rows),
-        "rows": capped,
-    }
 
 
 @mcp.tool()
@@ -78,7 +57,7 @@ async def get_cashflow(
         # Be forgiving if upstream ever changes shape: pass the payload through
         # rather than silently reporting an empty cashflow.
         if not any(key in cashflow for key in _CASHFLOW_AGGREGATE_KEYS):
-            return json_success(_strip_typenames(cashflow))
+            return json_success(strip_typenames(cashflow))
 
         by_category: List[Dict[str, Any]] = []
         for item in cashflow.get("byCategory", []):
@@ -145,23 +124,13 @@ async def get_cashflow(
                     "period": {"start_date": start_date, "end_date": end_date},
                     "limit": applied,
                     **overall,
-                    "by_category": _breakdown(by_category, applied),
-                    "by_category_group": _breakdown(by_category_group, applied),
-                    "by_merchant": _breakdown(by_merchant, applied),
+                    "by_category": breakdown(by_category, applied),
+                    "by_category_group": breakdown(by_category_group, applied),
+                    "by_merchant": breakdown(by_merchant, applied),
                 }
             )
 
-        # An explicit limit is the caller's call, including 0 for "never trim".
-        if limit is not None:
-            return render(limit or None)
-
-        # Otherwise return everything, stepping the cap down only far enough to
-        # fit under the response ceiling.
-        for applied in (None, *_CASHFLOW_LIMIT_LADDER):
-            rendered = render(applied)
-            if len(rendered) <= MAX_CASHFLOW_RESPONSE_CHARS:
-                return rendered
-        return rendered
+        return render_within_budget(render, limit)
     except Exception as e:
         return json_error("get_cashflow", e)
 

--- a/src/monarch_mcp_server/tools/summaries.py
+++ b/src/monarch_mcp_server/tools/summaries.py
@@ -7,7 +7,12 @@ from gql import gql
 
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
-from monarch_mcp_server.helpers import json_error, json_success
+from monarch_mcp_server.helpers import (
+    breakdown,
+    json_error,
+    json_success,
+    render_within_budget,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +119,7 @@ async def get_transactions_summary() -> str:
 async def get_spending_summary(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
+    limit: Optional[int] = None,
 ) -> str:
     """
     Get a spending summary broken down by category, category group, and merchant.
@@ -121,13 +127,21 @@ async def get_spending_summary(
     Shows how much you've spent in each category over a time period, plus
     overall income, expenses, and savings rate.
 
+    Every row is returned when the response fits. Only if it would overflow the
+    MCP response limit are the smallest rows trimmed, and each breakdown reports
+    its true total so nothing is dropped silently.
+
     Args:
         start_date: Start date in YYYY-MM-DD format.
         end_date: End date in YYYY-MM-DD format.
+        limit: Optional hard cap on rows per breakdown. Leave unset to return
+               everything that fits. Use 0 to disable trimming entirely — a wide
+               date range can then exceed the response limit.
 
     Returns:
-        Spending breakdown with by_category, by_category_group, by_merchant,
-        and overall totals (income, expenses, savings, savings_rate).
+        Spending breakdown with by_category, by_category_group, by_merchant —
+        each with total/returned/truncated counts and its ranked rows — plus
+        overall totals (income, expenses, savings, savings_rate).
 
     Examples:
         Get spending summary for current month:
@@ -165,7 +179,7 @@ async def get_spending_summary(
                     "sum": item.get("summary", {}).get("sum", 0),
                 }
             )
-        by_category.sort(key=lambda x: abs(x.get("sum", 0)), reverse=True)
+        by_category.sort(key=lambda x: abs(x.get("sum") or 0), reverse=True)
 
         by_category_group: List[Dict[str, Any]] = []
         for item in result.get("byCategoryGroup", []):
@@ -178,7 +192,7 @@ async def get_spending_summary(
                     "sum": item.get("summary", {}).get("sum", 0),
                 }
             )
-        by_category_group.sort(key=lambda x: abs(x.get("sum", 0)), reverse=True)
+        by_category_group.sort(key=lambda x: abs(x.get("sum") or 0), reverse=True)
 
         by_merchant: List[Dict[str, Any]] = []
         for item in result.get("byMerchant", []):
@@ -191,7 +205,12 @@ async def get_spending_summary(
                     "expense": item.get("summary", {}).get("sumExpense", 0),
                 }
             )
-        by_merchant.sort(key=lambda x: abs(x.get("expense", 0)), reverse=True)
+        # Rank on total flow, not expense alone: a payroll or transfer merchant
+        # can be the largest line in the period and must survive the cap.
+        by_merchant.sort(
+            key=lambda x: abs(x.get("income") or 0) + abs(x.get("expense") or 0),
+            reverse=True,
+        )
 
         overall = {}
         summary_items = result.get("summary", [])
@@ -204,17 +223,21 @@ async def get_spending_summary(
                 "savings_rate": s.get("savingsRate", 0),
             }
 
-        formatted: Dict[str, Any] = {
-            "period": {
-                "start_date": start_date,
-                "end_date": end_date,
-            },
-            **overall,
-            "by_category": by_category,
-            "by_category_group": by_category_group,
-            "by_merchant": by_merchant,
-        }
+        def render(applied: Optional[int]) -> str:
+            return json_success(
+                {
+                    "period": {
+                        "start_date": start_date,
+                        "end_date": end_date,
+                    },
+                    "limit": applied,
+                    **overall,
+                    "by_category": breakdown(by_category, applied),
+                    "by_category_group": breakdown(by_category_group, applied),
+                    "by_merchant": breakdown(by_merchant, applied),
+                }
+            )
 
-        return json_success(formatted)
+        return render_within_budget(render, limit)
     except Exception as e:
         return json_error("get_spending_summary", e)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,12 +137,124 @@ def mock_monarch_client():
         ],
     }
 
+    # Upstream get_cashflow returns the raw Common_GetCashFlowEntityAggregates
+    # payload: nested groupBy/summary wrappers, __typename on every node, and a
+    # merchant list that carries full logo URLs.
     client.get_cashflow.return_value = {
-        "cashflow": {
-            "income": 5000.00,
-            "expenses": -3200.00,
-            "savings": 1800.00,
-        }
+        "byCategory": [
+            {
+                "groupBy": {
+                    "category": {
+                        "id": "cat-1",
+                        "name": "Groceries",
+                        "icon": "🛒",
+                        "group": {
+                            "id": "grp-1",
+                            "type": "expense",
+                            "__typename": "CategoryGroup",
+                        },
+                        "__typename": "Category",
+                    },
+                    "__typename": "AggregateGroupBy",
+                },
+                "summary": {"sum": -3200.00, "__typename": "TransactionsSummary"},
+                "__typename": "AggregateData",
+            },
+            {
+                "groupBy": {
+                    "category": {
+                        "id": "cat-3",
+                        "name": "Paychecks",
+                        "icon": "💵",
+                        "group": {
+                            "id": "grp-2",
+                            "type": "income",
+                            "__typename": "CategoryGroup",
+                        },
+                        "__typename": "Category",
+                    },
+                    "__typename": "AggregateGroupBy",
+                },
+                "summary": {"sum": 5000.00, "__typename": "TransactionsSummary"},
+                "__typename": "AggregateData",
+            },
+        ],
+        "byCategoryGroup": [
+            {
+                "groupBy": {
+                    "categoryGroup": {
+                        "id": "grp-2",
+                        "name": "Income",
+                        "type": "income",
+                        "__typename": "CategoryGroup",
+                    },
+                    "__typename": "AggregateGroupBy",
+                },
+                "summary": {"sum": 5000.00, "__typename": "TransactionsSummary"},
+                "__typename": "AggregateData",
+            },
+            {
+                "groupBy": {
+                    "categoryGroup": {
+                        "id": "grp-1",
+                        "name": "Food",
+                        "type": "expense",
+                        "__typename": "CategoryGroup",
+                    },
+                    "__typename": "AggregateGroupBy",
+                },
+                "summary": {"sum": -3200.00, "__typename": "TransactionsSummary"},
+                "__typename": "AggregateData",
+            },
+        ],
+        "byMerchant": [
+            {
+                "groupBy": {
+                    "merchant": {
+                        "id": "mer-1",
+                        "name": "Whole Foods",
+                        "logoUrl": "https://res.cloudinary.com/monarch-money/x/wholefoods",
+                        "__typename": "Merchant",
+                    },
+                    "__typename": "AggregateGroupBy",
+                },
+                "summary": {
+                    "sumIncome": 0.00,
+                    "sumExpense": -3200.00,
+                    "__typename": "TransactionsSummary",
+                },
+                "__typename": "AggregateData",
+            },
+            {
+                "groupBy": {
+                    "merchant": {
+                        "id": "mer-2",
+                        "name": "Employer",
+                        "logoUrl": "https://res.cloudinary.com/monarch-money/x/employer",
+                        "__typename": "Merchant",
+                    },
+                    "__typename": "AggregateGroupBy",
+                },
+                "summary": {
+                    "sumIncome": 5000.00,
+                    "sumExpense": 0.00,
+                    "__typename": "TransactionsSummary",
+                },
+                "__typename": "AggregateData",
+            },
+        ],
+        "summary": [
+            {
+                "summary": {
+                    "sumIncome": 5000.00,
+                    "sumExpense": -3200.00,
+                    "savings": 1800.00,
+                    "savingsRate": 0.36,
+                    "__typename": "TransactionsSummary",
+                },
+                "__typename": "AggregateData",
+            }
+        ],
     }
 
     client.get_account_holdings.return_value = {

--- a/tests/test_financial.py
+++ b/tests/test_financial.py
@@ -1,21 +1,223 @@
 """Tests for financial-analysis MCP tools."""
 
+import copy
 import json
 
-from monarch_mcp_server.tools.financial import get_cashflow
+from monarch_mcp_server.tools.financial import (
+    MAX_CASHFLOW_RESPONSE_CHARS,
+    _CASHFLOW_LIMIT_LADDER,
+    get_cashflow,
+)
+
+
+def _merchant_row(index: int, income: float, expense: float):
+    """Build a raw byMerchant aggregate row, as upstream returns them."""
+    return {
+        "groupBy": {
+            "merchant": {
+                "id": f"mer-{index}",
+                "name": f"Merchant {index}",
+                "logoUrl": f"https://res.cloudinary.com/monarch-money/x/{index}",
+                "__typename": "Merchant",
+            },
+            "__typename": "AggregateGroupBy",
+        },
+        "summary": {
+            "sumIncome": income,
+            "sumExpense": expense,
+            "__typename": "TransactionsSummary",
+        },
+        "__typename": "AggregateData",
+    }
 
 
 class TestGetCashflow:
-    async def test_returns_cashflow_data(self):
+    async def test_returns_totals(self):
         result = json.loads(await get_cashflow())
-        assert result["cashflow"]["income"] == 5000.00
-        assert result["cashflow"]["expenses"] == -3200.00
+        assert result["total_income"] == 5000.00
+        assert result["total_expenses"] == -3200.00
+        assert result["savings"] == 1800.00
+        assert result["savings_rate"] == 0.36
 
     async def test_passes_date_params(self, mock_monarch_client):
         await get_cashflow(start_date="2026-01-01", end_date="2026-01-31")
         mock_monarch_client.get_cashflow.assert_called_once_with(
             start_date="2026-01-01", end_date="2026-01-31"
         )
+
+    async def test_echoes_period(self):
+        result = json.loads(
+            await get_cashflow(start_date="2026-01-01", end_date="2026-01-31")
+        )
+        assert result["period"] == {
+            "start_date": "2026-01-01",
+            "end_date": "2026-01-31",
+        }
+
+    async def test_flattens_breakdown_rows(self):
+        result = json.loads(await get_cashflow())
+
+        groceries = next(
+            row
+            for row in result["by_category"]["rows"]
+            if row["category"] == "Groceries"
+        )
+        assert groceries == {
+            "category": "Groceries",
+            "category_id": "cat-1",
+            "icon": "🛒",
+            "group_id": "grp-1",
+            "group_type": "expense",
+            "sum": -3200.00,
+        }
+
+        income_group = next(
+            row
+            for row in result["by_category_group"]["rows"]
+            if row["group"] == "Income"
+        )
+        assert income_group == {
+            "group": "Income",
+            "group_id": "grp-2",
+            "group_type": "income",
+            "sum": 5000.00,
+        }
+
+        employer = next(
+            row
+            for row in result["by_merchant"]["rows"]
+            if row["merchant"] == "Employer"
+        )
+        assert employer == {
+            "merchant": "Employer",
+            "merchant_id": "mer-2",
+            "income": 5000.00,
+            "expense": 0.00,
+        }
+
+    async def test_drops_graphql_noise(self):
+        """__typename and merchant logo URLs are the bulk of the raw payload."""
+        raw = await get_cashflow()
+        assert "__typename" not in raw
+        assert "cloudinary" not in raw
+        assert "logoUrl" not in raw
+
+    async def test_reports_counts_when_nothing_is_dropped(self):
+        result = json.loads(await get_cashflow())
+        assert result["limit"] is None
+        assert result["by_merchant"]["total"] == 2
+        assert result["by_merchant"]["returned"] == 2
+        assert result["by_merchant"]["truncated"] is False
+
+    async def test_returns_every_row_that_fits(self, mock_monarch_client):
+        """A response under the ceiling is never trimmed."""
+        payload = copy.deepcopy(mock_monarch_client.get_cashflow.return_value)
+        payload["byMerchant"] = [
+            _merchant_row(i, income=0.0, expense=-float(i)) for i in range(1, 127)
+        ]
+        mock_monarch_client.get_cashflow.return_value = payload
+
+        result = json.loads(await get_cashflow())
+
+        assert result["limit"] is None
+        assert result["by_merchant"]["returned"] == 126
+        assert result["by_merchant"]["truncated"] is False
+
+    async def test_trims_only_when_the_response_would_overflow(
+        self, mock_monarch_client
+    ):
+        payload = copy.deepcopy(mock_monarch_client.get_cashflow.return_value)
+        payload["byMerchant"] = [
+            _merchant_row(i, income=0.0, expense=-float(i)) for i in range(1, 4001)
+        ]
+        mock_monarch_client.get_cashflow.return_value = payload
+
+        raw = await get_cashflow()
+        result = json.loads(raw)
+
+        assert len(raw) <= MAX_CASHFLOW_RESPONSE_CHARS
+        assert result["limit"] in _CASHFLOW_LIMIT_LADDER
+        assert result["by_merchant"]["total"] == 4000
+        assert result["by_merchant"]["truncated"] is True
+        # Trimmed to fit, not slashed to the floor.
+        assert result["by_merchant"]["returned"] > 5
+
+    async def test_caps_long_breakdowns_and_says_so(self, mock_monarch_client):
+        payload = copy.deepcopy(mock_monarch_client.get_cashflow.return_value)
+        payload["byMerchant"] = [
+            _merchant_row(i, income=0.0, expense=-float(i)) for i in range(1, 101)
+        ]
+        mock_monarch_client.get_cashflow.return_value = payload
+
+        result = json.loads(await get_cashflow(limit=5))
+
+        assert result["limit"] == 5
+        assert result["by_merchant"]["total"] == 100
+        assert result["by_merchant"]["returned"] == 5
+        assert result["by_merchant"]["truncated"] is True
+        assert len(result["by_merchant"]["rows"]) == 5
+
+    async def test_keeps_the_largest_rows_by_absolute_flow(self, mock_monarch_client):
+        payload = copy.deepcopy(mock_monarch_client.get_cashflow.return_value)
+        payload["byMerchant"] = [
+            _merchant_row(i, income=0.0, expense=-float(i)) for i in range(1, 101)
+        ]
+        mock_monarch_client.get_cashflow.return_value = payload
+
+        result = json.loads(await get_cashflow(limit=3))
+
+        assert [row["merchant"] for row in result["by_merchant"]["rows"]] == [
+            "Merchant 100",
+            "Merchant 99",
+            "Merchant 98",
+        ]
+
+    async def test_ranks_merchants_by_income_as_well_as_expense(
+        self, mock_monarch_client
+    ):
+        """A big income merchant must not be dropped by expense-only ranking."""
+        payload = copy.deepcopy(mock_monarch_client.get_cashflow.return_value)
+        payload["byMerchant"] = [
+            _merchant_row(i, income=0.0, expense=-float(i)) for i in range(1, 101)
+        ] + [_merchant_row(999, income=50_000.0, expense=0.0)]
+        mock_monarch_client.get_cashflow.return_value = payload
+
+        result = json.loads(await get_cashflow(limit=3))
+
+        assert result["by_merchant"]["rows"][0]["merchant"] == "Merchant 999"
+
+    async def test_limit_zero_returns_everything(self, mock_monarch_client):
+        payload = copy.deepcopy(mock_monarch_client.get_cashflow.return_value)
+        payload["byMerchant"] = [
+            _merchant_row(i, income=0.0, expense=-float(i)) for i in range(1, 101)
+        ]
+        mock_monarch_client.get_cashflow.return_value = payload
+
+        result = json.loads(await get_cashflow(limit=0))
+
+        assert result["by_merchant"]["returned"] == 100
+        assert result["by_merchant"]["truncated"] is False
+
+    async def test_stays_under_the_ceiling_for_a_realistic_payload(
+        self, mock_monarch_client
+    ):
+        """The original bug: one real month blew past the MCP response ceiling."""
+        payload = copy.deepcopy(mock_monarch_client.get_cashflow.return_value)
+        payload["byMerchant"] = [
+            _merchant_row(i, income=0.0, expense=-float(i)) for i in range(1, 127)
+        ]
+        mock_monarch_client.get_cashflow.return_value = payload
+
+        assert len(await get_cashflow()) <= MAX_CASHFLOW_RESPONSE_CHARS
+
+    async def test_handles_unrecognized_payload_shape(self, mock_monarch_client):
+        mock_monarch_client.get_cashflow.return_value = {
+            "somethingNew": [{"value": 1, "__typename": "Whatever"}]
+        }
+
+        result = json.loads(await get_cashflow())
+
+        assert result["somethingNew"] == [{"value": 1}]
 
     async def test_handles_api_error(self, mock_monarch_client):
         mock_monarch_client.get_cashflow.side_effect = Exception("Cashflow error")

--- a/tests/test_financial.py
+++ b/tests/test_financial.py
@@ -3,11 +3,8 @@
 import copy
 import json
 
-from monarch_mcp_server.tools.financial import (
-    MAX_CASHFLOW_RESPONSE_CHARS,
-    _CASHFLOW_LIMIT_LADDER,
-    get_cashflow,
-)
+from monarch_mcp_server.helpers import LIMIT_LADDER, MAX_RESPONSE_CHARS
+from monarch_mcp_server.tools.financial import get_cashflow
 
 
 def _merchant_row(index: int, income: float, expense: float):
@@ -135,8 +132,8 @@ class TestGetCashflow:
         raw = await get_cashflow()
         result = json.loads(raw)
 
-        assert len(raw) <= MAX_CASHFLOW_RESPONSE_CHARS
-        assert result["limit"] in _CASHFLOW_LIMIT_LADDER
+        assert len(raw) <= MAX_RESPONSE_CHARS
+        assert result["limit"] in LIMIT_LADDER
         assert result["by_merchant"]["total"] == 4000
         assert result["by_merchant"]["truncated"] is True
         # Trimmed to fit, not slashed to the floor.
@@ -208,7 +205,7 @@ class TestGetCashflow:
         ]
         mock_monarch_client.get_cashflow.return_value = payload
 
-        assert len(await get_cashflow()) <= MAX_CASHFLOW_RESPONSE_CHARS
+        assert len(await get_cashflow()) <= MAX_RESPONSE_CHARS
 
     async def test_handles_unrecognized_payload_shape(self, mock_monarch_client):
         mock_monarch_client.get_cashflow.return_value = {

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -3,10 +3,31 @@
 import json
 from unittest.mock import AsyncMock, patch
 
+from monarch_mcp_server.helpers import LIMIT_LADDER, MAX_RESPONSE_CHARS
 from monarch_mcp_server.tools.summaries import (
     get_spending_summary,
     get_transactions_summary,
 )
+
+
+def _client_with_merchants(count: int) -> AsyncMock:
+    """A client whose aggregates hold *count* merchant rows and nothing else."""
+    client = AsyncMock()
+    client.gql_call.return_value = {
+        "byCategory": [],
+        "byCategoryGroup": [],
+        "byMerchant": [
+            {
+                "groupBy": {
+                    "merchant": {"id": f"mer-{i}", "name": f"Merchant {i}"},
+                },
+                "summary": {"sumIncome": 0.0, "sumExpense": -float(i)},
+            }
+            for i in range(1, count + 1)
+        ],
+        "summary": [],
+    }
+    return client
 
 
 class TestGetTransactionsSummary:
@@ -121,19 +142,23 @@ class TestGetSpendingSummary:
         assert data["savings"] == 4550.0
         assert data["savings_rate"] == 0.91
 
-        assert len(data["by_category"]) == 2
-        assert data["by_category"][0]["category"] == "Salary"
-        assert data["by_category"][0]["sum"] == 5000.0
-        assert data["by_category"][1]["category"] == "Groceries"
-        assert data["by_category"][1]["category_id"] == "cat-1"
-        assert data["by_category"][1]["group_type"] == "expense"
+        assert data["limit"] is None
 
-        assert len(data["by_category_group"]) == 1
-        assert data["by_category_group"][0]["group"] == "Food"
+        categories = data["by_category"]
+        assert (categories["total"], categories["returned"]) == (2, 2)
+        assert categories["truncated"] is False
+        assert categories["rows"][0]["category"] == "Salary"
+        assert categories["rows"][0]["sum"] == 5000.0
+        assert categories["rows"][1]["category"] == "Groceries"
+        assert categories["rows"][1]["category_id"] == "cat-1"
+        assert categories["rows"][1]["group_type"] == "expense"
 
-        assert len(data["by_merchant"]) == 1
-        assert data["by_merchant"][0]["merchant"] == "Whole Foods"
-        assert data["by_merchant"][0]["expense"] == -320.0
+        assert data["by_category_group"]["total"] == 1
+        assert data["by_category_group"]["rows"][0]["group"] == "Food"
+
+        assert data["by_merchant"]["total"] == 1
+        assert data["by_merchant"]["rows"][0]["merchant"] == "Whole Foods"
+        assert data["by_merchant"]["rows"][0]["expense"] == -320.0
 
     @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
     async def test_passes_date_filters(self, mock_get_client):
@@ -188,9 +213,13 @@ class TestGetSpendingSummary:
         result = await get_spending_summary()
 
         data = json.loads(result)
-        assert data["by_category"] == []
-        assert data["by_category_group"] == []
-        assert data["by_merchant"] == []
+        for key in ("by_category", "by_category_group", "by_merchant"):
+            assert data[key] == {
+                "total": 0,
+                "returned": 0,
+                "truncated": False,
+                "rows": [],
+            }
         assert "total_income" not in data
 
     @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
@@ -231,8 +260,8 @@ class TestGetSpendingSummary:
         result = await get_spending_summary()
 
         data = json.loads(result)
-        assert data["by_category"][0]["category"] == "Large"
-        assert data["by_category"][1]["category"] == "Small"
+        assert data["by_category"]["rows"][0]["category"] == "Large"
+        assert data["by_category"]["rows"][1]["category"] == "Small"
 
     @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
     async def test_handles_null_category(self, mock_get_client):
@@ -254,8 +283,68 @@ class TestGetSpendingSummary:
         result = await get_spending_summary()
 
         data = json.loads(result)
-        assert data["by_category"][0]["category"] is None
-        assert data["by_category"][0]["sum"] == -25.0
+        assert data["by_category"]["rows"][0]["category"] is None
+        assert data["by_category"]["rows"][0]["sum"] == -25.0
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_returns_every_merchant_that_fits(self, mock_get_client):
+        """A response under the ceiling is never trimmed."""
+        mock_get_client.return_value = _client_with_merchants(150)
+
+        data = json.loads(await get_spending_summary())
+
+        assert data["limit"] is None
+        assert data["by_merchant"]["returned"] == 150
+        assert data["by_merchant"]["truncated"] is False
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_trims_only_when_the_response_would_overflow(self, mock_get_client):
+        """A full year runs to thousands of merchants and must still fit."""
+        mock_get_client.return_value = _client_with_merchants(4000)
+
+        raw = await get_spending_summary()
+        data = json.loads(raw)
+
+        assert len(raw) <= MAX_RESPONSE_CHARS
+        assert data["limit"] in LIMIT_LADDER
+        assert data["by_merchant"]["total"] == 4000
+        assert data["by_merchant"]["truncated"] is True
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_ranks_merchants_by_income_as_well_as_expense(self, mock_get_client):
+        """A big income merchant must not be dropped by expense-only ranking."""
+        mock_client = _client_with_merchants(200)
+        mock_client.gql_call.return_value["byMerchant"].append(
+            {
+                "groupBy": {"merchant": {"id": "big", "name": "Payroll"}},
+                "summary": {"sumIncome": 90_000.0, "sumExpense": 0.0},
+            }
+        )
+        mock_get_client.return_value = mock_client
+
+        data = json.loads(await get_spending_summary(limit=3))
+
+        assert data["by_merchant"]["rows"][0]["merchant"] == "Payroll"
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_explicit_limit_is_honoured(self, mock_get_client):
+        mock_get_client.return_value = _client_with_merchants(150)
+
+        data = json.loads(await get_spending_summary(limit=5))
+
+        assert data["limit"] == 5
+        assert data["by_merchant"]["returned"] == 5
+        assert data["by_merchant"]["total"] == 150
+        assert data["by_merchant"]["truncated"] is True
+
+    @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
+    async def test_limit_zero_disables_trimming(self, mock_get_client):
+        mock_get_client.return_value = _client_with_merchants(4000)
+
+        data = json.loads(await get_spending_summary(limit=0))
+
+        assert data["by_merchant"]["returned"] == 4000
+        assert data["by_merchant"]["truncated"] is False
 
     @patch("monarch_mcp_server.tools.summaries.get_monarch_client")
     async def test_handles_error(self, mock_get_client):


### PR DESCRIPTION
## The bug

`get_cashflow` returns upstream's raw `Common_GetCashFlowEntityAggregates` payload verbatim. That payload carries a `__typename` on every node, a full Cloudinary logo URL per merchant, and an unbounded merchant list.

On a real account, **one month came to 97,422 characters** and was rejected by the MCP response limit — the tool never returned data at all:

```
Error: result (97,422 characters) exceeds maximum allowed tokens.
```

`get_spending_summary` has the same defect, just less visible: it already strips the GraphQL noise, so a single month fits. Wider ranges don't — a full year is **173,439 characters** and all time is **609,741**.

## The fix

Flatten the aggregates, drop the GraphQL noise, and rank each breakdown by absolute cash flow. Rows are trimmed **only when the response would actually overflow**, stepping a cap down a ladder until it fits — stripping the noise alone gets most ranges under the limit on its own, so a typical month is returned complete.

Every breakdown is now `{total, returned, truncated, rows}`, so a cap is never silent. `limit=N` overrides the automatic behaviour; `limit=0` disables trimming entirely.

The shared machinery (`strip_typenames`, `breakdown`, `render_within_budget`) lives in `helpers.py` and both tools use it, so they share one implementation and one response shape.

### Measured against a live account

| Range | Before | After | Cap applied | Rows returned |
|---|---|---|---|---|
| One month | 97,422 ❌ rejected | 30,783 | none | 41/41 categories, 15/15 groups, 126/126 merchants |
| Full year | 173,439 ❌ | 33,371 | 100 | 70/70, 16/16, 100/918 |
| All time | 609,741 ❌ | 36,115 | 100 | 82/82, 16/16, 100/3566 |

### Merchant ranking

Merchants rank on `|income| + |expense|`, not expense alone. `get_spending_summary` previously sorted by expense only, which drops the largest single line of a period whenever that line is income rather than an expense — common for payroll and transfers, and the case in the account this was tested against. There's a test pinning this in both tools.

## Breaking change

`get_spending_summary`'s breakdowns were bare lists and are now wrapped in the counts envelope. The counts are what make a trim visible; the alternative is a tool that silently returns a fraction of the data.

## Tests

239 pass (222 on `main`). The old `get_cashflow` tests passed against a hand-written `{"cashflow": {"income": 5000}}` mock that upstream never returns — which is exactly why this shipped. The fixture now carries a realistic raw payload, and there are regression tests for the size ceiling, the truncation counts, and the ranking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)