### PR TITLE
Fix keyring save failure on Windows by chunking oversized session blobs

### DIFF
--- a/src/monarch_mcp_server/secure_session.py
+++ b/src/monarch_mcp_server/secure_session.py
@@ -24,12 +24,27 @@ logger = logging.getLogger(__name__)
 KEYRING_SERVICE = "com.mcp.monarch-mcp-server"
 KEYRING_USERNAME = "monarch-token"
 
+# Windows Credential Manager rejects credential blobs over ~2560 bytes
+# (CRED_MAX_CREDENTIAL_BLOB_SIZE) with (1783, 'CredWrite', 'The stub
+# received bad data'), and keyring's WinVault backend stores passwords as
+# UTF-16 (2 bytes per char). A cookie-mode session blob (token +
+# device_uuid + cookies incl. cf_clearance) easily exceeds that, so blobs
+# longer than this many characters are split across multiple entries:
+# an index entry at KEYRING_USERNAME plus monarch-token-chunk-0..N-1.
+_KEYRING_CHUNK_SIZE = 1024
+_CHUNK_USERNAME_PREFIX = KEYRING_USERNAME + "-chunk-"
+_CHUNK_MARKER = "__monarch_chunks__"
+# Safety cap when sweeping chunk entries so a misbehaving backend that
+# returns a value for every username can't loop forever.
+_MAX_CHUNKS = 256
+
 # File-based fallback location
 _TOKEN_DIR = Path.home() / ".monarch-mcp-server"
 _TOKEN_FILE = _TOKEN_DIR / "token"
 
 
 _PROBE_USERNAME = "__keyring_probe__"
+_PROBE_VALUE = "x" * _KEYRING_CHUNK_SIZE
 
 
 def _keyring_available() -> bool:
@@ -41,6 +56,10 @@ def _keyring_available() -> bool:
     name-based check rejects real macOS keyrings and silently falls back to
     plaintext file storage. We instead set + get + delete a sentinel value
     and trust the backend only if every step succeeds.
+
+    The probe value is one full chunk (_KEYRING_CHUNK_SIZE chars), not a
+    single byte: Windows Credential Manager accepts tiny writes but rejects
+    large ones, so a 1-byte probe would pass while real saves fail.
     """
     try:
         import keyring
@@ -48,13 +67,30 @@ def _keyring_available() -> bool:
         return False
 
     try:
-        keyring.set_password(KEYRING_SERVICE, _PROBE_USERNAME, "1")
+        keyring.set_password(KEYRING_SERVICE, _PROBE_USERNAME, _PROBE_VALUE)
         stored = keyring.get_password(KEYRING_SERVICE, _PROBE_USERNAME)
         keyring.delete_password(KEYRING_SERVICE, _PROBE_USERNAME)
     except Exception:
         return False
 
-    return stored == "1"
+    return stored == _PROBE_VALUE
+
+
+def _chunk_username(index: int) -> str:
+    return f"{_CHUNK_USERNAME_PREFIX}{index}"
+
+
+def _parse_chunk_count(raw: str) -> Optional[int]:
+    """Return the chunk count if `raw` is a chunk-index entry, else None."""
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if isinstance(parsed, dict) and isinstance(parsed.get(_CHUNK_MARKER), int):
+        count = parsed[_CHUNK_MARKER]
+        if 0 < count <= _MAX_CHUNKS:
+            return count
+    return None
 
 
 class SecureMonarchSession:
@@ -94,6 +130,85 @@ class SecureMonarchSession:
         if _TOKEN_DIR.is_dir() and not list(_TOKEN_DIR.iterdir()):
             _TOKEN_DIR.rmdir()
 
+    # -- keyring helpers -------------------------------------------------------
+
+    def _keyring_save(self, blob: str) -> None:
+        """Save a blob to the keyring, chunking when it exceeds the safe size.
+
+        Small blobs are stored directly under KEYRING_USERNAME exactly as
+        before. Oversized blobs are split into _KEYRING_CHUNK_SIZE-char
+        pieces under monarch-token-chunk-0..N-1, with a small JSON index
+        entry under KEYRING_USERNAME. Chunks are written before the index so
+        a crash mid-save can't leave an index pointing at missing chunks.
+        Raises on failure so the caller can fall back to file storage.
+        """
+        import keyring
+
+        if len(blob) <= _KEYRING_CHUNK_SIZE:
+            keyring.set_password(KEYRING_SERVICE, KEYRING_USERNAME, blob)
+            new_count = 0
+        else:
+            chunks = [
+                blob[i : i + _KEYRING_CHUNK_SIZE]
+                for i in range(0, len(blob), _KEYRING_CHUNK_SIZE)
+            ]
+            if len(chunks) > _MAX_CHUNKS:
+                raise ValueError(
+                    f"Session blob too large to chunk: {len(blob)} chars"
+                )
+            for i, chunk in enumerate(chunks):
+                keyring.set_password(KEYRING_SERVICE, _chunk_username(i), chunk)
+            keyring.set_password(
+                KEYRING_SERVICE,
+                KEYRING_USERNAME,
+                json.dumps({_CHUNK_MARKER: len(chunks)}),
+            )
+            new_count = len(chunks)
+
+        # Remove stale chunk entries left over from a previous, larger save.
+        self._delete_chunk_entries(start=new_count)
+
+    def _keyring_load(self) -> Optional[str]:
+        """Load the blob from the keyring, reassembling chunks if needed."""
+        import keyring
+
+        raw = keyring.get_password(KEYRING_SERVICE, KEYRING_USERNAME)
+        if raw is None:
+            return None
+
+        count = _parse_chunk_count(raw)
+        if count is None:
+            return raw
+
+        parts = []
+        for i in range(count):
+            part = keyring.get_password(KEYRING_SERVICE, _chunk_username(i))
+            if part is None:
+                logger.warning(
+                    "⚠️  Keyring session is chunked but chunk %d/%d is missing",
+                    i,
+                    count,
+                )
+                return None
+            parts.append(part)
+        return "".join(parts)
+
+    def _delete_chunk_entries(self, start: int = 0) -> None:
+        """Delete chunk entries from `start` upward until one is absent."""
+        try:
+            import keyring
+        except ImportError:
+            return
+
+        for i in range(start, _MAX_CHUNKS):
+            username = _chunk_username(i)
+            try:
+                if keyring.get_password(KEYRING_SERVICE, username) is None:
+                    break
+                keyring.delete_password(KEYRING_SERVICE, username)
+            except Exception:
+                break
+
     # -- public API ----------------------------------------------------------
 
     def save_session_blob(
@@ -130,8 +245,7 @@ class SecureMonarchSession:
 
         if self._use_keyring:
             try:
-                import keyring
-                keyring.set_password(KEYRING_SERVICE, KEYRING_USERNAME, blob)
+                self._keyring_save(blob)
                 logger.info(
                     "✅ Session saved securely to keyring (auth_mode=%s)",
                     auth_mode,
@@ -176,8 +290,7 @@ class SecureMonarchSession:
         raw_session = None
         if self._use_keyring:
             try:
-                import keyring
-                raw_session = keyring.get_password(KEYRING_SERVICE, KEYRING_USERNAME)
+                raw_session = self._keyring_load()
             except Exception as e:
                 logger.warning(f"⚠️  Keyring load failed, trying file fallback: {e}")
 
@@ -225,6 +338,7 @@ class SecureMonarchSession:
                 logger.info("🗑️ Token deleted from keyring")
             except Exception:
                 pass
+            self._delete_chunk_entries()
 
         # Always try file cleanup too
         self._delete_token_file()

--- a/tests/test_secure_session.py
+++ b/tests/test_secure_session.py
@@ -1,5 +1,6 @@
 """Tests for keyring backend detection and secure session storage."""
 
+import json
 import sys
 import types
 from unittest.mock import MagicMock
@@ -64,7 +65,7 @@ def install_fake_keyring(monkeypatch):
 class TestKeyringAvailable:
     def test_returns_true_when_probe_round_trips(self, install_fake_keyring):
         """A real backend (set + get returns same value + delete) is accepted."""
-        fake = install_fake_keyring(_FakeKeyring(get_returns="1"))
+        fake = install_fake_keyring(_FakeKeyring(get_returns=ss_module._PROBE_VALUE))
         assert _keyring_available() is True
         assert len(fake.set_calls) == 1
         assert len(fake.get_calls) == 1
@@ -79,10 +80,22 @@ class TestKeyringAvailable:
         tokens to be written to a plaintext file. The probe roundtrip ignores
         class names entirely and only trusts what the backend can actually do.
         """
-        fake = install_fake_keyring(_FakeKeyring(get_returns="1"))
+        fake = install_fake_keyring(_FakeKeyring(get_returns=ss_module._PROBE_VALUE))
         # Simulate the macOS Keychain class name to prove name has no effect.
         fake.__class__.__name__ = "Keyring"
         assert _keyring_available() is True
+
+    def test_probe_uses_chunk_sized_payload(self, install_fake_keyring):
+        """A 1-byte probe passes on backends whose real saves fail.
+
+        Windows Credential Manager accepts tiny writes but rejects blobs over
+        ~2560 bytes, so the probe must write a full chunk to prove that
+        chunk-sized saves actually work.
+        """
+        fake = install_fake_keyring(_FakeKeyring(get_returns=ss_module._PROBE_VALUE))
+        _keyring_available()
+        (_service, _username, value) = fake.set_calls[0]
+        assert len(value) == ss_module._KEYRING_CHUNK_SIZE
 
     def test_returns_false_when_set_raises(self, install_fake_keyring):
         """The fail backend raises on set_password — we must NOT trust it."""
@@ -108,7 +121,10 @@ class TestKeyringAvailable:
     def test_returns_false_when_delete_raises(self, install_fake_keyring):
         """Delete failure means cleanup is broken; don't trust the backend."""
         install_fake_keyring(
-            _FakeKeyring(get_returns="1", delete_raises=RuntimeError("rm failed"))
+            _FakeKeyring(
+                get_returns=ss_module._PROBE_VALUE,
+                delete_raises=RuntimeError("rm failed"),
+            )
         )
         assert _keyring_available() is False
 
@@ -129,7 +145,7 @@ class TestKeyringAvailable:
 
     def test_probe_uses_dedicated_username(self, install_fake_keyring):
         """The probe must not clobber the real token username."""
-        fake = install_fake_keyring(_FakeKeyring(get_returns="1"))
+        fake = install_fake_keyring(_FakeKeyring(get_returns=ss_module._PROBE_VALUE))
         _keyring_available()
         for _service, username, _value in fake.set_calls:
             assert username != ss_module.KEYRING_USERNAME
@@ -158,7 +174,7 @@ class _StorageFakeKeyring:
 
 
 @pytest.fixture
-def storage_keyring(monkeypatch):
+def storage_keyring(monkeypatch, tmp_path):
     """Install a roundtrip-capable fake keyring and return a fresh session."""
     fake = _StorageFakeKeyring()
     module = types.ModuleType("keyring")
@@ -166,6 +182,10 @@ def storage_keyring(monkeypatch):
     module.get_password = fake.get_password
     module.delete_password = fake.delete_password
     monkeypatch.setitem(sys.modules, "keyring", module)
+    # Sandbox the file fallback so tests never read or write the real
+    # ~/.monarch-mcp-server/token on the host machine.
+    monkeypatch.setattr(ss_module, "_TOKEN_DIR", tmp_path / "fallback")
+    monkeypatch.setattr(ss_module, "_TOKEN_FILE", tmp_path / "fallback" / "token")
 
     session = ss_module.SecureMonarchSession()
     # __init__ ran the probe and set _use_keyring=True via the fake.
@@ -285,6 +305,172 @@ class TestBackwardCompatLoading:
         )
 
         assert session.load_session() is None
+
+
+class _WindowsLimitedKeyring(_StorageFakeKeyring):
+    """Simulates Windows Credential Manager's CRED_MAX_CREDENTIAL_BLOB_SIZE.
+
+    The WinVault backend stores passwords as UTF-16 (2 bytes/char) and the
+    OS rejects blobs over ~2560 bytes, so writes over 1280 characters fail
+    with the (1783, 'CredWrite', 'The stub received bad data') error.
+    """
+
+    MAX_CHARS = 1280
+
+    def set_password(self, service, username, value):
+        if len(value) > self.MAX_CHARS:
+            raise OSError(1783, "CredWrite", "The stub received bad data")
+        super().set_password(service, username, value)
+
+
+def _oversized_cookies():
+    """Cookies large enough that the JSON blob exceeds one keyring entry."""
+    return {
+        "session_id": "s" * 200,
+        "csrftoken": "c" * 100,
+        "cf_clearance": "f" * 3000,
+    }
+
+
+class TestChunkedKeyringStorage:
+    """Blobs too large for one Windows credential must chunk transparently."""
+
+    def test_oversized_blob_roundtrips(self, storage_keyring):
+        session, fake = storage_keyring
+        cookies = _oversized_cookies()
+        session.save_session_blob(
+            token="tok-abc",
+            device_uuid="dev-xyz",
+            cookies=cookies,
+            auth_mode="cookie",
+        )
+
+        loaded = session.load_session()
+        assert loaded is not None
+        assert loaded["token"] == "tok-abc"
+        assert loaded["device_uuid"] == "dev-xyz"
+        assert loaded["cookies"] == cookies
+        assert loaded["auth_mode"] == "cookie"
+
+    def test_oversized_blob_is_stored_in_chunks(self, storage_keyring):
+        session, fake = storage_keyring
+        session.save_session_blob(cookies=_oversized_cookies(), auth_mode="cookie")
+
+        main = fake.get_password(ss_module.KEYRING_SERVICE, ss_module.KEYRING_USERNAME)
+        index = json.loads(main)
+        count = index[ss_module._CHUNK_MARKER]
+        assert count >= 2
+
+        for i in range(count):
+            chunk = fake.get_password(
+                ss_module.KEYRING_SERVICE, ss_module._chunk_username(i)
+            )
+            assert chunk is not None
+            # Every entry must fit within one Windows credential blob.
+            assert len(chunk) <= ss_module._KEYRING_CHUNK_SIZE
+        # No orphan entries past the recorded count.
+        assert (
+            fake.get_password(
+                ss_module.KEYRING_SERVICE, ss_module._chunk_username(count)
+            )
+            is None
+        )
+
+    def test_oversized_blob_saves_on_windows_sized_backend(
+        self, monkeypatch, tmp_path
+    ):
+        """The exact production failure: a big cookie blob on Windows.
+
+        Before chunking, set_password raised (1783, 'CredWrite', ...) and the
+        session fell back to a plaintext file. With chunking every write is
+        under the limit, so the save must succeed inside the keyring.
+        """
+        fake = _WindowsLimitedKeyring()
+        module = types.ModuleType("keyring")
+        module.set_password = fake.set_password
+        module.get_password = fake.get_password
+        module.delete_password = fake.delete_password
+        monkeypatch.setitem(sys.modules, "keyring", module)
+        # Point the file fallback at a sandbox so we can prove it stays unused.
+        monkeypatch.setattr(ss_module, "_TOKEN_DIR", tmp_path / "fallback")
+        monkeypatch.setattr(ss_module, "_TOKEN_FILE", tmp_path / "fallback" / "token")
+
+        session = ss_module.SecureMonarchSession()
+        assert session._use_keyring is True
+
+        cookies = _oversized_cookies()
+        session.save_session_blob(cookies=cookies, auth_mode="cookie")
+
+        assert not (tmp_path / "fallback" / "token").exists(), (
+            "oversized session must not fall back to plaintext file storage"
+        )
+        loaded = session.load_session()
+        assert loaded["cookies"] == cookies
+
+    def test_small_save_after_oversized_removes_stale_chunks(self, storage_keyring):
+        session, fake = storage_keyring
+        session.save_session_blob(cookies=_oversized_cookies(), auth_mode="cookie")
+        session.save_session_blob(token="tiny-token", auth_mode="token")
+
+        loaded = session.load_session()
+        assert loaded == {"token": "tiny-token", "auth_mode": "token"}
+        # All chunk entries from the earlier oversized save must be gone.
+        assert (
+            fake.get_password(
+                ss_module.KEYRING_SERVICE, ss_module._chunk_username(0)
+            )
+            is None
+        )
+
+    def test_shrinking_oversized_save_removes_extra_chunks(self, storage_keyring):
+        """A smaller (but still chunked) save must not leave orphan chunks."""
+        session, fake = storage_keyring
+        session.save_session_blob(
+            cookies={"cf_clearance": "f" * 8000}, auth_mode="cookie"
+        )
+        session.save_session_blob(
+            cookies={"cf_clearance": "f" * 2000}, auth_mode="cookie"
+        )
+
+        loaded = session.load_session()
+        assert loaded["cookies"] == {"cf_clearance": "f" * 2000}
+        main = fake.get_password(ss_module.KEYRING_SERVICE, ss_module.KEYRING_USERNAME)
+        count = json.loads(main)[ss_module._CHUNK_MARKER]
+        assert (
+            fake.get_password(
+                ss_module.KEYRING_SERVICE, ss_module._chunk_username(count)
+            )
+            is None
+        )
+
+    def test_delete_token_removes_index_and_chunks(self, storage_keyring):
+        session, fake = storage_keyring
+        session.save_session_blob(cookies=_oversized_cookies(), auth_mode="cookie")
+
+        session.delete_token()
+
+        assert fake._store == {}
+        assert session.load_session() is None
+
+    def test_missing_chunk_treated_as_no_session(self, storage_keyring):
+        """A corrupted chunked entry must not crash or return partial JSON."""
+        session, fake = storage_keyring
+        session.save_session_blob(cookies=_oversized_cookies(), auth_mode="cookie")
+        fake.delete_password(
+            ss_module.KEYRING_SERVICE, ss_module._chunk_username(1)
+        )
+
+        assert session.load_session() is None
+
+    def test_single_entry_format_unchanged_for_small_blobs(self, storage_keyring):
+        """Small sessions must keep the exact pre-chunking storage format."""
+        session, fake = storage_keyring
+        session.save_session_blob(token="tok", device_uuid="dev", auth_mode="token")
+
+        main = fake.get_password(ss_module.KEYRING_SERVICE, ss_module.KEYRING_USERNAME)
+        parsed = json.loads(main)
+        assert ss_module._CHUNK_MARKER not in parsed
+        assert parsed["token"] == "tok"
 
 
 class TestGetAuthenticatedClient:


### PR DESCRIPTION
## Problem

On Windows, saving a cookie-mode session fails with:

```
keyring save error (1783, 'CredWrite', 'The stub received bad data')
```

and the session silently falls back to **plaintext file storage** at `~/.monarch-mcp-server/token` — while the logs make it look like secure storage is working.

Root cause: Windows Credential Manager caps credential blobs at ~2560 bytes (`CRED_MAX_CREDENTIAL_BLOB_SIZE`), and keyring's WinVault backend stores passwords as UTF-16 (2 bytes/char), so anything over ~1280 characters is rejected. The cookie-mode JSON blob introduced in #73 (token + device_uuid + cookies including `cf_clearance`) essentially always exceeds that, so on Windows cookie auth *always* degrades to the plaintext fallback.

## Fix

`secure_session.py` now chunks oversized blobs across multiple keyring entries:

- Blobs ≤ 1024 chars keep the exact single-entry format at `monarch-token` — no change for existing installs.
- Larger blobs are split into 1024-char chunks under `monarch-token-chunk-0..N-1`, with a small JSON index (`{"__monarch_chunks__": N}`) at `monarch-token`.
- Chunks are written before the index, so a crash mid-save can never leave an index pointing at missing chunks.
- Saves and `delete_token` sweep stale chunk entries, so shrinking sessions leave no orphans.
- A chunked entry with a missing chunk is treated as "no session" (falls through to the file fallback) rather than returning truncated JSON.
- Backward compatible with all existing formats: single-entry JSON, legacy bare-token strings, and file-fallback sessions load unchanged.

Chunking was chosen over zlib+base64 compression because `cf_clearance` is high-entropy data that barely compresses — compression cannot guarantee fitting under the limit.

## Probe hardening

`_keyring_available()` round-tripped a 1-byte sentinel, which passes on Windows even though real saves fail. The probe now round-trips a full chunk-sized (1024-char) payload, so a backend that accepts tiny writes but rejects real ones is no longer trusted.

## Tests

New `TestChunkedKeyringStorage` class covering:

- oversized cookie-blob save/load round-trip
- a simulated Windows backend that raises error 1783 on writes over 1280 chars — proving the save now stays in the keyring with no plaintext fallback
- stale-chunk cleanup when sessions shrink, chunked deletion, missing-chunk handling
- format stability for small blobs (no chunk marker leaks into normal sessions)

Also sandboxed the file-fallback path in the shared test fixture: tests previously read the real `~/.monarch-mcp-server/token`, so `test_no_session_returns_none` failed on any machine where the fallback had ever triggered.

Full suite: **231 passed**.
