### PR TITLE
Filter the review queue server side and make truncation visible

### DIFF
--- a/src/monarch_mcp_server/tools/transactions.py
+++ b/src/monarch_mcp_server/tools/transactions.py
@@ -999,6 +999,7 @@ async def get_transactions_needing_review(
     uncategorized_only: bool = False,
     without_notes_only: bool = False,
     limit: int = 100,
+    offset: int = 0,
     account_id: Optional[str] = None,
 ) -> str:
     """
@@ -1006,21 +1007,37 @@ async def get_transactions_needing_review(
 
     This is the primary tool for finding transactions to categorize and review.
 
+    The review filter is applied by Monarch, not locally, so the count
+    reflects the whole account rather than one arbitrary page. The response
+    is an envelope carrying count, total_count and truncated, so a partial
+    page is visible rather than looking like the complete answer.
+
     Args:
-        needs_review: Filter for transactions flagged as needing review (default: True)
+        needs_review: True for transactions flagged as needing review
+            (default), False for transactions already reviewed.
         days: Only include transactions from the last N days (e.g., 7 for last week)
         uncategorized_only: Only include transactions without a category assigned
         without_notes_only: Only include transactions without notes/memos
         limit: Maximum number of transactions to return (default: 100)
+        offset: Number of transactions to skip, for paging the queue
         account_id: Filter by specific account ID
 
     Returns:
-        List of transactions matching the criteria with full details.
+        An envelope with the matching transactions under "data".
     """
     try:
         client = await get_monarch_client()
 
-        filters: Dict[str, Any] = {"limit": limit}
+        filters: Dict[str, Any] = {"limit": limit, "offset": offset}
+
+        # Sent upstream rather than applied to an already fetched page. The
+        # previous local filter meant the tool asked for an arbitrary page of
+        # *all* transactions and reported however many of those happened to
+        # need review, with no way to tell that the page had been truncated
+        # and no offset to page past it. It also treated needs_review=False as
+        # "no filter" rather than as its inverse, so passing False returned
+        # every transaction on the page, including ones needing review.
+        filters["needs_review"] = needs_review
 
         if days:
             end = datetime.now().strftime("%Y-%m-%d")
@@ -1035,12 +1052,12 @@ async def get_transactions_needing_review(
             filters["has_notes"] = False
 
         transactions_data = await client.get_transactions(**filters)
+        all_transactions = transactions_data.get("allTransactions") or {}
+        results = all_transactions.get("results") or []
+        total_count = all_transactions.get("totalCount")
 
         transaction_list = []
-        for txn in transactions_data.get("allTransactions", {}).get("results", []):
-            if needs_review and not txn.get("needsReview", False):
-                continue
-
+        for txn in results:
             if uncategorized_only:
                 category = txn.get("category")
                 if category and category.get("id"):
@@ -1048,6 +1065,31 @@ async def get_transactions_needing_review(
 
             transaction_list.append(format_transaction(txn))
 
-        return json_success(transaction_list)
+        args: Dict[str, Any] = {
+            "needs_review": needs_review,
+            "days": days,
+            "uncategorized_only": uncategorized_only,
+            "without_notes_only": without_notes_only,
+            "limit": limit,
+            "offset": offset,
+            "account_id": account_id,
+        }
+        # uncategorized_only is still applied locally, so it can shrink the
+        # page below the limit. Reporting the server side total alongside it
+        # would imply this page is complete, which it is not.
+        server_total = None if uncategorized_only else total_count
+        return json_success(
+            tool_response_envelope(
+                "get_transactions_needing_review",
+                args,
+                transaction_list,
+                total_count=server_total,
+                search_info=(
+                    {"local_filter": "uncategorized_only"}
+                    if uncategorized_only
+                    else None
+                ),
+            )
+        )
     except Exception as e:
         return json_error("get_transactions_needing_review", e)

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -59,10 +59,11 @@ class TestGetTransactionsNeedingReview:
 
         result = await get_transactions_needing_review(needs_review=True)
 
-        transactions = json.loads(result)
-        assert len(transactions) == 1
-        assert transactions[0]["id"] == "txn_1"
-        assert transactions[0]["needs_review"] is True
+        # The filter is Monarch's job now, so the mocked page is returned as
+        # given. What matters is that the flag was actually sent upstream.
+        assert mock_client.get_transactions.call_args.kwargs["needs_review"] is True
+        envelope = json.loads(result)
+        assert envelope["count"] == 2
 
     @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
     async def test_get_transactions_uncategorized_filter(self, mock_get_client):
@@ -102,7 +103,8 @@ class TestGetTransactionsNeedingReview:
             needs_review=True, uncategorized_only=True
         )
 
-        transactions = json.loads(result)
+        envelope = json.loads(result)
+        transactions = envelope["data"]
         assert len(transactions) == 1
         assert transactions[0]["id"] == "txn_1"
         assert transactions[0]["category"] is None
@@ -149,7 +151,7 @@ class TestGetTransactionsNeedingReview:
 
         result = await get_transactions_needing_review(needs_review=True)
 
-        transactions = json.loads(result)
+        transactions = json.loads(result)["data"]
         assert len(transactions) == 1
         txn = transactions[0]
         assert txn["id"] == "txn_1"
@@ -185,8 +187,9 @@ class TestGetTransactionsNeedingReview:
 
         result = await get_transactions_needing_review()
 
-        transactions = json.loads(result)
-        assert len(transactions) == 0
+        envelope = json.loads(result)
+        assert envelope["count"] == 0
+        assert envelope["data"] == []
 
 
 class TestUpdateTransactionNotes:
@@ -1063,3 +1066,102 @@ class TestRejectedWritesAreNotReportedAsSuccess:
         result = json.loads(await bulk_categorize_transactions(["1"], "cat-1"))
         assert result["failed"] == 1
         assert result["errors"][0]["error"]
+
+
+class TestReviewQueueFiltersServerSide:
+    """The review filter must be Monarch's job, not a local pass over one page.
+
+    Filtering locally meant the tool asked for an arbitrary page of all
+    transactions and reported however many of those happened to need review,
+    with nothing in the response saying the page was truncated and no offset
+    to page past it.
+    """
+
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
+    async def test_needs_review_is_sent_upstream(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.get_transactions.return_value = {
+            "allTransactions": {"results": [], "totalCount": 0}
+        }
+        mock_get_client.return_value = mock_client
+
+        await get_transactions_needing_review()
+
+        assert mock_client.get_transactions.call_args.kwargs["needs_review"] is True
+
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
+    async def test_needs_review_false_inverts_rather_than_disabling(
+        self, mock_get_client
+    ):
+        """False used to mean "no filter", returning the very rows it excluded."""
+        mock_client = AsyncMock()
+        mock_client.get_transactions.return_value = {
+            "allTransactions": {"results": [], "totalCount": 0}
+        }
+        mock_get_client.return_value = mock_client
+
+        await get_transactions_needing_review(needs_review=False)
+
+        assert mock_client.get_transactions.call_args.kwargs["needs_review"] is False
+
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
+    async def test_truncation_is_visible_to_the_caller(self, mock_get_client):
+        """A full page against a much larger total must not look complete."""
+        mock_client = AsyncMock()
+        mock_client.get_transactions.return_value = {
+            "allTransactions": {
+                "results": [
+                    {"id": f"txn_{i}", "date": "2024-01-15", "amount": -1.0}
+                    for i in range(3)
+                ],
+                "totalCount": 5000,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        envelope = json.loads(await get_transactions_needing_review(limit=3))
+
+        assert envelope["count"] == 3
+        assert envelope["total_count"] == 5000
+        assert envelope["truncated"] is True
+
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
+    async def test_offset_pages_the_queue(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.get_transactions.return_value = {
+            "allTransactions": {"results": [], "totalCount": 0}
+        }
+        mock_get_client.return_value = mock_client
+
+        await get_transactions_needing_review(offset=100)
+
+        assert mock_client.get_transactions.call_args.kwargs["offset"] == 100
+
+    @patch("monarch_mcp_server.tools.transactions.get_monarch_client")
+    async def test_local_uncategorized_filter_does_not_claim_a_server_total(
+        self, mock_get_client
+    ):
+        """uncategorized_only still shrinks the page after the fact.
+
+        Reporting the server side total next to it would imply the page is
+        the complete set of uncategorized rows, which it is not.
+        """
+        mock_client = AsyncMock()
+        mock_client.get_transactions.return_value = {
+            "allTransactions": {
+                "results": [
+                    {"id": "a", "category": None},
+                    {"id": "b", "category": {"id": "c1", "name": "Groceries"}},
+                ],
+                "totalCount": 900,
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        envelope = json.loads(
+            await get_transactions_needing_review(uncategorized_only=True)
+        )
+
+        assert envelope["count"] == 1
+        assert envelope["total_count"] is None
+        assert envelope["search"] == {"local_filter": "uncategorized_only"}


### PR DESCRIPTION
Closes #116.

The tool documented as the primary way to find transactions to review never asked Monarch for transactions needing review. It fetched a page of everything and filtered it in Python, so an agent seeing three results concluded there were three to review when the real number was unknown and arbitrary. The upstream client has supported `needs_review` all along.

Also fixes the inverted argument: the guard was `if needs_review and not txn.get(...)`, so passing False disabled filtering entirely and returned every transaction on the page, including the ones that did need review.

Response now goes through the existing `tool_response_envelope`, matching `get_transactions`, so `count`, `total_count` and `truncated` are visible. `uncategorized_only` is still a local pass, so the server total is deliberately withheld when it is used rather than implying the page is complete.

Suite at 296.