### PR TITLE
feat(accounts): add update_account tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ live tool registry and the functions' signatures, so it does not drift.
 | `monarch_login` | Sign in via a secure form in the client UI | None |
 | `monarch_login_with_token` | Sign in with a browser copied session token | None |
 | `monarch_logout` | Clear the stored session and drop the cached client | None |
+| `update_account` | Update an account's name, balance, type or visibility settings | `account_id`, `name`?, `balance`?, `account_type`?, `account_sub_type`?, `include_in_net_worth`?, `hide_from_summary_list`?, `hide_transactions_from_reports`?, `dry_run`? |
 | `refresh_accounts` | Request account data refresh from financial institutions | `account_ids`? |
 | `review_recurring_stream` | Set the review status of a recurring transaction stream | `stream_id`, `review_status` |
 | `search_transactions` | Search and filter transactions with comprehensive filtering options | `search`?, `limit`?, `offset`?, `start_date`?, `end_date`?, `category_ids`?, `account_ids`?, `tag_ids`?, `has_attachments`?, `has_notes`?, `hidden_from_reports`?, `is_split`?, `is_recurring`? |
@@ -542,6 +543,8 @@ authenticate with `login_setup.py` before enabling it.
 
 These tools mutate your Monarch data. The list is every registered tool that writes, checked against the source rather than maintained by hand:
 
+**Accounts**: `update_account`
+
 **Transactions**: `create_transaction`, `update_transaction`, `delete_transaction`, `categorize_transaction`, `update_transaction_notes`, `mark_transaction_reviewed`, `bulk_categorize_transactions`, `split_transaction`, `upload_account_balance_history`
 
 **Tags**: `set_transaction_tags`, `add_transaction_tag`, `create_transaction_tag`
@@ -558,7 +561,7 @@ These tools mutate your Monarch data. The list is every registered tool that wri
 
 Because the LLM can be influenced by data it reads back (a malicious-looking memo or merchant name in a transaction), the safest setup is to configure your MCP client to require manual approval before any mutating tool runs. In Claude Desktop and Claude Code this is the default behavior for unknown tools; keep it that way for the tools listed above rather than allow-listing them.
 
-`bulk_categorize_transactions`, `upload_account_balance_history` and `update_category` accept a `dry_run=True` argument that returns the planned changes without executing them, useful for previewing before approving.
+`bulk_categorize_transactions`, `upload_account_balance_history`, `update_account` and `update_category` accept a `dry_run=True` argument that returns the planned changes without executing them, useful for previewing before approving.
 
 `update_category` additionally requires `confirm_rollover_reset=True` before `rollover_start_month` or `rollover_starting_balance` will be applied. Those two restart a category's rollover period and discard the balance accumulated in it, which cannot be undone, so they cannot ride along unnoticed in a call that otherwise reads like a rename.
 

--- a/src/monarch_mcp_server/read_only.py
+++ b/src/monarch_mcp_server/read_only.py
@@ -57,6 +57,8 @@ MUTATING_TOOLS: FrozenSet[str] = frozenset(
         "monarch_login",
         "monarch_login_with_token",
         "monarch_logout",
+        # Accounts
+        "update_account",
         # Side effecting: posts a refresh request to the institutions.
         "refresh_accounts",
     }

--- a/src/monarch_mcp_server/tools/accounts.py
+++ b/src/monarch_mcp_server/tools/accounts.py
@@ -52,6 +52,138 @@ async def get_accounts() -> str:
         return json_error("get_accounts", e)
 
 
+
+@mcp.tool()
+async def update_account(
+    account_id: str,
+    name: Optional[str] = None,
+    balance: Optional[float] = None,
+    account_type: Optional[str] = None,
+    account_sub_type: Optional[str] = None,
+    include_in_net_worth: Optional[bool] = None,
+    hide_from_summary_list: Optional[bool] = None,
+    hide_transactions_from_reports: Optional[bool] = None,
+    dry_run: bool = False,
+) -> str:
+    """Update an account's name, balance, type or visibility settings.
+
+    Fills a gap that otherwise forces a trip to the Monarch UI: renaming a
+    generically named account, excluding a custodial account from net worth,
+    or correcting the balance of an account whose institution reports nothing.
+
+    Only the fields you pass are changed; omitted fields are left alone.
+
+    Args:
+        account_id: The account to update (see get_accounts).
+        name: New display name. Aggregators often supply useless names like
+            "CREDIT CARD (...1234)"; a name carrying issuer, product and last
+            four survives re-syncs and is legible in a report months later.
+        balance: Set the current balance. Intended for manual accounts and for
+            synced accounts whose institution does not report a balance --
+            a loan showing 0.00 while a real balance is owed, for example.
+            A synced account that later starts reporting will overwrite this.
+        account_type: Account group type, e.g. "loan", "other_asset",
+            "other_liability".
+        account_sub_type: Sub type, e.g. "mortgage", "line_of_credit", "auto".
+        include_in_net_worth: Whether the balance counts toward net worth. Set
+            False for accounts you hold but do not own -- custodial UTMA/UGMA
+            accounts are the child's property, so counting them overstates the
+            custodian's position.
+        hide_from_summary_list: Hide the account from the Accounts view. Note
+            this hides the balance from you as well; prefer
+            include_in_net_worth=False when the goal is only to stop it
+            counting.
+        hide_transactions_from_reports: Exclude the account's transactions from
+            budgets and reports, without touching net worth.
+        dry_run: If True, report the current and proposed values without
+            writing anything.
+
+    Returns:
+        The updated account, or the planned change when dry_run is True.
+    """
+    fields = {
+        "account_name": name,
+        "account_balance": balance,
+        "account_type": account_type,
+        "account_sub_type": account_sub_type,
+        "include_in_net_worth": include_in_net_worth,
+        "hide_from_summary_list": hide_from_summary_list,
+        "hide_transactions_from_reports": hide_transactions_from_reports,
+    }
+    changes = {k: v for k, v in fields.items() if v is not None}
+    if not changes:
+        return json_error(
+            "update_account",
+            ValueError(
+                "No fields to update. Pass at least one of: name, balance, "
+                "account_type, account_sub_type, include_in_net_worth, "
+                "hide_from_summary_list, hide_transactions_from_reports."
+            ),
+        )
+
+    try:
+        client = await get_monarch_client()
+
+        if dry_run:
+            accounts = await client.get_accounts()
+            current = next(
+                (
+                    a
+                    for a in accounts.get("accounts", [])
+                    if str(a.get("id")) == str(account_id)
+                ),
+                None,
+            )
+            if current is None:
+                return json_error(
+                    "update_account", ValueError(f"Account {account_id} not found")
+                )
+            return json_success(
+                {
+                    "dry_run": True,
+                    "account_id": account_id,
+                    "current": {
+                        "name": current.get("displayName"),
+                        "balance": current.get("currentBalance"),
+                        "include_in_net_worth": current.get("includeInNetWorth"),
+                        "hide_from_summary_list": current.get("hideFromList"),
+                        "hide_transactions_from_reports": current.get(
+                            "hideTransactionsFromReports"
+                        ),
+                    },
+                    "proposed": changes,
+                }
+            )
+
+        result = await client.update_account(account_id=account_id, **changes)
+        payload = (result or {}).get("updateAccount", {})
+        errors = payload.get("errors")
+        if errors:
+            return json_error(
+                "update_account",
+                RuntimeError(f"Monarch rejected the update: {errors}"),
+            )
+
+        account = payload.get("account") or {}
+        return json_success(
+            {
+                "updated": True,
+                "account_id": account_id,
+                "applied": changes,
+                "account": {
+                    "name": account.get("displayName"),
+                    "balance": account.get("currentBalance"),
+                    "include_in_net_worth": account.get("includeInNetWorth"),
+                    "hide_from_summary_list": account.get("hideFromList"),
+                    "hide_transactions_from_reports": account.get(
+                        "hideTransactionsFromReports"
+                    ),
+                },
+            }
+        )
+    except Exception as e:
+        return json_error("update_account", e)
+
 @mcp.tool()
 async def refresh_accounts(account_ids: Optional[List[str]] = None) -> str:
     """Request account data refresh from financial institutions.

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -6,6 +6,7 @@ from monarch_mcp_server.tools.accounts import (
     get_accounts,
     get_account_holdings,
     refresh_accounts,
+    update_account,
     get_account_balance_history,
     upload_account_balance_history,
 )
@@ -219,3 +220,101 @@ class TestUploadAccountBalanceHistory:
         mock_monarch_client.get_account_history.side_effect = Exception("Timeout")
         result = await upload_account_balance_history("12345", '{"2026-04-21": 0}')
         assert "upload_account_balance_history" in result
+
+
+class TestUpdateAccount:
+    """A generic aggregator name or a wrongly counted balance previously forced
+    a trip to the web UI; these cover the tool that closes that gap."""
+
+    async def test_renames_an_account(self, mock_monarch_client):
+        mock_monarch_client.update_account.return_value = {
+            "updateAccount": {
+                "account": {
+                    "displayName": "Issuer Card Product (...0000)",
+                    "currentBalance": -816.78,
+                    "includeInNetWorth": True,
+                    "hideFromList": False,
+                    "hideTransactionsFromReports": False,
+                },
+                "errors": None,
+            }
+        }
+        result = json.loads(
+            await update_account(
+                account_id="acc-1", name="Issuer Card Product (...0000)"
+            )
+        )
+        assert result["updated"] is True
+        assert result["applied"] == {"account_name": "Issuer Card Product (...0000)"}
+        mock_monarch_client.update_account.assert_awaited_once_with(
+            account_id="acc-1", account_name="Issuer Card Product (...0000)"
+        )
+
+    async def test_omitted_fields_are_not_sent(self, mock_monarch_client):
+        """Only what the caller passed may reach Monarch, so an unrelated
+        setting cannot be reset to a default as a side effect."""
+        mock_monarch_client.update_account.return_value = {
+            "updateAccount": {"account": {}, "errors": None}
+        }
+        await update_account(account_id="acc-1", include_in_net_worth=False)
+        mock_monarch_client.update_account.assert_awaited_once_with(
+            account_id="acc-1", include_in_net_worth=False
+        )
+
+    async def test_false_is_a_real_value_not_an_omission(self, mock_monarch_client):
+        """include_in_net_worth=False is the whole point of the flag; a falsy
+        check rather than an `is not None` check would silently drop it."""
+        mock_monarch_client.update_account.return_value = {
+            "updateAccount": {"account": {}, "errors": None}
+        }
+        await update_account(
+            account_id="acc-1",
+            hide_from_summary_list=False,
+            hide_transactions_from_reports=False,
+        )
+        _, kwargs = mock_monarch_client.update_account.await_args
+        assert kwargs["hide_from_summary_list"] is False
+        assert kwargs["hide_transactions_from_reports"] is False
+
+    async def test_zero_balance_is_not_treated_as_omitted(self, mock_monarch_client):
+        """Setting a paid-off account to 0.00 is a legitimate correction."""
+        mock_monarch_client.update_account.return_value = {
+            "updateAccount": {"account": {}, "errors": None}
+        }
+        await update_account(account_id="acc-1", balance=0.0)
+        _, kwargs = mock_monarch_client.update_account.await_args
+        assert kwargs["account_balance"] == 0.0
+
+    async def test_no_fields_is_an_error_not_a_silent_noop(self, mock_monarch_client):
+        result = json.loads(await update_account(account_id="acc-1"))
+        assert result["error"] is True
+        mock_monarch_client.update_account.assert_not_awaited()
+
+    async def test_dry_run_reports_current_and_proposed_without_writing(
+        self, mock_monarch_client
+    ):
+        result = json.loads(
+            await update_account(account_id="acc-1", name="Renamed", dry_run=True)
+        )
+        assert result["dry_run"] is True
+        assert result["current"]["name"] == "Checking Account"
+        assert result["proposed"] == {"account_name": "Renamed"}
+        mock_monarch_client.update_account.assert_not_awaited()
+
+    async def test_dry_run_on_unknown_account_errors(self, mock_monarch_client):
+        result = json.loads(
+            await update_account(account_id="nope", name="X", dry_run=True)
+        )
+        assert result["error"] is True
+        assert "not found" in result["message"]
+
+    async def test_monarch_payload_errors_are_surfaced(self, mock_monarch_client):
+        mock_monarch_client.update_account.return_value = {
+            "updateAccount": {
+                "account": None,
+                "errors": [{"message": "invalid account type"}],
+            }
+        }
+        result = json.loads(await update_account(account_id="acc-1", name="X"))
+        assert result["error"] is True
+        assert "invalid account type" in result["message"]


### PR DESCRIPTION
## What

Adds an `update_account` MCP tool. The account surface was read-only apart from `refresh_accounts` and `upload_account_balance_history`, so renaming an account, excluding one from net worth, or hiding its transactions all meant leaving the agent and using the web UI.

`MonarchMoney.update_account` already exists in the underlying library and `Common_UpdateAccount` is already defined — this only wires them up.

## Why

Two cases hit in ordinary use:

**Generic aggregator names.** Institutions supply names like `CREDIT CARD (...1234)`. When several cards come from one issuer, the display name can't tell them apart, and a report read months later is unreadable. Renaming is a one-line fix that currently requires the UI.

**Custodial accounts.** UTMA/UGMA accounts are the child's property, not the custodian's, so counting them overstates net worth. `include_in_net_worth=False` is the correct treatment and there was no way to set it from a tool.

## Design notes

- **Only fields the caller passes are forwarded**, so an unrelated setting can't be reset as a side effect.
- The guard is `is not None`, not a falsy check. `include_in_net_worth=False` is the entire point of the flag, and a balance of `0.00` is a legitimate correction for a paid-off account — a falsy check would silently drop both.
- **Registered in `MUTATING_TOOLS`**, so read-only deployments never see it.
- **Supports `dry_run=True`**, reporting current vs proposed values without writing, matching the convention in `upload_account_balance_history` and `update_category`.
- Errors follow the existing `json_error(tool_name, exc)` shape, and Monarch payload errors are surfaced rather than swallowed.

## Tests

Nine new tests in `tests/test_accounts.py` covering the write path, field filtering, the `False` and `0.0` cases, the empty-update error, both `dry_run` branches, and Monarch payload errors.

`README.md` tool table updated so `test_readme_tool_reference` stays green.

Full suite: **325 passed**. Verified `update_account` is absent from the 25 tools registered under `MONARCH_MCP_READ_ONLY=1` and present in the 50 registered normally.

## Not included

The household/member owner field isn't exposed by the library's `update_account`, so this doesn't cover it.