### PR TITLE
Harden session storage against loss, races, and corrupt reads

### DIFF
--- a/src/monarch_mcp_server/auth.py
+++ b/src/monarch_mcp_server/auth.py
@@ -13,6 +13,7 @@ except ImportError:  # mcp < 2.0
 from monarchmoney import MonarchMoney, RequireMFAException
 from pydantic import BaseModel, Field
 
+from monarch_mcp_server.client import clear_client_cache
 from monarch_mcp_server.secure_session import secure_session
 
 
@@ -93,6 +94,11 @@ async def login_interactive(ctx: Context) -> str:
         )
 
     secure_session.save_authenticated_session(mm)
+    # The module level client cache holds its own Authorization header and is
+    # unaffected by what storage now contains. Without this, a re-login after a
+    # session expires reports success while every subsequent call keeps using
+    # the dead client, and the only fix is restarting the host process.
+    clear_client_cache()
     return "Logged in. Session saved to system keyring."
 
 
@@ -117,9 +123,14 @@ async def login_with_token_interactive(ctx: Context) -> str:
     mm = MonarchMoney(token=token)
     await mm.get_subscription_details()
     secure_session.save_token(token)
+    clear_client_cache()
     return "Session token saved to system keyring."
 
 
 async def logout() -> str:
     secure_session.delete_token()
+    # Deleting the stored session is not enough. A cached client keeps its own
+    # Authorization header, so without dropping the cache every tool call after
+    # a logout still returns live financial data for the life of the process.
+    clear_client_cache()
     return "Cleared stored Monarch session."

--- a/src/monarch_mcp_server/secure_session.py
+++ b/src/monarch_mcp_server/secure_session.py
@@ -5,10 +5,12 @@ Uses the system keyring when available, with an automatic file-based
 fallback for environments without a keyring backend (e.g. WSL, headless Linux).
 """
 
+import base64
 import json
 import logging
 import os
 import stat
+import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 from monarchmoney import MonarchMoney
@@ -45,6 +47,53 @@ _TOKEN_FILE = _TOKEN_DIR / "token"
 
 _PROBE_USERNAME = "__keyring_probe__"
 _PROBE_VALUE = "x" * _KEYRING_CHUNK_SIZE
+
+
+# --- Windows DPAPI encryption for the file fallback -------------------------
+#
+# On Windows the keyring backend (Credential Manager) has a hard size limit on
+# the credential blob, so a full cookie session (~1 KB+) cannot be stored there
+# and we fall back to a file. To avoid leaving that file as plaintext, we
+# encrypt it at rest with DPAPI (CryptProtectData), scoped to the current user
+# — the same per-user protection Credential Manager itself uses, without the
+# size cap. On non-Windows platforms this is a no-op and the file stays as-is.
+_DPAPI_PREFIX = "DPAPI:"
+
+
+def _dpapi_available() -> bool:
+    """True only on Windows with pywin32's win32crypt importable."""
+    if sys.platform != "win32":
+        return False
+    try:
+        import win32crypt  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def _dpapi_encrypt(plaintext: str) -> str:
+    """Encrypt a string with DPAPI; returns ``DPAPI:<base64>``."""
+    import win32crypt
+
+    blob = win32crypt.CryptProtectData(
+        plaintext.encode("utf-8"),
+        "monarch-mcp-server session",  # description (not secret)
+        None,
+        None,
+        None,
+        0,
+    )
+    return _DPAPI_PREFIX + base64.b64encode(blob).decode("ascii")
+
+
+def _dpapi_decrypt(payload: str) -> str:
+    """Decrypt a ``DPAPI:<base64>`` string produced by :func:`_dpapi_encrypt`."""
+    import win32crypt
+
+    raw = base64.b64decode(payload[len(_DPAPI_PREFIX):])
+    # CryptUnprotectData returns (description, data).
+    _desc, data = win32crypt.CryptUnprotectData(raw, None, None, None, 0)
+    return data.decode("utf-8")
 
 
 def _keyring_available() -> bool:
@@ -108,19 +157,45 @@ class SecureMonarchSession:
 
     def _save_token_file(self, token: str) -> None:
         _TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+        # Encrypt at rest with DPAPI on Windows; plaintext elsewhere.
+        if _dpapi_available():
+            data = _dpapi_encrypt(token)
+            how = "DPAPI-encrypted"
+        else:
+            data = token
+            how = "plaintext"
         # Write with owner-only permissions
-        _TOKEN_FILE.write_text(token)
+        _TOKEN_FILE.write_text(data)
         _TOKEN_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 600
         _TOKEN_DIR.chmod(stat.S_IRWXU)  # 700
-        logger.info(f"✅ Token saved to {_TOKEN_FILE}")
+        logger.info(f"✅ Token saved ({how}) to {_TOKEN_FILE}")
 
     def _load_token_file(self) -> Optional[str]:
-        if _TOKEN_FILE.is_file():
-            token = _TOKEN_FILE.read_text().strip()
-            if token:
-                logger.info(f"✅ Token loaded from {_TOKEN_FILE}")
+        if not _TOKEN_FILE.is_file():
+            return None
+        raw = _TOKEN_FILE.read_text().strip()
+        if not raw:
+            return None
+
+        if raw.startswith(_DPAPI_PREFIX):
+            try:
+                token = _dpapi_decrypt(raw)
+                logger.info(f"✅ Token loaded (DPAPI-encrypted) from {_TOKEN_FILE}")
                 return token
-        return None
+            except Exception as e:
+                logger.warning(f"⚠️  Could not decrypt token file: {e}")
+                return None
+
+        # Legacy plaintext file. Migrate it to encrypted-at-rest transparently
+        # when DPAPI is available, then return the value.
+        logger.info(f"✅ Token loaded (plaintext) from {_TOKEN_FILE}")
+        if _dpapi_available():
+            try:
+                self._save_token_file(raw)
+                logger.info("🔐 Migrated plaintext token file to DPAPI-encrypted at rest")
+            except Exception as e:
+                logger.warning(f"⚠️  Could not migrate token file to encrypted: {e}")
+        return raw
 
     def _delete_token_file(self) -> None:
         if _TOKEN_FILE.is_file():

--- a/src/monarch_mcp_server/secure_session.py
+++ b/src/monarch_mcp_server/secure_session.py
@@ -12,7 +12,7 @@ import os
 import stat
 import sys
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 from monarchmoney import MonarchMoney
 
 from monarch_mcp_server.monarch_auth import (
@@ -36,6 +36,16 @@ KEYRING_USERNAME = "monarch-token"
 _KEYRING_CHUNK_SIZE = 1024
 _CHUNK_USERNAME_PREFIX = KEYRING_USERNAME + "-chunk-"
 _CHUNK_MARKER = "__monarch_chunks__"
+# Chunk entries are written under a generation tag, and the index that names
+# the generation is flipped only after every chunk of that generation is
+# stored. Overwriting chunks in place is not safe: a save that fails partway
+# (Windows CredWrite rejecting chunk 3 of 5, or the process being killed)
+# would leave the previous index pointing at a mix of old and new bytes, which
+# destroys a working session and, because the keyring is preferred over the
+# file, hides the fallback written by the error path too. Two generations are
+# enough, since the previous one is only deleted once the new index is live.
+_CHUNK_GEN_MARKER = "__monarch_gen__"
+_CHUNK_GENERATIONS = (0, 1)
 # Safety cap when sweeping chunk entries so a misbehaving backend that
 # returns a value for every username can't loop forever.
 _MAX_CHUNKS = 256
@@ -45,7 +55,13 @@ _TOKEN_DIR = Path.home() / ".monarch-mcp-server"
 _TOKEN_FILE = _TOKEN_DIR / "token"
 
 
-_PROBE_USERNAME = "__keyring_probe__"
+# The probe username is per-process. MCP hosts routinely start more than one
+# server process, and with a single shared username their probes race: both
+# write the sentinel, the first to finish deletes it, and the second's read
+# returns None. That process concludes the keyring is unusable and silently
+# drops to file storage for its whole lifetime, so whichever process happens to
+# serve a tool call decides whether authentication works.
+_PROBE_USERNAME = f"__keyring_probe__{os.getpid()}"
 _PROBE_VALUE = "x" * _KEYRING_CHUNK_SIZE
 
 
@@ -65,7 +81,7 @@ def _dpapi_available() -> bool:
     if sys.platform != "win32":
         return False
     try:
-        import win32crypt  # noqa: F401
+        import win32crypt  # type: ignore[import-untyped]  # noqa: F401
     except Exception:
         return False
     return True
@@ -93,7 +109,8 @@ def _dpapi_decrypt(payload: str) -> str:
     raw = base64.b64decode(payload[len(_DPAPI_PREFIX):])
     # CryptUnprotectData returns (description, data).
     _desc, data = win32crypt.CryptUnprotectData(raw, None, None, None, 0)
-    return data.decode("utf-8")
+    decoded: str = data.decode("utf-8")
+    return decoded
 
 
 def _keyring_available() -> bool:
@@ -109,6 +126,11 @@ def _keyring_available() -> bool:
     The probe value is one full chunk (_KEYRING_CHUNK_SIZE chars), not a
     single byte: Windows Credential Manager accepts tiny writes but rejects
     large ones, so a 1-byte probe would pass while real saves fail.
+
+    Only set and get decide the verdict. A backend that stores and returns the
+    sentinel works for storage, and failing the probe over a delete error would
+    downgrade a working keyring to plaintext file storage, which is strictly
+    worse. Cleanup therefore runs in a finally block on a best-effort basis.
     """
     try:
         import keyring
@@ -118,28 +140,162 @@ def _keyring_available() -> bool:
     try:
         keyring.set_password(KEYRING_SERVICE, _PROBE_USERNAME, _PROBE_VALUE)
         stored = keyring.get_password(KEYRING_SERVICE, _PROBE_USERNAME)
-        keyring.delete_password(KEYRING_SERVICE, _PROBE_USERNAME)
     except Exception:
         return False
+    finally:
+        try:
+            keyring.delete_password(KEYRING_SERVICE, _PROBE_USERNAME)
+        except Exception:
+            pass
 
     return stored == _PROBE_VALUE
 
 
-def _chunk_username(index: int) -> str:
-    return f"{_CHUNK_USERNAME_PREFIX}{index}"
+def _chunk_username(index: int, generation: Optional[int] = None) -> str:
+    """Username for chunk *index*.
+
+    ``generation`` of None selects the ungenerationed layout written before
+    generations existed, which must still be readable on upgrade.
+    """
+    if generation is None:
+        return f"{_CHUNK_USERNAME_PREFIX}{index}"
+    return f"{KEYRING_USERNAME}-g{generation}-chunk-{index}"
 
 
-def _parse_chunk_count(raw: str) -> Optional[int]:
-    """Return the chunk count if `raw` is a chunk-index entry, else None."""
+def _parse_chunk_index(raw: str) -> Optional[Tuple[int, Optional[int]]]:
+    """Return ``(count, generation)`` if *raw* is a chunk index, else None.
+
+    ``generation`` is None for an index written before generations existed.
+    """
     try:
         parsed = json.loads(raw)
     except (json.JSONDecodeError, TypeError):
         return None
-    if isinstance(parsed, dict) and isinstance(parsed.get(_CHUNK_MARKER), int):
-        count = parsed[_CHUNK_MARKER]
-        if 0 < count <= _MAX_CHUNKS:
-            return count
-    return None
+    if not isinstance(parsed, dict):
+        return None
+    count = parsed.get(_CHUNK_MARKER)
+    if not isinstance(count, int) or not 0 < count <= _MAX_CHUNKS:
+        return None
+    generation = parsed.get(_CHUNK_GEN_MARKER)
+    if not isinstance(generation, int) or generation not in _CHUNK_GENERATIONS:
+        generation = None
+    return count, generation
+
+
+def _parse_chunk_count(raw: str) -> Optional[int]:
+    """Return the chunk count if `raw` is a chunk-index entry, else None."""
+    parsed = _parse_chunk_index(raw)
+    return parsed[0] if parsed else None
+
+
+def _write_secret_file(path: Path, data: str) -> None:
+    """Write *data* to *path* atomically, never exposing it at a wider mode.
+
+    Two properties matter here, because this file holds a long lived credential
+    with full account access:
+
+    - The file is created with 0600 already set, via ``os.open`` with an
+      explicit mode. ``write_text`` followed by ``chmod`` creates the file under
+      the process umask first, typically 0644, leaving a window in which any
+      local user can read the token.
+    - The write goes to a temp file in the same directory, is flushed and
+      fsynced, and is then moved into place with ``os.replace``. A concurrent
+      reader therefore sees either the old blob or the new one, never a partial
+      one, and a crash or a full disk cannot leave the stored session truncated.
+    """
+    directory = path.parent
+    tmp_path = directory / f".{path.name}.{os.getpid()}.tmp"
+    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+    # Best effort: fsync the directory so the rename itself is durable. Not
+    # supported on every platform, and not worth failing the save over.
+    try:
+        dir_fd = os.open(directory, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except (OSError, AttributeError):
+        pass
+
+
+# A Monarch session token is a compact opaque string. Nothing that fails to
+# parse as JSON should be accepted as one unless it actually looks like one:
+# the fallback exists only for very old installs that stored the raw token.
+_MAX_BARE_TOKEN_CHARS = 1024
+_TOKEN_FORBIDDEN_CHARS = frozenset('{}[]"\'\\ \t\r\n')
+
+
+def _looks_like_bare_token(value: str) -> bool:
+    """Whether *value* is plausibly a legacy raw token rather than debris.
+
+    Without this check, a corrupted blob that happens not to start with a
+    brace is accepted as a token. That is not hypothetical: splicing chunks
+    from two different saves yields exactly such a string, and it produced a
+    client whose every call failed with an opaque 401.
+    """
+    if not value or len(value) > _MAX_BARE_TOKEN_CHARS:
+        return False
+    return not (_TOKEN_FORBIDDEN_CHARS & set(value))
+
+
+def _parse_session_blob(raw_session: str) -> Optional[Dict[str, Any]]:
+    """Parse a stored session blob, or return None if it is not usable.
+
+    Accepts three formats:
+
+    1. Bare token string (very old installs).
+    2. JSON blob with token and optional device_uuid, no auth_mode.
+    3. Current JSON blob with explicit auth_mode and optional cookies.
+
+    Cookies are returned as a nested dict to preserve their original key/value
+    pairs (an older implementation flattened everything to str(value), which
+    corrupted nested dicts).
+    """
+    try:
+        parsed = json.loads(raw_session)
+    except json.JSONDecodeError:
+        if _looks_like_bare_token(raw_session):
+            # Legacy entry: the stored value is the bare token string.
+            return {"token": raw_session, "auth_mode": "token"}
+        # Anything else was written as a JSON blob and did not survive intact:
+        # a truncated write, a partially reassembled set of keyring chunks, or
+        # a corrupted file. Handing the fragment back as a token would build a
+        # client with a garbage Authorization header that 401s on every call,
+        # which is far harder to diagnose than a missing session.
+        return None
+
+    if not isinstance(parsed, dict):
+        return None
+    if not parsed.get("token") and not parsed.get("cookies"):
+        return None
+
+    result: Dict[str, Any] = {}
+    if isinstance(parsed.get("token"), str):
+        result["token"] = parsed["token"]
+    if isinstance(parsed.get("device_uuid"), str):
+        result["device_uuid"] = parsed["device_uuid"]
+    cookies = parsed.get("cookies")
+    if isinstance(cookies, dict) and cookies:
+        result["cookies"] = {str(k): str(v) for k, v in cookies.items()}
+    # Default to "cookie" only when cookies are present and no explicit
+    # auth_mode says otherwise; otherwise default to "token".
+    result["auth_mode"] = parsed.get(
+        "auth_mode", "cookie" if result.get("cookies") else "token"
+    )
+    return result
 
 
 class SecureMonarchSession:
@@ -156,7 +312,14 @@ class SecureMonarchSession:
     # -- file-based helpers --------------------------------------------------
 
     def _save_token_file(self, token: str) -> None:
-        _TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+        _TOKEN_DIR.mkdir(parents=True, exist_ok=True, mode=stat.S_IRWXU)
+        # mkdir's mode is masked by the umask, so narrow the directory before
+        # anything is written into it rather than after.
+        try:
+            _TOKEN_DIR.chmod(stat.S_IRWXU)  # 700
+        except OSError as e:
+            logger.warning(f"⚠️  Could not restrict {_TOKEN_DIR}: {e}")
+
         # Encrypt at rest with DPAPI on Windows; plaintext elsewhere.
         if _dpapi_available():
             data = _dpapi_encrypt(token)
@@ -164,10 +327,8 @@ class SecureMonarchSession:
         else:
             data = token
             how = "plaintext"
-        # Write with owner-only permissions
-        _TOKEN_FILE.write_text(data)
-        _TOKEN_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 600
-        _TOKEN_DIR.chmod(stat.S_IRWXU)  # 700
+
+        _write_secret_file(_TOKEN_FILE, data)
         logger.info(f"✅ Token saved ({how}) to {_TOKEN_FILE}")
 
     def _load_token_file(self) -> Optional[str]:
@@ -211,17 +372,23 @@ class SecureMonarchSession:
         """Save a blob to the keyring, chunking when it exceeds the safe size.
 
         Small blobs are stored directly under KEYRING_USERNAME exactly as
-        before. Oversized blobs are split into _KEYRING_CHUNK_SIZE-char
-        pieces under monarch-token-chunk-0..N-1, with a small JSON index
-        entry under KEYRING_USERNAME. Chunks are written before the index so
-        a crash mid-save can't leave an index pointing at missing chunks.
-        Raises on failure so the caller can fall back to file storage.
+        before. Oversized blobs are split into _KEYRING_CHUNK_SIZE-char pieces
+        under monarch-token-g{gen}-chunk-0..N-1, with a small JSON index entry
+        under KEYRING_USERNAME naming the generation and the count.
+
+        The new generation is written in full before the index is flipped to
+        point at it, and the previous generation is deleted only afterwards.
+        So a save that fails at any point leaves the previously stored session
+        completely intact and still readable. Raises on failure so the caller
+        can fall back to file storage.
         """
         import keyring
 
+        previous = self._current_chunk_index()
+        previous_generation = previous[1] if previous else None
+
         if len(blob) <= _KEYRING_CHUNK_SIZE:
             keyring.set_password(KEYRING_SERVICE, KEYRING_USERNAME, blob)
-            new_count = 0
         else:
             chunks = [
                 blob[i : i + _KEYRING_CHUNK_SIZE]
@@ -231,17 +398,41 @@ class SecureMonarchSession:
                 raise ValueError(
                     f"Session blob too large to chunk: {len(blob)} chars"
                 )
+            generation = self._next_generation(previous_generation)
             for i, chunk in enumerate(chunks):
-                keyring.set_password(KEYRING_SERVICE, _chunk_username(i), chunk)
+                keyring.set_password(
+                    KEYRING_SERVICE, _chunk_username(i, generation), chunk
+                )
+            # Only now does the new data become the live session.
             keyring.set_password(
                 KEYRING_SERVICE,
                 KEYRING_USERNAME,
-                json.dumps({_CHUNK_MARKER: len(chunks)}),
+                json.dumps(
+                    {_CHUNK_MARKER: len(chunks), _CHUNK_GEN_MARKER: generation}
+                ),
             )
-            new_count = len(chunks)
+        # The superseded generation is now unreferenced. Clearing it is
+        # housekeeping, so a failure here must not fail the save.
+        self._delete_superseded_chunks(previous)
 
-        # Remove stale chunk entries left over from a previous, larger save.
-        self._delete_chunk_entries(start=new_count)
+    def _current_chunk_index(self) -> Optional[Tuple[int, Optional[int]]]:
+        """Return ``(count, generation)`` for the live chunked session, if any."""
+        try:
+            import keyring
+
+            raw = keyring.get_password(KEYRING_SERVICE, KEYRING_USERNAME)
+        except Exception:
+            return None
+        return _parse_chunk_index(raw) if raw is not None else None
+
+    @staticmethod
+    def _next_generation(previous: Optional[int]) -> int:
+        """Pick a generation tag that cannot collide with the live one."""
+        if previous is None:
+            return _CHUNK_GENERATIONS[0]
+        return _CHUNK_GENERATIONS[
+            (_CHUNK_GENERATIONS.index(previous) + 1) % len(_CHUNK_GENERATIONS)
+        ]
 
     def _keyring_load(self) -> Optional[str]:
         """Load the blob from the keyring, reassembling chunks if needed."""
@@ -251,13 +442,16 @@ class SecureMonarchSession:
         if raw is None:
             return None
 
-        count = _parse_chunk_count(raw)
-        if count is None:
+        index = _parse_chunk_index(raw)
+        if index is None:
             return raw
+        count, generation = index
 
         parts = []
         for i in range(count):
-            part = keyring.get_password(KEYRING_SERVICE, _chunk_username(i))
+            part = keyring.get_password(
+                KEYRING_SERVICE, _chunk_username(i, generation)
+            )
             if part is None:
                 logger.warning(
                     "⚠️  Keyring session is chunked but chunk %d/%d is missing",
@@ -268,21 +462,41 @@ class SecureMonarchSession:
             parts.append(part)
         return "".join(parts)
 
-    def _delete_chunk_entries(self, start: int = 0) -> None:
-        """Delete chunk entries from `start` upward until one is absent."""
+    def _delete_superseded_chunks(
+        self, previous: Optional[Tuple[int, Optional[int]]]
+    ) -> None:
+        """Delete the chunk entries the previous index pointed at."""
+        if previous is None:
+            return
+        count, generation = previous
+        self._delete_chunk_entries(generation=generation, limit=count)
+
+    def _delete_chunk_entries(
+        self, generation: Optional[int] = None, limit: int = _MAX_CHUNKS
+    ) -> None:
+        """Delete chunk entries for *generation* until one is absent.
+
+        A generation of None targets the ungenerationed layout written before
+        generations existed, so an upgraded install still gets cleaned up.
+        """
         try:
             import keyring
         except ImportError:
             return
 
-        for i in range(start, _MAX_CHUNKS):
-            username = _chunk_username(i)
+        for i in range(min(limit, _MAX_CHUNKS)):
+            username = _chunk_username(i, generation)
             try:
                 if keyring.get_password(KEYRING_SERVICE, username) is None:
                     break
                 keyring.delete_password(KEYRING_SERVICE, username)
             except Exception:
                 break
+
+    def _delete_all_chunk_entries(self) -> None:
+        """Sweep every chunk layout: both generations and the legacy naming."""
+        for generation in (None, *_CHUNK_GENERATIONS):
+            self._delete_chunk_entries(generation=generation)
 
     # -- public API ----------------------------------------------------------
 
@@ -362,46 +576,38 @@ class SecureMonarchSession:
         original key/value pairs (legacy ``load_session`` flattened
         everything to ``str(value)`` which corrupted nested dicts).
         """
-        raw_session = None
-        if self._use_keyring:
-            try:
-                raw_session = self._keyring_load()
-            except Exception as e:
-                logger.warning(f"⚠️  Keyring load failed, trying file fallback: {e}")
+        # Each source is tried in turn. A source that holds an unusable value
+        # must not end the search: if the keyring entry is corrupt, the file
+        # fallback may still hold a perfectly good session, and giving up at
+        # the first bad read would strand a user who actually is logged in.
+        for load_raw, source in (
+            (self._keyring_load_guarded, "keyring"),
+            (self._load_token_file, "file fallback"),
+        ):
+            raw_session = load_raw()
+            if not raw_session:
+                continue
+            parsed = _parse_session_blob(raw_session)
+            if parsed is not None:
+                logger.info("✅ Session loaded from secure storage (%s)", source)
+                return parsed
+            logger.error(
+                "❌ Stored session in %s is unusable; trying the next source.",
+                source,
+            )
 
-        if raw_session is None:
-            raw_session = self._load_token_file()
+        logger.info("🔍 No session found")
+        return None
 
-        if not raw_session:
-            logger.info("🔍 No session found")
+    def _keyring_load_guarded(self) -> Optional[str]:
+        """_keyring_load, but never raising, and a no-op without a keyring."""
+        if not self._use_keyring:
             return None
-
-        logger.info("✅ Session loaded from secure storage")
         try:
-            parsed = json.loads(raw_session)
-        except json.JSONDecodeError:
-            # Legacy entry: the stored value is the bare token string.
-            return {"token": raw_session, "auth_mode": "token"}
-
-        if not isinstance(parsed, dict):
+            return self._keyring_load()
+        except Exception as e:
+            logger.warning(f"⚠️  Keyring load failed, trying file fallback: {e}")
             return None
-        if not parsed.get("token") and not parsed.get("cookies"):
-            return None
-
-        result: Dict[str, Any] = {}
-        if isinstance(parsed.get("token"), str):
-            result["token"] = parsed["token"]
-        if isinstance(parsed.get("device_uuid"), str):
-            result["device_uuid"] = parsed["device_uuid"]
-        cookies = parsed.get("cookies")
-        if isinstance(cookies, dict) and cookies:
-            result["cookies"] = {str(k): str(v) for k, v in cookies.items()}
-        # Default to "cookie" only when cookies are present and no explicit
-        # auth_mode says otherwise; otherwise default to "token".
-        result["auth_mode"] = parsed.get(
-            "auth_mode", "cookie" if result.get("cookies") else "token"
-        )
-        return result
 
     def delete_token(self) -> None:
         """Delete the authentication token from all storage backends."""
@@ -413,7 +619,7 @@ class SecureMonarchSession:
                 logger.info("🗑️ Token deleted from keyring")
             except Exception:
                 pass
-            self._delete_chunk_entries()
+            self._delete_all_chunk_entries()
 
         # Always try file cleanup too
         self._delete_token_file()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,44 @@ sys.modules.setdefault("monarchmoney.monarchmoney", MagicMock())
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def isolate_credential_storage(monkeypatch, tmp_path):
+    """Keep the whole suite away from real credential storage.
+
+    Two things went wrong without this. Tests that exercise session loading
+    read whatever the developer actually had stored, so a test asserting "no
+    session returns None" failed on any authenticated machine and passed
+    everywhere else. And constructing a SecureMonarchSession runs the keyring
+    probe, which writes to the real login keychain on macOS and can raise an
+    OS credential prompt during an ordinary test run.
+
+    Both the file fallback and the keyring backend are redirected here. Tests
+    that install their own keyring fake still win, because their monkeypatch
+    runs after this one.
+    """
+    import types
+
+    from monarch_mcp_server import secure_session as ss_module
+
+    monkeypatch.setattr(ss_module, "_TOKEN_DIR", tmp_path / "credential-store")
+    monkeypatch.setattr(
+        ss_module, "_TOKEN_FILE", tmp_path / "credential-store" / "token"
+    )
+
+    store: dict = {}
+    fake = types.ModuleType("keyring")
+    fake.set_password = lambda service, username, value: store.__setitem__(
+        (service, username), value
+    )
+    fake.get_password = lambda service, username: store.get((service, username))
+    fake.delete_password = lambda service, username: store.pop(
+        (service, username), None
+    )
+    monkeypatch.setitem(sys.modules, "keyring", fake)
+
+    yield
+
+
 @pytest.fixture
 def mock_monarch_client():
     """Create a mock MonarchMoney client with default responses."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,6 +9,13 @@ from monarchmoney import RequireMFAException
 
 from monarch_mcp_server import auth
 
+# Captured at import time, before conftest's autouse fixture replaces the name
+# in monarch_mcp_server.client with a mock. The cache invalidation test needs
+# the real implementation to prove an unauthenticated process actually refuses.
+_real_get_monarch_client = __import__(
+    "monarch_mcp_server.client", fromlist=["get_monarch_client"]
+).get_monarch_client
+
 
 def make_ctx(*elicit_results):
     """Build a mock Context whose elicit() returns the given results in order."""
@@ -108,6 +115,60 @@ class TestLogout:
         result = asyncio.run(auth.logout())
         assert "Cleared" in result
         no_session_save.delete_token.assert_called_once()
+
+
+class TestClientCacheInvalidation:
+    """Storage and the cached client must be kept in step.
+
+    The cached MonarchMoney holds its own Authorization header, so it is
+    unaffected by what is or is not in the keyring.
+    """
+
+    def test_logout_drops_the_cached_client(self, no_session_save):
+        from monarch_mcp_server import client as client_module
+
+        client_module._cached_client = object()
+        asyncio.run(auth.logout())
+        assert client_module._cached_client is None
+
+    def test_login_drops_the_stale_cached_client(self, no_session_save):
+        from monarch_mcp_server import client as client_module
+
+        client_module._cached_client = object()
+        mm = AsyncMock()
+        with patch("monarch_mcp_server.auth.MonarchMoney", return_value=mm):
+            ctx = make_ctx(accept(email="a@b.com", password="pw"))
+            asyncio.run(auth.login_interactive(ctx))
+        assert client_module._cached_client is None
+
+    def test_token_login_drops_the_stale_cached_client(self, no_session_save):
+        from monarch_mcp_server import client as client_module
+
+        client_module._cached_client = object()
+        mm = AsyncMock()
+        with patch("monarch_mcp_server.auth.MonarchMoney", return_value=mm):
+            ctx = make_ctx(accept(token="fresh-token"))
+            asyncio.run(auth.login_with_token_interactive(ctx))
+        assert client_module._cached_client is None
+
+    def test_logged_out_process_cannot_serve_tool_calls(self, no_session_save):
+        """The end to end property: after logout, the next call must re-auth.
+
+        Before this, monarch_logout reported success while every subsequent
+        get_accounts in that process still returned live financial data.
+        """
+        from monarch_mcp_server import client as client_module
+
+        client_module._cached_client = object()
+        asyncio.run(auth.logout())
+
+        with patch.object(
+            client_module.secure_session,
+            "get_authenticated_client",
+            return_value=None,
+        ):
+            with pytest.raises(RuntimeError, match="Authentication needed"):
+                asyncio.run(_real_get_monarch_client())
 
 
 class TestDebugSessionLoading:

--- a/tests/test_secure_session.py
+++ b/tests/test_secure_session.py
@@ -118,15 +118,42 @@ class TestKeyringAvailable:
         )
         assert _keyring_available() is False
 
-    def test_returns_false_when_delete_raises(self, install_fake_keyring):
-        """Delete failure means cleanup is broken; don't trust the backend."""
+    def test_delete_failure_does_not_reject_a_working_backend(
+        self, install_fake_keyring
+    ):
+        """A backend that stores and returns the sentinel is usable.
+
+        Rejecting it because the probe could not clean itself up downgrades a
+        working keyring to plaintext file storage, which is strictly worse than
+        leaving one stale sentinel entry behind.
+        """
         install_fake_keyring(
             _FakeKeyring(
                 get_returns=ss_module._PROBE_VALUE,
                 delete_raises=RuntimeError("rm failed"),
             )
         )
+        assert _keyring_available() is True
+
+    def test_probe_username_is_process_scoped(self):
+        """Concurrent server processes must not race on one shared sentinel.
+
+        MCP hosts start more than one server process. With a single shared
+        probe username their probes interleave, one process deletes the
+        sentinel the other just wrote, and that process concludes the keyring
+        is unusable for its whole lifetime.
+        """
+        import os
+
+        assert str(os.getpid()) in ss_module._PROBE_USERNAME
+
+    def test_probe_cleans_up_even_when_get_raises(self, install_fake_keyring):
+        """A failed probe must not leave its sentinel behind."""
+        fake = install_fake_keyring(
+            _FakeKeyring(get_raises=RuntimeError("read failed"))
+        )
         assert _keyring_available() is False
+        assert [u for _s, u in fake.delete_calls] == [ss_module._PROBE_USERNAME]
 
     def test_returns_false_when_keyring_not_installed(self, monkeypatch):
         """If the keyring package is absent, treat as unavailable, don't crash."""
@@ -359,11 +386,12 @@ class TestChunkedKeyringStorage:
         main = fake.get_password(ss_module.KEYRING_SERVICE, ss_module.KEYRING_USERNAME)
         index = json.loads(main)
         count = index[ss_module._CHUNK_MARKER]
+        generation = index[ss_module._CHUNK_GEN_MARKER]
         assert count >= 2
 
         for i in range(count):
             chunk = fake.get_password(
-                ss_module.KEYRING_SERVICE, ss_module._chunk_username(i)
+                ss_module.KEYRING_SERVICE, ss_module._chunk_username(i, generation)
             )
             assert chunk is not None
             # Every entry must fit within one Windows credential blob.
@@ -371,7 +399,8 @@ class TestChunkedKeyringStorage:
         # No orphan entries past the recorded count.
         assert (
             fake.get_password(
-                ss_module.KEYRING_SERVICE, ss_module._chunk_username(count)
+                ss_module.KEYRING_SERVICE,
+                ss_module._chunk_username(count, generation),
             )
             is None
         )
@@ -415,12 +444,14 @@ class TestChunkedKeyringStorage:
         loaded = session.load_session()
         assert loaded == {"token": "tiny-token", "auth_mode": "token"}
         # All chunk entries from the earlier oversized save must be gone.
-        assert (
-            fake.get_password(
-                ss_module.KEYRING_SERVICE, ss_module._chunk_username(0)
+        for generation in (None, *ss_module._CHUNK_GENERATIONS):
+            assert (
+                fake.get_password(
+                    ss_module.KEYRING_SERVICE,
+                    ss_module._chunk_username(0, generation),
+                )
+                is None
             )
-            is None
-        )
 
     def test_shrinking_oversized_save_removes_extra_chunks(self, storage_keyring):
         """A smaller (but still chunked) save must not leave orphan chunks."""
@@ -435,10 +466,12 @@ class TestChunkedKeyringStorage:
         loaded = session.load_session()
         assert loaded["cookies"] == {"cf_clearance": "f" * 2000}
         main = fake.get_password(ss_module.KEYRING_SERVICE, ss_module.KEYRING_USERNAME)
-        count = json.loads(main)[ss_module._CHUNK_MARKER]
+        index = json.loads(main)
+        count = index[ss_module._CHUNK_MARKER]
         assert (
             fake.get_password(
-                ss_module.KEYRING_SERVICE, ss_module._chunk_username(count)
+                ss_module.KEYRING_SERVICE,
+                ss_module._chunk_username(count, index[ss_module._CHUNK_GEN_MARKER]),
             )
             is None
         )
@@ -456,8 +489,12 @@ class TestChunkedKeyringStorage:
         """A corrupted chunked entry must not crash or return partial JSON."""
         session, fake = storage_keyring
         session.save_session_blob(cookies=_oversized_cookies(), auth_mode="cookie")
+        index = json.loads(
+            fake.get_password(ss_module.KEYRING_SERVICE, ss_module.KEYRING_USERNAME)
+        )
         fake.delete_password(
-            ss_module.KEYRING_SERVICE, ss_module._chunk_username(1)
+            ss_module.KEYRING_SERVICE,
+            ss_module._chunk_username(1, index[ss_module._CHUNK_GEN_MARKER]),
         )
 
         assert session.load_session() is None
@@ -471,6 +508,246 @@ class TestChunkedKeyringStorage:
         parsed = json.loads(main)
         assert ss_module._CHUNK_MARKER not in parsed
         assert parsed["token"] == "tok"
+
+
+class TestFailedSaveIsNonDestructive:
+    """A save that fails must never cost the user the session they had.
+
+    Chunk entries are written under a generation tag and the index is flipped
+    only once every chunk is stored, so a partial write is invisible.
+    """
+
+    def test_partial_chunk_write_leaves_previous_session_intact(
+        self, storage_keyring, monkeypatch
+    ):
+        session, fake = storage_keyring
+        good = {"session_id": "s" * 200, "cf_clearance": "f" * 3000}
+        session.save_session_blob(cookies=good, auth_mode="cookie")
+        assert session.load_session()["cookies"] == good
+
+        # Fail midway through writing the replacement, the way Windows
+        # Credential Manager does when it runs out of credential space.
+        calls = {"n": 0}
+        real_set = fake.set_password
+
+        def flaky_set(service, username, value):
+            calls["n"] += 1
+            if calls["n"] == 3:
+                raise OSError(1783, "CredWrite", "The stub received bad data")
+            return real_set(service, username, value)
+
+        monkeypatch.setitem(
+            sys.modules,
+            "keyring",
+            _module_from(fake, set_password=flaky_set),
+        )
+
+        with pytest.raises(OSError):
+            session._keyring_save("x" * 5000)
+
+        # The session the user actually had is still there and still correct.
+        assert session.load_session()["cookies"] == good
+
+    def test_corrupt_keyring_entry_falls_through_to_file_fallback(
+        self, storage_keyring, monkeypatch, tmp_path
+    ):
+        """A bad keyring read must not strand a user who has a good file."""
+        session, fake = storage_keyring
+        session._save_token_file(
+            json.dumps({"token": "file-token", "auth_mode": "token"})
+        )
+        fake.set_password(
+            ss_module.KEYRING_SERVICE,
+            ss_module.KEYRING_USERNAME,
+            '{"auth_mode": "cookie", "token": "eyJ0eX',
+        )
+
+        loaded = session.load_session()
+        assert loaded is not None, "a corrupt keyring entry hid a good session"
+        assert loaded["token"] == "file-token"
+
+    def test_legacy_ungenerationed_chunks_still_load(self, storage_keyring):
+        """Sessions written before generations existed must survive upgrade."""
+        session, fake = storage_keyring
+        blob = json.dumps({"token": "t" * 2000, "auth_mode": "token"})
+        chunks = [
+            blob[i : i + ss_module._KEYRING_CHUNK_SIZE]
+            for i in range(0, len(blob), ss_module._KEYRING_CHUNK_SIZE)
+        ]
+        for i, chunk in enumerate(chunks):
+            fake.set_password(
+                ss_module.KEYRING_SERVICE, ss_module._chunk_username(i), chunk
+            )
+        fake.set_password(
+            ss_module.KEYRING_SERVICE,
+            ss_module.KEYRING_USERNAME,
+            json.dumps({ss_module._CHUNK_MARKER: len(chunks)}),
+        )
+
+        assert session.load_session()["token"] == "t" * 2000
+
+    def test_next_save_after_legacy_chunks_does_not_clobber_them(
+        self, storage_keyring
+    ):
+        """The first generationed save must not overwrite the live legacy data."""
+        session, fake = storage_keyring
+        blob = json.dumps({"token": "t" * 2000, "auth_mode": "token"})
+        chunks = [
+            blob[i : i + ss_module._KEYRING_CHUNK_SIZE]
+            for i in range(0, len(blob), ss_module._KEYRING_CHUNK_SIZE)
+        ]
+        for i, chunk in enumerate(chunks):
+            fake.set_password(
+                ss_module.KEYRING_SERVICE, ss_module._chunk_username(i), chunk
+            )
+        fake.set_password(
+            ss_module.KEYRING_SERVICE,
+            ss_module.KEYRING_USERNAME,
+            json.dumps({ss_module._CHUNK_MARKER: len(chunks)}),
+        )
+
+        session.save_session_blob(cookies={"cf_clearance": "n" * 3000}, auth_mode="cookie")
+
+        assert session.load_session()["cookies"] == {"cf_clearance": "n" * 3000}
+        # The superseded legacy chunks are cleaned up, not left dangling.
+        assert (
+            fake.get_password(
+                ss_module.KEYRING_SERVICE, ss_module._chunk_username(0)
+            )
+            is None
+        )
+
+
+def _module_from(fake, **overrides):
+    module = types.ModuleType("keyring")
+    module.set_password = overrides.get("set_password", fake.set_password)
+    module.get_password = overrides.get("get_password", fake.get_password)
+    module.delete_password = overrides.get("delete_password", fake.delete_password)
+    return module
+
+
+@pytest.fixture
+def file_session(monkeypatch, tmp_path):
+    """A session forced onto the file fallback, sandboxed to tmp_path."""
+    monkeypatch.setattr(ss_module, "_keyring_available", lambda: False)
+    monkeypatch.setattr(ss_module, "_TOKEN_DIR", tmp_path / "store")
+    monkeypatch.setattr(ss_module, "_TOKEN_FILE", tmp_path / "store" / "token")
+    session = ss_module.SecureMonarchSession()
+    assert session._use_keyring is False
+    return session, tmp_path / "store" / "token"
+
+
+class TestFileFallbackWrites:
+    """The file fallback holds a full access credential; treat it as one."""
+
+    def test_file_is_never_world_readable(self, file_session):
+        """0600 must be set at creation, not after the bytes are on disk.
+
+        write_text creates the file under the process umask (typically 0644)
+        and only then chmods, leaving a window where any local user can read
+        the token.
+        """
+        import os
+        import stat as stat_module
+
+        session, token_file = file_session
+        session.save_session_blob(token="tok", auth_mode="token")
+
+        mode = stat_module.S_IMODE(os.stat(token_file).st_mode)
+        assert mode == 0o600, oct(mode)
+        dir_mode = stat_module.S_IMODE(os.stat(token_file.parent).st_mode)
+        assert dir_mode == 0o700, oct(dir_mode)
+
+    def test_write_is_atomic_via_replace(self, file_session, monkeypatch):
+        """A reader must never observe a partially written blob."""
+        import os
+
+        session, token_file = file_session
+        session.save_session_blob(token="original", auth_mode="token")
+
+        seen = {}
+        real_replace = os.replace
+
+        def spy_replace(src, dst):
+            # Before the rename lands, the live file still holds the old blob.
+            seen["during"] = ss_module._TOKEN_FILE.read_text()
+            return real_replace(src, dst)
+
+        monkeypatch.setattr(os, "replace", spy_replace)
+        session.save_session_blob(token="replacement", auth_mode="token")
+
+        assert "original" in seen["during"]
+        assert session.load_session()["token"] == "replacement"
+
+    def test_failed_write_leaves_no_temp_file_behind(self, file_session, monkeypatch):
+        import os
+
+        session, token_file = file_session
+        session.save_session_blob(token="good", auth_mode="token")
+
+        def boom(src, dst):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(os, "replace", boom)
+        with pytest.raises(OSError):
+            session.save_session_blob(token="doomed", auth_mode="token")
+
+        assert session.load_session()["token"] == "good"
+        assert list(token_file.parent.iterdir()) == [token_file]
+
+
+class TestCorruptedSessionHandling:
+    """A truncated JSON blob must not be reinterpreted as a bare token."""
+
+    def test_truncated_json_is_not_treated_as_a_legacy_token(self, file_session):
+        """The exact half-written-blob shape from a crash mid save.
+
+        Read back as a token it becomes an Authorization header of garbage,
+        and every call 401s for the life of the process.
+        """
+        session, token_file = file_session
+        token_file.parent.mkdir(parents=True, exist_ok=True)
+        token_file.write_text('{"auth_mode": "cookie", "token": "eyJ0eX')
+
+        assert session.load_session() is None
+
+    def test_truncated_json_array_is_also_rejected(self, file_session):
+        session, token_file = file_session
+        token_file.parent.mkdir(parents=True, exist_ok=True)
+        token_file.write_text('[{"token": "abc"')
+
+        assert session.load_session() is None
+
+    def test_genuine_legacy_bare_token_still_loads(self, file_session):
+        """Very old installs stored the raw token string; keep reading those."""
+        session, token_file = file_session
+        token_file.parent.mkdir(parents=True, exist_ok=True)
+        token_file.write_text("legacy-bare-token-value")
+
+        assert session.load_session() == {
+            "token": "legacy-bare-token-value",
+            "auth_mode": "token",
+        }
+
+    def test_spliced_chunk_debris_is_not_accepted_as_a_token(self, file_session):
+        """Debris that does not start with a brace must still be rejected.
+
+        Reassembling chunks from two different saves produces exactly this
+        shape. Accepted as a token it yields a client whose every call fails
+        with an opaque 401 for the life of the process.
+        """
+        session, token_file = file_session
+        token_file.parent.mkdir(parents=True, exist_ok=True)
+        token_file.write_text('xxxxxxxx", "cookies": {"cf_clearance": "ffff"}}')
+
+        assert session.load_session() is None
+
+    def test_absurdly_long_value_is_not_accepted_as_a_token(self, file_session):
+        session, token_file = file_session
+        token_file.parent.mkdir(parents=True, exist_ok=True)
+        token_file.write_text("x" * 5000)
+
+        assert session.load_session() is None
 
 
 class TestGetAuthenticatedClient:


### PR DESCRIPTION
Closes #114, #75, #121, #120, #106. Includes @chirstius's commit from #81, rebased.

### Keyring probe raced between processes (#114)
The sentinel used one shared username, so two server processes probing at once had one delete the entry the other just wrote. The loser concluded the keyring was unusable and read only the file fallback for the rest of its life, which an interactive login never writes. Now per process. Cleanup moved into a finally block, and a delete failure no longer fails the probe, since rejecting a backend that stores and returns the sentinel downgrades a working keyring to plaintext.

### Token file was briefly world readable (#75) and written non atomically (#121)
Created with 0600 already set via os.open, written to a temp file in the same directory, fsynced, then moved into place with os.replace.

### A failed chunked keyring save destroyed the stored session
Not filed, found while reviewing #113. Chunks were overwritten in place, so a save that failed partway left the old index pointing at a mix of old and new bytes. That is reachable on Windows, where CredWrite is exactly what fails midway. Chunks now carry a generation tag and the index is flipped only once every chunk is stored, so a partial write is a no op.

Verified by simulating a CredWrite failure on chunk 3 of 5. With the old layout the session is destroyed. With this change it stays intact and correct.

### A corrupt blob was read back as a bare legacy token
Splicing chunks from two saves yields a string that is not JSON and does not start with a brace, so the legacy path accepted it as a token and built a client that failed every call with an opaque 401. Corrupt values are now rejected, the legacy path requires something that actually looks like a token, and an unusable keyring entry falls through to the file fallback rather than ending the search.

### Client cache never invalidated (#120)
The cached client holds its own Authorization header, so logout reported success while every later tool call still returned live financial data, and a re login after expiry could not take effect without restarting the host.

### Tests read real credential storage (#106)
An autouse fixture redirects both the file fallback and the keyring backend. Tests can no longer read a developer session or raise an OS keychain prompt.

Suite at 256 passing. mypy on this file goes from 4 errors to 1, the pre existing monarchmoney stub.