### PR TITLE
Stop reporting refused writes as completed ones

### DIFF
--- a/src/monarch_mcp_server/helpers.py
+++ b/src/monarch_mcp_server/helpers.py
@@ -102,6 +102,60 @@ def format_transaction(txn: Dict[str, Any], extended: bool = False) -> Dict[str,
     return info
 
 
+def payload_errors(
+    result: Any, *payload_keys: str
+) -> Optional[Dict[str, Any]]:
+    """Return a GraphQL payload's ``errors`` object, or None if the write took.
+
+    ``gql_call`` raises on transport errors and on top level GraphQL errors,
+    but Monarch rejects a mutation by returning ``errors`` *inside* an HTTP 200
+    body. Treating "no exception" as success therefore reports refused writes
+    as completed ones, which is worse than an outright failure: the caller
+    marks the work done and moves on.
+
+    Pass the payload keys to look under, e.g. ``"updateTransaction"``. With no
+    keys, every top level payload in the response is checked.
+
+    Monarch sometimes rejects with an all null error object, which is truthy
+    but carries no information, so that is normalised to a readable message.
+    """
+    if not isinstance(result, dict):
+        return None
+
+    candidates = (
+        [result.get(key) for key in payload_keys]
+        if payload_keys
+        else list(result.values())
+    )
+
+    for payload in candidates:
+        if not isinstance(payload, dict):
+            continue
+        errors = payload.get("errors")
+        if not errors:
+            continue
+        if isinstance(errors, dict):
+            meaningful = {
+                k: v
+                for k, v in errors.items()
+                if k != "__typename" and v is not None
+            }
+            return meaningful or {"message": "Monarch rejected the request"}
+        return {"message": "Monarch rejected the request", "errors": errors}
+
+    return None
+
+
+def json_rejected(tool_name: str, errors: Dict[str, Any]) -> str:
+    """Serialize a payload level rejection as an explicit failure."""
+    logger.warning(f"{tool_name} was rejected by Monarch: {errors}")
+    return json.dumps(
+        {"success": False, "tool": tool_name, "errors": errors},
+        indent=2,
+        default=str,
+    )
+
+
 def json_success(data: Any) -> str:
     """Serialize *data* to a JSON string for tool responses."""
     return json.dumps(data, indent=2, default=str)

--- a/src/monarch_mcp_server/tools/categories.py
+++ b/src/monarch_mcp_server/tools/categories.py
@@ -228,6 +228,7 @@ async def update_category(
     rollover_frequency: Optional[str] = None,
     rollover_target_amount: Optional[float] = None,
     rollover_type: Optional[str] = None,
+    confirm_rollover_reset: bool = False,
     dry_run: bool = False,
 ) -> str:
     """
@@ -256,6 +257,12 @@ async def update_category(
             "variable".
         rollover_target_amount: Target amount for rollover savings goal.
         rollover_type: Rollover type. Values: "monthly".
+        confirm_rollover_reset: Required opt in for rollover_start_month and
+            rollover_starting_balance. Those two restart the category's
+            rollover period, discarding a balance that accumulated over months
+            or years, and there is no undo. Every other argument here is a
+            routine edit, so the destructive pair must be asked for explicitly
+            rather than riding along in a call that reads like a rename.
         dry_run: If True, return the planned changes without executing the
             mutation. Shows current vs proposed values.
 
@@ -293,6 +300,29 @@ async def update_category(
                     "message": (
                         f"Invalid budget_variability: {budget_variability!r}. "
                         f"Must be one of: {sorted(_VALID_BUDGET_VARIABILITY)}"
+                    ),
+                }
+            )
+
+        resets_rollover = [
+            arg
+            for arg, value in (
+                ("rollover_start_month", rollover_start_month),
+                ("rollover_starting_balance", rollover_starting_balance),
+            )
+            if value is not None
+        ]
+        if resets_rollover and not confirm_rollover_reset:
+            return json_success(
+                {
+                    "success": False,
+                    "message": (
+                        f"{' and '.join(resets_rollover)} restarts this "
+                        "category's rollover period and discards the balance "
+                        "accumulated so far, which cannot be undone. Pass "
+                        "confirm_rollover_reset=True to proceed, or use "
+                        "dry_run=True to preview. Renames, icons, group moves "
+                        "and budget variability do not need it."
                     ),
                 }
             )

--- a/src/monarch_mcp_server/tools/rules.py
+++ b/src/monarch_mcp_server/tools/rules.py
@@ -282,6 +282,19 @@ def _build_amount_criteria(
             "value": value,
             "valueRange": None,
         }
+
+    # Exactly one half supplied. Dropping the criterion here would create a
+    # rule far broader than the caller asked for and still report success: an
+    # amount threshold that silently disappears leaves a rule matching every
+    # transaction from that merchant, and with apply_to_existing it rewrites
+    # the history immediately. A standing policy is worth failing loudly over.
+    if operator or value is not None:
+        raise ValueError(
+            "amount_operator and amount_value must be given together "
+            f"(got amount_operator={operator!r}, amount_value={value!r}). "
+            "Use amount_operator='between' with amount_lower and amount_upper "
+            "for a range."
+        )
     return None
 
 

--- a/src/monarch_mcp_server/tools/splits.py
+++ b/src/monarch_mcp_server/tools/splits.py
@@ -5,7 +5,12 @@ from typing import Any, Dict, List
 
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
-from monarch_mcp_server.helpers import json_success, json_error
+from monarch_mcp_server.helpers import (
+    json_error,
+    json_rejected,
+    json_success,
+    payload_errors,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +63,14 @@ async def split_transaction(
             transaction_id=transaction_id,
             split_data=splits,
         )
+
+        # The outcome was previously hardcoded to success. Monarch rejects a
+        # split that does not sum to the original amount by returning errors in
+        # the payload of an HTTP 200, so this reported a write that never
+        # happened.
+        errors = payload_errors(result, "updateTransactionSplit")
+        if errors:
+            return json_rejected("split_transaction", errors)
 
         return json_success({
             "success": True,

--- a/src/monarch_mcp_server/tools/tags.py
+++ b/src/monarch_mcp_server/tools/tags.py
@@ -5,7 +5,12 @@ from typing import List
 
 from monarch_mcp_server.app import mcp
 from monarch_mcp_server.client import get_monarch_client
-from monarch_mcp_server.helpers import json_success, json_error
+from monarch_mcp_server.helpers import (
+    json_error,
+    json_rejected,
+    json_success,
+    payload_errors,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +40,9 @@ async def set_transaction_tags(
             transaction_id=transaction_id,
             tag_ids=tag_ids,
         )
+        errors = payload_errors(result, "setTransactionTags")
+        if errors:
+            return json_rejected("set_transaction_tags", errors)
         return json_success(result)
     except Exception as e:
         return json_error("set_transaction_tags", e)
@@ -68,6 +76,9 @@ async def create_transaction_tag(name: str, color: str) -> str:
     try:
         client = await get_monarch_client()
         result = await client.create_transaction_tag(name=name, color=color)
+        errors = payload_errors(result, "createTransactionTag")
+        if errors:
+            return json_rejected("create_transaction_tag", errors)
         return json_success(result)
     except Exception as e:
         return json_error("create_transaction_tag", e)
@@ -84,14 +95,50 @@ async def add_transaction_tag(transaction_id: str, tag_id: str) -> str:
     """
     try:
         client = await get_monarch_client()
-        details = await client.get_transaction_details(transaction_id)
-        txn = details.get("getTransaction") or {}
+        # redirect_posted defaults to True upstream, which answers a query for
+        # a pending transaction with its posted counterpart. Since this is a
+        # read modify replace, that would write the twin's tag set over the
+        # pending transaction's own, silently dropping tags.
+        details = await client.get_transaction_details(
+            transaction_id, redirect_posted=False
+        )
+        txn = details.get("getTransaction") if isinstance(details, dict) else None
+
+        # A missing or mismatched payload must not be treated as "no tags".
+        # set_transaction_tags is a full replacement, so degrading to an empty
+        # list turns this documented additive operation into a wipe.
+        if not isinstance(txn, dict):
+            return json_rejected(
+                "add_transaction_tag",
+                {
+                    "message": (
+                        f"Could not read transaction {transaction_id}; refusing "
+                        "to replace its tags with an unverified set."
+                    )
+                },
+            )
+        returned_id = txn.get("id")
+        if returned_id is not None and str(returned_id) != str(transaction_id):
+            return json_rejected(
+                "add_transaction_tag",
+                {
+                    "message": (
+                        f"Monarch returned transaction {returned_id} for a "
+                        f"request for {transaction_id}; refusing to write one "
+                        "transaction's tags onto another."
+                    )
+                },
+            )
+
         existing = [t.get("id") for t in (txn.get("tags") or []) if t.get("id")]
         if tag_id not in existing:
             existing.append(tag_id)
         result = await client.set_transaction_tags(
             transaction_id=transaction_id, tag_ids=existing
         )
+        errors = payload_errors(result, "setTransactionTags")
+        if errors:
+            return json_rejected("add_transaction_tag", errors)
         return json_success(result)
     except Exception as e:
         return json_error("add_transaction_tag", e)

--- a/src/monarch_mcp_server/tools/transactions.py
+++ b/src/monarch_mcp_server/tools/transactions.py
@@ -16,6 +16,8 @@ from monarch_mcp_server.helpers import (
     format_exception,
     format_transaction,
     json_error,
+    json_rejected,
+    payload_errors,
     json_success,
     tool_response_envelope,
 )
@@ -715,6 +717,9 @@ async def update_transaction(
             update_data["notes"] = notes
 
         result = await client.update_transaction(**update_data)
+        errors = payload_errors(result, "updateTransaction")
+        if errors:
+            return json_rejected("update_transaction", errors)
         return json_success(result)
     except Exception as e:
         return json_error("update_transaction", e)
@@ -734,6 +739,9 @@ async def categorize_transaction(transaction_id: str, category_id: str) -> str:
         result = await client.update_transaction(
             transaction_id=transaction_id, category_id=category_id
         )
+        errors = payload_errors(result, "updateTransaction")
+        if errors:
+            return json_rejected("categorize_transaction", errors)
         return json_success(result)
     except Exception as e:
         return json_error("categorize_transaction", e)
@@ -771,6 +779,9 @@ async def update_transaction_notes(
             transaction_id=transaction_id,
             notes=formatted_notes,
         )
+        errors = payload_errors(result, "updateTransaction")
+        if errors:
+            return json_rejected("update_transaction_notes", errors)
         return json_success(result)
     except Exception as e:
         return json_error("update_transaction_notes", e)
@@ -795,6 +806,9 @@ async def mark_transaction_reviewed(transaction_id: str) -> str:
             transaction_id=transaction_id,
             needs_review=False,
         )
+        errors = payload_errors(result, "updateTransaction")
+        if errors:
+            return json_rejected("mark_transaction_reviewed", errors)
         return json_success(result)
     except Exception as e:
         return json_error("mark_transaction_reviewed", e)
@@ -842,14 +856,17 @@ async def bulk_categorize_transactions(
             "errors": [],
         }
 
-        async def _update_one(txn_id: str) -> None:
+        async def _update_one(txn_id: str) -> Any:
             update_params: Dict[str, Any] = {
                 "transaction_id": txn_id,
                 "category_id": category_id,
             }
             if mark_reviewed:
                 update_params["needs_review"] = False
-            await client.update_transaction(**update_params)
+            # Returned, not discarded: Monarch refuses a write by putting
+            # errors in the payload of an HTTP 200, so the absence of an
+            # exception says nothing about whether anything was written.
+            return await client.update_transaction(**update_params)
 
         # Use asyncio.gather for concurrent updates
         tasks = [_update_one(txn_id) for txn_id in transaction_ids]
@@ -861,11 +878,20 @@ async def bulk_categorize_transactions(
                 results["errors"].append(
                     {
                         "transaction_id": txn_id,
-                        "error": str(outcome),
+                        "error": format_exception(outcome),
                     }
                 )
-            else:
-                results["successful"] += 1
+                continue
+
+            errors = payload_errors(outcome, "updateTransaction")
+            if errors:
+                results["failed"] += 1
+                results["errors"].append(
+                    {"transaction_id": txn_id, "error": errors}
+                )
+                continue
+
+            results["successful"] += 1
 
         return json_success(results)
     except Exception as e:
@@ -888,6 +914,9 @@ async def delete_transaction(transaction_id: str) -> str:
     try:
         client = await get_monarch_client()
         result = await client.delete_transaction(transaction_id=transaction_id)
+        errors = payload_errors(result, "deleteTransaction")
+        if errors:
+            return json_rejected("delete_transaction", errors)
         return json_success(result)
     except Exception as e:
         return json_error("delete_transaction", e)

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -180,6 +180,7 @@ class TestUpdateCategory:
                 rollover_start_month="2026-05-01",
                 rollover_starting_balance=0,
                 rollover_frequency="variable",
+                confirm_rollover_reset=True,
             )
         )
 
@@ -219,12 +220,67 @@ class TestUpdateCategory:
             exclude_from_budget=False,
             rollover_enabled=False,
             rollover_starting_balance=0,
+            confirm_rollover_reset=True,
         )
 
         call_vars = mock_client.gql_call.call_args.kwargs["variables"]
         assert call_vars["input"]["excludeFromBudget"] is False
         assert call_vars["input"]["rolloverEnabled"] is False
         assert call_vars["input"]["rolloverStartingBalance"] == 0
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_rollover_reset_requires_explicit_confirmation(
+        self, mock_get_client
+    ):
+        """A rollover balance accrues over months or years and has no undo.
+
+        Every argument that resets it is optional, so a call that reads like a
+        rename can carry the reset in the same payload.
+        """
+        for kwargs in (
+            {"rollover_start_month": "2026-05-01"},
+            {"rollover_starting_balance": 0},
+        ):
+            result = json.loads(
+                await update_category(category_id="cat-123", **kwargs)
+            )
+            assert result["success"] is False
+            assert "confirm_rollover_reset" in result["message"]
+        mock_get_client.assert_not_called()
+
+    @patch("monarch_mcp_server.tools.categories.get_monarch_client")
+    async def test_non_destructive_edits_need_no_confirmation(
+        self, mock_get_client
+    ):
+        """Renames and the like must not be made harder by the guard."""
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "updateCategory": {
+                "errors": None,
+                "category": {
+                    "id": "cat-123",
+                    "name": "Renamed",
+                    "icon": "X",
+                    "budgetVariability": "fixed",
+                    "excludeFromBudget": False,
+                    "isSystemCategory": False,
+                    "isDisabled": False,
+                    "isProtected": False,
+                    "group": {
+                        "id": "grp-1",
+                        "type": "expense",
+                        "groupLevelBudgetingEnabled": False,
+                    },
+                    "rolloverPeriod": None,
+                },
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = json.loads(
+            await update_category(category_id="cat-123", name="Renamed")
+        )
+        assert result["success"] is True
 
     @patch("monarch_mcp_server.tools.categories.get_monarch_client")
     async def test_invalid_budget_variability(self, mock_get_client):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -715,3 +715,85 @@ class TestDeleteTransactionRule:
         data = json.loads(result)
         assert data["success"] is True
         assert "deleted" in data["message"].lower()
+
+
+class TestAmountCriterionIsNeverSilentlyDropped:
+    """A rule is standing policy, so a lost criterion is not a small thing.
+
+    The amount criterion was built behind a two part guard and omitted
+    entirely when only one half was supplied, with the tool still reporting
+    that the rule was created.
+    """
+
+    @patch("monarch_mcp_server.tools.rules.get_monarch_client")
+    async def test_value_without_operator_is_rejected(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        result = json.loads(
+            await create_transaction_rule(
+                merchant_criteria_value="Costco",
+                amount_value=500.0,
+                set_category_id="cat_travel",
+                apply_to_existing=True,
+            )
+        )
+
+        assert result.get("error") or result.get("success") is False
+        assert "amount_operator" in json.dumps(result)
+        # Nothing may reach the API: the rule would match every Costco
+        # transaction and apply_to_existing rewrites history immediately.
+        mock_client.gql_call.assert_not_called()
+
+    @patch("monarch_mcp_server.tools.rules.get_monarch_client")
+    async def test_operator_without_value_is_rejected(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        result = json.loads(
+            await create_transaction_rule(
+                merchant_criteria_value="Costco",
+                amount_operator="gt",
+                set_category_id="cat_travel",
+            )
+        )
+
+        assert result.get("error") or result.get("success") is False
+        mock_client.gql_call.assert_not_called()
+
+    @patch("monarch_mcp_server.tools.rules.get_monarch_client")
+    async def test_both_halves_together_still_work(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "createTransactionRuleV2": {"errors": None, "transactionRule": {"id": "r1"}}
+        }
+        mock_get_client.return_value = mock_client
+
+        result = json.loads(
+            await create_transaction_rule(
+                merchant_criteria_value="Costco",
+                amount_operator="gt",
+                amount_value=500.0,
+                set_category_id="cat_travel",
+            )
+        )
+
+        assert result["success"] is True
+        sent = mock_client.gql_call.call_args.kwargs["variables"]["input"]
+        assert sent["amountCriteria"]["operator"] == "gt"
+        assert sent["amountCriteria"]["value"] == 500.0
+
+    @patch("monarch_mcp_server.tools.rules.get_monarch_client")
+    async def test_no_amount_arguments_at_all_is_fine(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.gql_call.return_value = {
+            "createTransactionRuleV2": {"errors": None, "transactionRule": {"id": "r1"}}
+        }
+        mock_get_client.return_value = mock_client
+
+        result = json.loads(
+            await create_transaction_rule(
+                merchant_criteria_value="Costco", set_category_id="cat_x"
+            )
+        )
+        assert result["success"] is True

--- a/tests/test_splits.py
+++ b/tests/test_splits.py
@@ -1,0 +1,38 @@
+"""Tests for transaction split tools."""
+
+import json
+
+from monarch_mcp_server.tools.splits import split_transaction
+
+
+class TestSplitTransactionReportsRejection:
+    async def test_rejected_split_is_not_reported_as_success(
+        self, mock_monarch_client
+    ):
+        """The outcome used to be hardcoded to success.
+
+        Monarch rejects a split that does not sum to the original amount by
+        returning errors in the payload of an HTTP 200.
+        """
+        mock_monarch_client.update_transaction_splits.return_value = {
+            "updateTransactionSplit": {
+                "errors": {
+                    "message": "Splits must sum to the transaction amount",
+                    "code": "INVALID",
+                }
+            }
+        }
+        result = json.loads(
+            await split_transaction("txn-1", [{"amount": -5.0}])
+        )
+        assert result["success"] is False
+        assert "sum to the transaction amount" in json.dumps(result)
+
+    async def test_accepted_split_still_reports_success(self, mock_monarch_client):
+        mock_monarch_client.update_transaction_splits.return_value = {
+            "updateTransactionSplit": {"errors": None, "transaction": {"id": "1"}}
+        }
+        result = json.loads(
+            await split_transaction("txn-1", [{"amount": -5.0}, {"amount": -5.0}])
+        )
+        assert result["success"] is True

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -154,3 +154,65 @@ class TestAddTransactionTag:
         mock_monarch_client.get_transaction_details.side_effect = Exception("boom")
         result = await add_transaction_tag("txn-1", "tag-2")
         assert "add_transaction_tag" in result
+
+
+class TestAddTagNeverSilentlyReplaces:
+    """add_transaction_tag is documented as additive.
+
+    It is implemented as read modify replace, so anything that makes the read
+    untrustworthy turns it into a blind full replacement that reports success.
+    """
+
+    async def test_reads_the_pending_transaction_not_its_posted_twin(
+        self, mock_monarch_client
+    ):
+        """redirect_posted defaults to True upstream.
+
+        For a pending transaction Monarch then answers with the posted
+        counterpart, whose tags are written back over the pending one.
+        """
+        await add_transaction_tag("txn-1", "tag-2")
+        _args, kwargs = mock_monarch_client.get_transaction_details.call_args
+        assert kwargs.get("redirect_posted") is False
+
+    async def test_refuses_when_the_read_returns_another_transaction(
+        self, mock_monarch_client
+    ):
+        mock_monarch_client.get_transaction_details.return_value = {
+            "getTransaction": {"id": "POSTED-999", "tags": []}
+        }
+        result = json.loads(await add_transaction_tag("PENDING-111", "tagB"))
+        assert result["success"] is False
+        mock_monarch_client.set_transaction_tags.assert_not_called()
+
+    async def test_refuses_when_the_read_returns_nothing(self, mock_monarch_client):
+        """A null payload previously degraded into a one tag full wipe."""
+        mock_monarch_client.get_transaction_details.return_value = {
+            "getTransaction": None
+        }
+        result = json.loads(await add_transaction_tag("txn-1", "tag-2"))
+        assert result["success"] is False
+        mock_monarch_client.set_transaction_tags.assert_not_called()
+
+    async def test_rejected_write_is_not_reported_as_success(
+        self, mock_monarch_client
+    ):
+        mock_monarch_client.set_transaction_tags.return_value = {
+            "setTransactionTags": {
+                "errors": {"message": "Tag not found", "code": "INVALID"}
+            }
+        }
+        result = json.loads(await add_transaction_tag("txn-1", "tag-2"))
+        assert result["success"] is False
+        assert "Tag not found" in json.dumps(result)
+
+
+class TestSetTagsReportsRejection:
+    async def test_rejected_write_is_not_reported_as_success(
+        self, mock_monarch_client
+    ):
+        mock_monarch_client.set_transaction_tags.return_value = {
+            "setTransactionTags": {"errors": {"message": "nope", "code": "X"}}
+        }
+        result = json.loads(await set_transaction_tags("txn-1", ["tag-1"]))
+        assert result["success"] is False

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -987,3 +987,79 @@ class TestCategorizeTransaction:
         mock_monarch_client.update_transaction.side_effect = Exception("boom")
         result = await categorize_transaction("txn-1", "cat-2")
         assert "categorize_transaction" in result
+
+
+class TestRejectedWritesAreNotReportedAsSuccess:
+    """gql_call raises on transport and top level GraphQL errors.
+
+    Monarch refuses a mutation differently: errors come back inside the
+    payload of an HTTP 200. Treating "no exception" as success reports writes
+    that never happened, which is worse than failing, because the caller marks
+    the work done and moves on.
+    """
+
+    REJECTION = {
+        "updateTransaction": {
+            "transaction": None,
+            "errors": {"message": "Category not found", "code": "INVALID"},
+        }
+    }
+
+    async def test_categorize_transaction(self, mock_monarch_client):
+        mock_monarch_client.update_transaction.return_value = self.REJECTION
+        result = json.loads(await categorize_transaction("txn-1", "bogus"))
+        assert result["success"] is False
+        assert "Category not found" in json.dumps(result)
+
+    async def test_mark_transaction_reviewed(self, mock_monarch_client):
+        mock_monarch_client.update_transaction.return_value = self.REJECTION
+        result = json.loads(await mark_transaction_reviewed("txn-1"))
+        assert result["success"] is False
+
+    async def test_update_transaction_notes(self, mock_monarch_client):
+        mock_monarch_client.update_transaction.return_value = self.REJECTION
+        result = json.loads(await update_transaction_notes("txn-1", "note"))
+        assert result["success"] is False
+
+    async def test_update_transaction(self, mock_monarch_client):
+        mock_monarch_client.update_transaction.return_value = self.REJECTION
+        result = json.loads(await update_transaction("txn-1", category_id="x"))
+        assert result["success"] is False
+
+    async def test_bulk_categorize_counts_rejections_as_failures(
+        self, mock_monarch_client
+    ):
+        """The whole batch was reported as categorized while nothing was."""
+        mock_monarch_client.update_transaction.return_value = self.REJECTION
+        result = json.loads(
+            await bulk_categorize_transactions(["1", "2", "3"], "bogus")
+        )
+        assert result["successful"] == 0
+        assert result["failed"] == 3
+        assert len(result["errors"]) == 3
+
+    async def test_bulk_categorize_still_counts_real_successes(
+        self, mock_monarch_client
+    ):
+        mock_monarch_client.update_transaction.return_value = {
+            "updateTransaction": {"transaction": {"id": "1"}, "errors": None}
+        }
+        result = json.loads(
+            await bulk_categorize_transactions(["1", "2"], "cat-1")
+        )
+        assert result["successful"] == 2
+        assert result["failed"] == 0
+
+    async def test_bulk_categorize_error_text_is_never_blank(
+        self, mock_monarch_client
+    ):
+        """Some transport exceptions stringify to the empty string."""
+
+        class Silent(Exception):
+            def __str__(self):
+                return ""
+
+        mock_monarch_client.update_transaction.side_effect = Silent()
+        result = json.loads(await bulk_categorize_transactions(["1"], "cat-1"))
+        assert result["failed"] == 1
+        assert result["errors"][0]["error"]


### PR DESCRIPTION
Closes #115, #119, #117, #107.

Monarch rejects a mutation by returning `errors` inside the payload of an HTTP 200. `gql_call` only raises on transport and top level GraphQL errors, so every mutator that treated the absence of an exception as success reported writes that never happened. That is worse than an outright failure, because the caller marks the work done and moves on.

`rules.py`, `merchants.py` and `budgets.py` already did this correctly. This adds a shared `payload_errors` helper and applies the same convention to the transaction, tag and split mutators.

Worst cases fixed:

- `bulk_categorize_transactions` counted every non raising call as a success, so a fully rejected batch of three returned `successful: 3, failed: 0`. It also used `str(outcome)`, which yields an empty message for exceptions that stringify blank.
- `split_transaction` hardcoded `success: True` regardless of outcome.
- `add_transaction_tag` is documented as additive but implemented as read modify replace. `redirect_posted` defaults to True upstream, so for a pending transaction the read returned the posted twin and its tag set was written over the pending one. A null payload degraded to an empty list, turning the add into a one tag wipe. It now reads with `redirect_posted=False` and refuses to write unless the returned id matches.
- `create_transaction_rule` dropped the amount criterion when only one of `amount_operator` or `amount_value` was supplied, then reported success. With `apply_to_existing=True` that rewrites history against a rule far broader than asked for. The `between` half of #117 was already fixed by #89.
- `update_category` now requires `confirm_rollover_reset=True` for `rollover_start_month` and `rollover_starting_balance`. Those restart a rollover period and discard a balance accumulated over months or years, with no undo, and every argument that does it was optional. Renames, icons, group moves and budget variability are unaffected.

#118 is mostly closed by #89, which added the zero criteria guard. Its dry_run suggestion is left open.

Suite at 291 passing, mypy unchanged.