### PR TITLE
Do not delete the existing session before a new login is verified

### DIFF
--- a/login_setup.py
+++ b/login_setup.py
@@ -174,9 +174,12 @@ async def main():
         print(f"⚠️  Could not check version: {e}")
 
     try:
-        secure_session.delete_token()
-        print("🗑️ Cleared existing secure sessions")
-
+        # The previous session is deliberately left in place until the new one
+        # is verified and saved. Deleting it up front meant that a bad cookie
+        # paste, a Cloudflare captcha, or a 401 on the connection test left the
+        # user with no working session at all, worse off than before running
+        # this script. save_authenticated_session already overwrites whatever
+        # is stored, so nothing needs clearing first.
         print("\nHow do you sign in to Monarch Money?")
         print(
             "  1) Session cookies from browser   "


### PR DESCRIPTION
Takes the login_setup.py half of #83 by @peter216. The auth.py half of that PR conflicted because #110 already landed the same cookie mode status fix.

The upfront delete_token had no effect on a successful run, since save_authenticated_session overwrites the stored entry anyway. Its only observable effect was on the failure path, where it left the user with nothing.

Closes #83.