### PR TITLE
Add opt in read only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,31 @@ monarch-mcp-server/
 - Session tokens are stored in the system keyring
 - Authentication handled in secure terminal environment
 
+### Strongest option: read only mode
+
+Set `MONARCH_MCP_READ_ONLY=1` in the server's environment and the mutating
+tools are never registered. They do not appear in the tool list and cannot be
+called at all, which is stronger than an approval prompt: a model that was
+talked into a write by a merchant name or memo it read back cannot invoke a
+tool that is not there.
+
+```json
+{
+  "mcpServers": {
+    "Monarch Money": {
+      "command": "/opt/homebrew/bin/uv",
+      "args": ["run", "--project", "/path/to/your/monarch-mcp-server", "monarch-mcp-server"],
+      "env": { "MONARCH_MCP_READ_ONLY": "1" }
+    }
+  }
+}
+```
+
+This leaves 25 of the 49 tools available, covering everything that reads.
+Read only is off by default, so existing setups are unaffected. Note that it
+also removes the login and logout tools, since those change durable state, so
+authenticate with `login_setup.py` before enabling it.
+
 ### Recommended: require approval for mutating tools
 
 These tools mutate your Monarch data. The list is every registered tool that writes, checked against the source rather than maintained by hand:

--- a/src/monarch_mcp_server/app.py
+++ b/src/monarch_mcp_server/app.py
@@ -20,6 +20,12 @@ logging.getLogger("gql.transport.aiohttp").setLevel(logging.WARNING)
 # Initialize FastMCP server
 mcp = FastMCP("Monarch Money MCP Server")
 
+# Must run before the tool modules are imported, since it works by wrapping
+# mcp.tool() and registration happens at import time.
+from monarch_mcp_server import read_only  # noqa: E402
+
+read_only.install(mcp)
+
 # Import tools package to trigger @mcp.tool() registration
 import monarch_mcp_server.tools  # noqa: E402, F401
 

--- a/src/monarch_mcp_server/read_only.py
+++ b/src/monarch_mcp_server/read_only.py
@@ -1,0 +1,103 @@
+"""Opt in read only mode.
+
+Set ``MONARCH_MCP_READ_ONLY`` to a truthy value and the mutating tools are
+never registered, so they do not appear in the tool list and cannot be called
+at all. This is stronger than relying on client side approval prompts: a tool
+that is not registered cannot be invoked by a model that was talked into it by
+a merchant name or memo it read back, which is the threat the README's
+approval section is about.
+
+Read only is off by default. Enabling it is a deliberate choice, so existing
+setups keep working exactly as before.
+"""
+
+import logging
+import os
+from typing import Any, Callable, FrozenSet, TypeVar
+
+logger = logging.getLogger(__name__)
+
+ENV_VAR = "MONARCH_MCP_READ_ONLY"
+
+_TRUTHY = frozenset({"1", "true", "t", "yes", "y", "on"})
+
+# Every registered tool that writes. Listed explicitly rather than matched by
+# name prefix: this is a security control, and a tool silently failing to be
+# recognised as mutating would defeat the whole point.
+MUTATING_TOOLS: FrozenSet[str] = frozenset(
+    {
+        # Transactions
+        "create_transaction",
+        "update_transaction",
+        "delete_transaction",
+        "categorize_transaction",
+        "update_transaction_notes",
+        "mark_transaction_reviewed",
+        "bulk_categorize_transactions",
+        "split_transaction",
+        "upload_account_balance_history",
+        # Tags
+        "set_transaction_tags",
+        "add_transaction_tag",
+        "create_transaction_tag",
+        # Rules
+        "create_transaction_rule",
+        "update_transaction_rule",
+        "delete_transaction_rule",
+        # Categories and budgets
+        "create_transaction_category",
+        "update_category",
+        "set_budget_amount",
+        # Merchants
+        "update_merchant",
+        "review_recurring_stream",
+        # Session mutation. Logging out or replacing the stored session is a
+        # change to durable state, and a read only deployment should not be
+        # able to do it either.
+        "monarch_login",
+        "monarch_login_with_token",
+        "monarch_logout",
+        # Side effecting: posts a refresh request to the institutions.
+        "refresh_accounts",
+    }
+)
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def is_read_only() -> bool:
+    """Whether read only mode is enabled for this process."""
+    return os.environ.get(ENV_VAR, "").strip().lower() in _TRUTHY
+
+
+def install(mcp: Any) -> None:
+    """Make ``mcp.tool()`` skip mutating tools while read only is enabled.
+
+    Wrapping registration is what keeps this change small: every tool module
+    already registers through ``@mcp.tool()``, so nothing else has to know
+    about read only mode, and the decorated function is still returned so the
+    re-exports in ``server.py`` keep working.
+    """
+    if not is_read_only():
+        return
+
+    original_tool = mcp.tool
+
+    def guarded_tool(*args: Any, **kwargs: Any) -> Callable[[F], F]:
+        register = original_tool(*args, **kwargs)
+
+        def decorator(fn: F) -> F:
+            name = kwargs.get("name") or getattr(fn, "__name__", "")
+            if name in MUTATING_TOOLS:
+                logger.info("Read only mode: not registering %s", name)
+                return fn
+            return register(fn)
+
+        return decorator
+
+    mcp.tool = guarded_tool  # type: ignore[method-assign]
+    logger.warning(
+        "%s is set: %d mutating tools will not be registered",
+        ENV_VAR,
+        len(MUTATING_TOOLS),
+    )

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -1,0 +1,105 @@
+"""Tests for opt in read only mode."""
+
+import asyncio
+import subprocess
+import sys
+
+import pytest
+
+from monarch_mcp_server import read_only
+
+
+class TestIsReadOnly:
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " y "])
+    def test_truthy_values_enable_it(self, monkeypatch, value):
+        monkeypatch.setenv(read_only.ENV_VAR, value)
+        assert read_only.is_read_only() is True
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe"])
+    def test_everything_else_leaves_it_off(self, monkeypatch, value):
+        monkeypatch.setenv(read_only.ENV_VAR, value)
+        assert read_only.is_read_only() is False
+
+    def test_unset_leaves_it_off(self, monkeypatch):
+        """Off by default, so existing setups are unaffected."""
+        monkeypatch.delenv(read_only.ENV_VAR, raising=False)
+        assert read_only.is_read_only() is False
+
+
+class TestRegistration:
+    """Registration is skipped, not just guarded at call time.
+
+    A tool that is never registered cannot be invoked at all, which is
+    stronger than a client side approval prompt: the threat in the README's
+    approval section is a model influenced by a memo or merchant name it read
+    back, and that model cannot call what it cannot see.
+    """
+
+    def test_mutating_tools_are_not_registered(self, monkeypatch):
+        registered = []
+
+        class FakeMCP:
+            def tool(self, *args, **kwargs):
+                def decorator(fn):
+                    registered.append(fn.__name__)
+                    return fn
+
+                return decorator
+
+        monkeypatch.setenv(read_only.ENV_VAR, "1")
+        fake = FakeMCP()
+        read_only.install(fake)
+
+        def delete_transaction():
+            pass
+
+        def get_accounts():
+            pass
+
+        assert fake.tool()(delete_transaction) is delete_transaction
+        fake.tool()(get_accounts)
+
+        assert "delete_transaction" not in registered
+        assert "get_accounts" in registered
+
+    def test_nothing_is_skipped_when_disabled(self, monkeypatch):
+        registered = []
+
+        class FakeMCP:
+            def tool(self, *args, **kwargs):
+                def decorator(fn):
+                    registered.append(fn.__name__)
+                    return fn
+
+                return decorator
+
+        monkeypatch.delenv(read_only.ENV_VAR, raising=False)
+        fake = FakeMCP()
+        read_only.install(fake)
+
+        def delete_transaction():
+            pass
+
+        fake.tool()(delete_transaction)
+        assert registered == ["delete_transaction"]
+
+
+class TestMutatingToolList:
+    async def test_every_named_tool_actually_exists(self):
+        """A typo here would silently leave a mutating tool exposed."""
+        from monarch_mcp_server.app import mcp
+
+        registered = {t.name for t in await mcp.list_tools()}
+        # Only meaningful when read only is off, which is the default in tests.
+        if not read_only.is_read_only():
+            unknown = read_only.MUTATING_TOOLS - registered
+            assert not unknown, f"MUTATING_TOOLS names no such tools: {sorted(unknown)}"
+
+    async def test_it_matches_the_readme_approval_list(self):
+        """The two lists answer the same question and must not diverge."""
+        from pathlib import Path
+
+        readme = (Path(__file__).resolve().parent.parent / "README.md").read_text()
+        section = readme[readme.index("### Recommended: require approval") :]
+        missing = {n for n in read_only.MUTATING_TOOLS if f"`{n}`" not in section}
+        assert not missing, f"in MUTATING_TOOLS but not the README list: {sorted(missing)}"


### PR DESCRIPTION
Closes #98.

`MONARCH_MCP_READ_ONLY=1` stops the mutating tools from being registered at all. They are absent from the tool list rather than guarded at call time, which is the point: the threat the README approval section describes is a model influenced by data it read back and did not author, and that model cannot call a tool it cannot see.

Implemented by wrapping `mcp.tool()` before the tool modules are imported. No tool module needs to know about the mode, and the decorated function is still returned so the `server.py` re-exports keep working. That keeps this to one new module plus three lines in `app.py`.

The mutating set is listed explicitly rather than matched by name prefix. For a security control, a tool quietly failing to be recognised as mutating defeats the purpose. Tests assert every name in the set is a real registered tool and that the set stays in step with the README approval list.

Off by default, so existing setups are unaffected. 49 tools normally, 25 in read only mode, verified on both mcp 1.13.1 and 2.1.1.

This is the non breaking half of what #61 proposed. That PR made read only the default and rewrote the auth surface, which would break every existing install.