### PR TITLE
Add CI and supply chain workflows

### DIFF
--- a/.github/audit-baseline.txt
+++ b/.github/audit-baseline.txt
@@ -5,9 +5,15 @@
 # Every entry is a deliberate, dated acknowledgement. Remove entries as
 # dependencies are upgraded. Do not add one without saying why.
 #
-# Seeded 2026-09-07 from the first CI run of this workflow.
-# Nearly all of these are transitive under mcp[cli] and clear by
-# upgrading mcp, which is tracked separately.
+# Seeded 2026-09-06 from the first CI run of this workflow.
+#
+# Do not assume an mcp bump clears this. It does not. Measured against the
+# committed lock: constraining to mcp[cli]>=1.28.1,<2 resolves to 1.29.1 and
+# clears exactly the three mcp entries. Every starlette and python-multipart
+# entry survives, because mcp depends on them with lower bounds only and uv
+# resolves minimally, so a transitive pin that already satisfies the new
+# constraint does not move. Clearing those needs an explicit
+# uv lock --upgrade-package starlette python-multipart, or a full upgrade.
 
 # black 25.1.0
 PYSEC-2026-2120  # fixed in 26.3.0

--- a/.github/audit-baseline.txt
+++ b/.github/audit-baseline.txt
@@ -1,0 +1,71 @@
+# Known advisories against the locked dependency set, accepted for now.
+# The audit fails on any advisory NOT listed here, so a newly published
+# one is a red build while this standing backlog stays quiet.
+#
+# Every entry is a deliberate, dated acknowledgement. Remove entries as
+# dependencies are upgraded. Do not add one without saying why.
+#
+# Seeded 2026-09-07 from the first CI run of this workflow.
+# Nearly all of these are transitive under mcp[cli] and clear by
+# upgrading mcp, which is tracked separately.
+
+# black 25.1.0
+PYSEC-2026-2120  # fixed in 26.3.0
+PYSEC-2026-2121  # fixed in 26.3.1
+
+# click 8.2.1
+PYSEC-2026-2132  # fixed in 8.3.3
+
+# cryptography 45.0.7
+GHSA-537c-gmf6-5ccf  # fixed in 48.0.1
+PYSEC-2026-2141  # fixed in 46.0.5
+PYSEC-2026-35  # fixed in 46.0.6
+PYSEC-2026-3552  # fixed in 50.0.0
+PYSEC-2026-3553  # fixed in 49.0.0
+PYSEC-2026-3554  # fixed in 49.0.0
+PYSEC-2026-36  # fixed in 46.0.7
+
+# filelock 3.19.1
+PYSEC-2026-1374  # fixed in 3.20.3
+PYSEC-2026-1375  # fixed in 3.20.1
+
+# idna 3.10
+PYSEC-2026-215  # fixed in 3.15
+
+# jaraco-context 6.0.1
+CVE-2026-23949  # fixed in 6.1.0
+PYSEC-2026-1469  # fixed in 6.1.0
+
+# mcp 1.13.1
+PYSEC-2026-1617  # fixed in 1.23.0
+PYSEC-2026-3482  # fixed in 1.27.2
+PYSEC-2026-3483  # fixed in 1.28.1
+
+# pygments 2.19.2
+PYSEC-2026-2987  # fixed in 2.20.0
+
+# pytest 8.4.2
+PYSEC-2026-1845  # fixed in 9.0.3
+
+# python-dotenv 1.1.1
+PYSEC-2026-2270  # fixed in 1.2.2
+
+# python-multipart 0.0.20
+PYSEC-2026-1852  # fixed in 0.0.22
+PYSEC-2026-3036  # fixed in 0.0.30
+PYSEC-2026-3037  # fixed in 0.0.30
+PYSEC-2026-3038  # fixed in 0.0.26
+PYSEC-2026-3039  # fixed in 0.0.27
+PYSEC-2026-3040  # fixed in 0.0.31
+PYSEC-2026-3041  # fixed in 0.0.30
+
+# starlette 0.47.3
+PYSEC-2026-161  # fixed in 1.0.1
+PYSEC-2026-1942  # fixed in 0.49.1
+PYSEC-2026-2280  # fixed in 1.1.0
+PYSEC-2026-2281  # fixed in 1.1.0
+PYSEC-2026-248  # fixed in 1.3.0
+PYSEC-2026-249  # fixed in 1.3.1
+
+# virtualenv 20.34.0
+PYSEC-2026-2009  # fixed in 20.36.1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Pinning every action to a commit SHA stops a retagged release walking in, but
+# it also means a pinned action never receives its own security fixes. This is
+# the other half of that strategy: Dependabot proposes the SHA bumps, and the
+# workflows above check what lands.
+#
+# Version updates work from the manifests and do not need the dependency graph,
+# which is off for this repository.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: deps
+    # Grouped so the standing advisory backlog clears in one reviewable pull
+    # request rather than a dozen, since nearly all of it is transitive under
+    # mcp and moves together.
+    groups:
+      python:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+# pull_request (not pull_request_target) so forked-PR code runs with a read-only
+# token against the fork's context. pull_request_target would hand untrusted code
+# a write-scoped token for this repo.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Least privilege: nothing here writes to the repo, so read access to the code is
+# all any job needs. Scopes not listed are dropped, not inherited.
+permissions:
+  contents: read
+
+# A newer push to a PR makes the in-flight run obsolete; don't burn runners on it.
+# main is exempt so every merged commit keeps a result.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  # Pinned rather than floating so a uv release cannot change what CI installs
+  # without a reviewed commit. uv is also the thing that extracts every package
+  # archive here, so its version is a supply chain decision in its own right:
+  # everything before 0.11.15 carries advisories covering arbitrary file write
+  # via entry point names, file deletion via RECORD entries, tar path traversal,
+  # and ZIP parsing differentials that let an archive present different contents
+  # to a scanner than to the installer. That last one would undercut the whole
+  # point of the supply chain workflow. Verified that this version accepts the
+  # current revision 2 uv.lock unchanged, so the pin costs nothing.
+  UV_VERSION: "0.12.10"
+
+jobs:
+  # Split out from the tests so a drifted lockfile reports as its own failure
+  # instead of hiding behind a Python version in the matrix.
+  lockfile:
+    name: Lockfile is in sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Actions are pinned to full commit SHAs: a tag is mutable, so a compromised
+      # or retagged release would otherwise run in this workflow unreviewed.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      # Fails if pyproject.toml asks for versions uv.lock doesn't pin. Without this,
+      # a dependency bump that skips `uv lock` leaves the lock pinning the old
+      # version, and the hashes it carries stop covering what's actually requested.
+      - name: uv lock --check
+        run: uv lock --check
+
+  test:
+    name: Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      # Report every version's result; one failure shouldn't mask the others.
+      fail-fast: false
+      matrix:
+        # Tracks requires-python = ">=3.12,<3.14" in pyproject.toml.
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: ${{ env.UV_VERSION }}
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
+      # --locked installs exactly what uv.lock pins, hash-verified, and refuses to
+      # re-resolve. Without it CI could quietly test a different dependency set
+      # than the one that was reviewed. --extra dev pulls in pytest.
+      - name: Install dependencies
+        run: uv sync --locked --extra dev
+
+      # --no-sync because the step above already built the environment.
+      - name: Run tests
+        run: uv run --no-sync pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ env:
   # point of the supply chain workflow. Verified that this version accepts the
   # current revision 2 uv.lock unchanged, so the pin costs nothing.
   UV_VERSION: "0.12.10"
+  # sha256 of uv-x86_64-unknown-linux-gnu.tar.gz for UV_VERSION, from the
+  # release's published .sha256. setup-uv only validates against a checksum
+  # table baked into the action at its pinned commit, and that table stops at
+  # uv 0.12.4, so without this the newer binary is fetched and executed with no
+  # integrity check and only a core.debug line to say so. Update both together.
+  UV_CHECKSUM: "173d95a0c32d18c896c46ba6fafbf3cf9c14ab74b033f81b76c883ef492a976b"
 
 jobs:
   # Split out from the tests so a drifted lockfile reports as its own failure
@@ -42,10 +48,15 @@ jobs:
       # Actions are pinned to full commit SHAs: a tag is mutable, so a compromised
       # or retagged release would otherwise run in this workflow unreviewed.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # This job builds and runs fork controlled code, so do not leave the
+          # token in .git/config for it to read.
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
+          checksum: ${{ env.UV_CHECKSUM }}
           enable-cache: true
 
       # Fails if pyproject.toml asks for versions uv.lock doesn't pin. Without this,
@@ -66,10 +77,15 @@ jobs:
         python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # This job builds and runs fork controlled code, so do not leave the
+          # token in .git/config for it to read.
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
+          checksum: ${{ env.UV_CHECKSUM }}
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ env:
   # integrity check and only a core.debug line to say so. Update both together.
   UV_CHECKSUM: "173d95a0c32d18c896c46ba6fafbf3cf9c14ab74b033f81b76c883ef492a976b"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # Split out from the tests so a drifted lockfile reports as its own failure
   # instead of hiding behind a Python version in the matrix.
@@ -49,8 +53,8 @@ jobs:
       # or retagged release would otherwise run in this workflow unreviewed.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # This job builds and runs fork controlled code, so do not leave the
-          # token in .git/config for it to read.
+          # Nothing in this job needs the token, so do not leave it in
+          # .git/config.
           persist-credentials: false
 
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -2,14 +2,17 @@
 #
 # This server holds a long-lived credential for the user's real financial
 # accounts, so a compromised or vulnerable dependency is the highest-impact
-# failure mode in the repo. Two checks live here:
+# failure mode in the repo. One check lives here: `audit` screens the *locked*
+# dependency set (everything `uv.lock` actually resolves to, not the loose
+# ranges in requirements.txt) against both the PyPI advisory database and OSV,
+# and fails on anything not already recorded in .github/audit-baseline.txt.
 #
-#   1. `audit` - screens the *locked* dependency set (everything `uv.lock`
-#      actually resolves to, not the loose ranges in requirements.txt) against
-#      both the PyPI advisory database and OSV.
-#   2. `dependency-review` - blocks a pull request that *introduces* a
-#      known-vulnerable dependency version. This action only works on
-#      `pull_request` events, hence the `if:` guard.
+# There was a `dependency-review` job here. It was removed rather than fixed:
+# the dependency graph is disabled for this repository, and enabling it would
+# not have helped much, because GitHub's graph does not parse `uv.lock` while
+# requirements.txt and pyproject.toml carry only lower bounds. There is no
+# concrete version for it to evaluate, and every transitive change lands in
+# the lock where it cannot see it.
 #
 # Deliberately NOT implemented here (tracked in #99 / #100): the network-egress
 # canary job, the sdist-diff artifact on bump PRs, and PyPI-vs-tag
@@ -194,12 +197,11 @@ jobs:
         #   is what actually surfaces these: it puts a standing, dated list in
         #   front of a maintainer without coupling it to unrelated work.
         #
-        # The complementary hard gate lives in the `dependency-review` job
-        # below, which can afford `fail-on-severity: high` because it only
-        # fires on PRs that change dependencies - it cannot block unrelated
-        # work by construction. Between the two, a PR that *introduces* a
-        # high-severity advisory is blocked, while advisories that merely
-        # already exist are reported.
+        # The hard gate is the baseline delta below: anything not already
+        # recorded in .github/audit-baseline.txt fails the build. That is what
+        # separates "this backlog is known and accepted" from "something new
+        # was published against a pin we ship", without going permanently red
+        # over the former.
         #
         # This step interpolates nothing; it reads only files produced above.
         run: |

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -74,6 +74,7 @@ jobs:
       # --require-hashes --strict), and the gate would read the attacker's file
       # and report no advisories. RUNNER_TEMP is not attacker writable, so a
       # report existing there means pip-audit actually wrote it.
+      BASELINE_FILE: .github/audit-baseline.txt
       REQUIREMENTS_FILE: requirements-audit.txt
       OSV_REPORT_NAME: pip-audit-osv.json
       PYPI_REPORT_NAME: pip-audit-pypi.json
@@ -116,7 +117,16 @@ jobs:
             --no-emit-project \
             --no-editable \
             --format requirements-txt \
-            --output-file "${RUNNER_TEMP}/${REQUIREMENTS_FILE}"
+            --output-file "${RUNNER_TEMP}/${REQUIREMENTS_FILE}.marked"
+          # pip-audit silently skips any requirement whose environment marker is
+          # false on the runner, without even recording it as skipped, so
+          # --strict does not notice. On ubuntu that quietly drops the win32
+          # pins (colorama, pywin32, pywin32-ctypes) that Windows users of this
+          # server actually install. Strip the markers so every locked pin is
+          # audited regardless of the platform CI happens to run on.
+          sed -E 's/ ; [^\\]*(\\?)$/ \1/' \
+            "${RUNNER_TEMP}/${REQUIREMENTS_FILE}.marked" \
+            > "${RUNNER_TEMP}/${REQUIREMENTS_FILE}"
           echo "Exported $(grep -cE '^[A-Za-z0-9]' "${RUNNER_TEMP}/${REQUIREMENTS_FILE}") pinned requirements."
 
       - name: pip-audit against OSV
@@ -236,6 +246,35 @@ jobs:
                       )
                       entry["sources"].append(label)
 
+          # Anything whose id set does not intersect the baseline is new since
+          # the backlog was last acknowledged, and fails the build.
+          #
+          # Matching on the whole id set rather than the primary id is
+          # deliberate: pip-audit re-sorts ids to prefer PYSEC and CVE as the
+          # primary, so a primary id can change when a service later adds an
+          # alias. Matching every id keeps a baseline entry stable.
+          baseline: set[str] = set()
+          baseline_path = pathlib.Path(os.environ["BASELINE_FILE"])
+          if baseline_path.is_file():
+              for raw in baseline_path.read_text().splitlines():
+                  entry = raw.split("#", 1)[0].strip()
+                  if entry:
+                      baseline.add(entry.upper())
+
+          new_findings = sorted(
+              key
+              for key, entry in findings.items()
+              if not {str(i).upper() for i in entry["ids"]} & baseline
+          )
+
+          # Kept as a separate always-fail regardless of the baseline. A
+          # malicious package advisory is never something to acknowledge and
+          # move on from, so it must not be silenceable by adding a line to a
+          # file. Note the prefix test alone is not sufficient coverage:
+          # GitHub-reviewed malware is not consistently mirrored into the MAL-
+          # namespace (the canonical ctx compromise is GHSA-4g82-3jcr-q52w,
+          # "Malware in ctx"). The baseline delta above is what actually
+          # catches that case, because such an advisory would be new.
           malicious = sorted(
               key
               for key, entry in findings.items()
@@ -255,6 +294,21 @@ jobs:
                   f"{', '.join(unavailable)}.\n"
               )
 
+          if new_findings:
+              out.append(
+                  f"\n### New advisories since the baseline ({len(new_findings)}) "
+                  "- build failed\n\n"
+              )
+              out.append(
+                  "Upgrade the dependency, or add the advisory id to "
+                  f"`{os.environ['BASELINE_FILE']}` with a note saying why it "
+                  "is accepted.\n\n"
+              )
+              for name, version, vid in new_findings:
+                  entry = findings[(name, version, vid)]
+                  fix = ", ".join(entry["fix"]) or "none published"
+                  out.append(f"- `{name}=={version}` {vid}, fixed in {fix}\n")
+
           if malicious:
               out.append("\n### Malicious package advisories (build failed)\n")
               for name, version, vid in malicious:
@@ -271,8 +325,8 @@ jobs:
                   src = ", ".join(sorted(set(entry["sources"])))
                   out.append(f"| `{name}` | `{version}` | {vid} | {fix} | {src} |\n")
               out.append(
-                  "\nNon-malicious advisories are reported, not gated - see the "
-                  "comment on this step for the reasoning.\n"
+                  f"\n{len(findings) - len(new_findings)} of these are in the "
+                  "accepted baseline and did not fail the build.\n"
               )
           else:
               out.append("\nNo known advisories against the locked dependency set.\n")
@@ -300,47 +354,22 @@ jobs:
               )
               raise SystemExit(1)
 
+          failed = False
+
           if malicious:
               for name, version, vid in malicious:
                   print(f"::error::Malicious package advisory {vid} for {name}=={version}")
+              failed = True
+
+          if new_findings:
+              for name, version, vid in new_findings:
+                  print(
+                      f"::error::New advisory {vid} for {name}=={version}. "
+                      "Upgrade it, or add the id to "
+                      f"{os.environ['BASELINE_FILE']} with a reason."
+                  )
+              failed = True
+
+          if failed:
               raise SystemExit(1)
           PY
-
-  dependency-review:
-    name: Dependency review
-    # `actions/dependency-review-action` compares the dependency graph of the
-    # base ref against the head ref, so it is only meaningful on pull requests.
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      # Needed to resolve the pull request's base and head refs. Deliberately
-      # `read` and not `write`: `write` is only required to post the summary as
-      # a PR comment, and the job summary is enough.
-      pull-requests: read
-    steps:
-      - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Dependency review
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
-        with:
-          # This gate can afford to be a hard failure where the audit job
-          # cannot: it only evaluates dependencies the PR itself adds or bumps,
-          # so it is incapable of blocking a PR that does not touch
-          # dependencies. `high` rather than `low` keeps a bump from being
-          # blocked by a low-severity advisory in an unrelated transitive dep
-          # while still stopping the cases that matter.
-          fail-on-severity: high
-          fail-on-scopes: runtime, development
-          vulnerability-check: true
-          # No license policy is defined for this repo yet, so leave license
-          # enforcement off rather than fail on an undeclared policy.
-          license-check: false
-          show-patched-versions: true
-          # Posting to the PR would need `pull-requests: write`; the job summary
-          # carries the same information at lower privilege.
-          comment-summary-in-pr: never

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,329 @@
+# Supply-chain checks.
+#
+# This server holds a long-lived credential for the user's real financial
+# accounts, so a compromised or vulnerable dependency is the highest-impact
+# failure mode in the repo. Two checks live here:
+#
+#   1. `audit` - screens the *locked* dependency set (everything `uv.lock`
+#      actually resolves to, not the loose ranges in requirements.txt) against
+#      both the PyPI advisory database and OSV.
+#   2. `dependency-review` - blocks a pull request that *introduces* a
+#      known-vulnerable dependency version. This action only works on
+#      `pull_request` events, hence the `if:` guard.
+#
+# Deliberately NOT implemented here (tracked in #99 / #100): the network-egress
+# canary job, the sdist-diff artifact on bump PRs, and PyPI-vs-tag
+# verification. Lockfile drift (`uv lock --check`) belongs to ci.yml (#95), not
+# to this workflow.
+#
+# Hardening notes, since a security workflow is itself an attack surface:
+#   * No `pull_request_target`. Fork PR code is only ever built with a
+#     read-only token and no access to repository secrets.
+#   * Every third-party action is pinned to a full 40-character commit SHA,
+#     with the human-readable tag in a trailing comment. A floating tag on a
+#     security workflow would defeat the point of having one.
+#   * No `${{ ... }}` interpolation of attacker-controlled values (PR title,
+#     branch name, author, body) into any `run:` block. Values that a `run:`
+#     block needs are passed through `env:` instead.
+
+name: Supply chain
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  # Advisories get published against dependencies we have not touched in
+  # months, so the audit has to run on a clock and not only on code changes.
+  schedule:
+    - cron: "23 6 * * 1" # Mondays, 06:23 UTC
+
+# Least privilege: nothing in this workflow writes anything. `contents: read`
+# is the floor; the one job that needs more widens it at the job level. In
+# particular we do not take `security-events: write`, because we deliberately
+# do not upload SARIF - the findings go to the job summary instead.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Superseded PR runs are worth cancelling; scheduled and main-branch runs are
+  # not, because their whole job is to produce a record.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  audit:
+    name: Audit locked dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      # Pinned so that a compromised pip-audit release cannot walk in through
+      # this job. The advisory data itself is fetched from the services at run
+      # time, so pinning the tool does not stale the results. Bump manually.
+      PIP_AUDIT_VERSION: "2.10.1"
+      REQUIREMENTS_FILE: requirements-audit.txt
+      OSV_REPORT: pip-audit-osv.json
+      PYPI_REPORT: pip-audit-pypi.json
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.10"
+          # sha256 of uv-x86_64-unknown-linux-gnu.tar.gz for the version above,
+          # from the release's published .sha256 file. Verified by the action
+          # before the binary is unpacked.
+          checksum: "173d95a0c32d18c896c46ba6fafbf3cf9c14ab74b033f81b76c883ef492a976b"
+          # No cross-run cache: a poisoned cache entry is a real path into a
+          # security job, and this dependency tree is far too small to need one.
+          enable-cache: false
+
+      - name: Export the locked dependency set
+        # `--frozen` guarantees we audit exactly what `uv.lock` already pins. If
+        # the export were allowed to re-resolve, we would be auditing something
+        # other than what ships.
+        #
+        # `--all-extras` pulls the `dev` extra in too. A malicious `pytest` runs
+        # on maintainer machines and on this runner just as a malicious `mcp`
+        # would, so it is in scope for the malicious-package gate below.
+        #
+        # The export carries `--hash=` lines for every pin, which lets the audit
+        # run with `--require-hashes --no-deps --disable-pip`: no resolver, no
+        # index traffic, nothing installed. The only network call is to the
+        # advisory service.
+        run: |
+          uv export \
+            --frozen \
+            --all-extras \
+            --no-emit-project \
+            --no-editable \
+            --format requirements-txt \
+            --output-file "${REQUIREMENTS_FILE}"
+          echo "Exported $(grep -cE '^[A-Za-z0-9]' "${REQUIREMENTS_FILE}") pinned requirements."
+
+      - name: pip-audit against OSV
+        # OSV carries malicious-package advisories (MAL-* IDs) in addition to
+        # CVEs, which is what makes it the gate for known-compromised releases,
+        # typosquats, and versions yanked for malware.
+        #
+        # `|| true`: pip-audit exits non-zero both when it finds something and
+        # when it fails outright. The gate step below distinguishes the two by
+        # checking whether the JSON report parsed.
+        run: |
+          uvx --from "pip-audit==${PIP_AUDIT_VERSION}" pip-audit \
+            --requirement "${REQUIREMENTS_FILE}" \
+            --require-hashes \
+            --no-deps \
+            --disable-pip \
+            --strict \
+            --vulnerability-service osv \
+            --aliases on \
+            --format json \
+            --output "${OSV_REPORT}" \
+            --progress-spinner off || true
+
+      - name: pip-audit against the PyPI advisory database
+        # Run as well as OSV, not instead of it: the two databases have
+        # overlapping but not identical coverage, and running both means a
+        # single upstream outage does not blind the check.
+        run: |
+          uvx --from "pip-audit==${PIP_AUDIT_VERSION}" pip-audit \
+            --requirement "${REQUIREMENTS_FILE}" \
+            --require-hashes \
+            --no-deps \
+            --disable-pip \
+            --strict \
+            --vulnerability-service pypi \
+            --aliases on \
+            --format json \
+            --output "${PYPI_REPORT}" \
+            --progress-spinner off || true
+
+      - name: Report findings and gate on malicious packages
+        # FAIL vs REPORT, and why it is split this way:
+        #
+        # Hard-failing on any advisory anywhere in the tree is the obvious
+        # choice and the wrong one here. At the time this workflow was written
+        # the committed lock already carried about 30 distinct advisories across
+        # 12 packages: starlette, python-multipart, mcp, click, pygments and
+        # friends, nearly all of them transitive under `mcp[cli]` and none of
+        # them fixable from this repo without waiting on upstream. A hard gate
+        # would have every unrelated PR red on arrival, which trains everyone
+        # to ignore the check. A security control that is always failing is a
+        # security control that is off.
+        #
+        # So the split is by *actionability and false-positive rate*:
+        #
+        #   MAL-* (malicious package) -> hard fail. A malicious-package
+        #   advisory means the exact release we pin is actively compromised.
+        #   There is no "we will get to it" version of that, and the
+        #   false-positive rate is effectively zero. This is precisely the
+        #   attack #99 is about, and it is worth blocking every PR over.
+        #
+        #   Everything else -> report to the job summary. The weekly schedule
+        #   is what actually surfaces these: it puts a standing, dated list in
+        #   front of a maintainer without coupling it to unrelated work.
+        #
+        # The complementary hard gate lives in the `dependency-review` job
+        # below, which can afford `fail-on-severity: high` because it only
+        # fires on PRs that change dependencies - it cannot block unrelated
+        # work by construction. Between the two, a PR that *introduces* a
+        # high-severity advisory is blocked, while advisories that merely
+        # already exist are reported.
+        #
+        # This step interpolates nothing; it reads only files produced above.
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+          import sys
+
+          SOURCES = (
+              ("OSV", os.environ["OSV_REPORT"]),
+              ("PyPI", os.environ["PYPI_REPORT"]),
+          )
+
+          findings: dict[tuple[str, str, str], dict[str, object]] = {}
+          available: list[str] = []
+          unavailable: list[str] = []
+          audited = 0
+
+          for label, path in SOURCES:
+              try:
+                  report = json.loads(pathlib.Path(path).read_text())
+                  dependencies = report["dependencies"]
+              except (OSError, ValueError, KeyError, TypeError):
+                  unavailable.append(label)
+                  continue
+
+              available.append(label)
+              audited = max(audited, len(dependencies))
+
+              for dep in dependencies:
+                  name, version = dep.get("name", "?"), dep.get("version", "?")
+                  for vuln in dep.get("vulns", []):
+                      key = (name, version, vuln.get("id", "?"))
+                      ids = [key[2], *vuln.get("aliases", [])]
+                      entry = findings.setdefault(
+                          key,
+                          {
+                              "ids": ids,
+                              "fix": vuln.get("fix_versions") or [],
+                              "sources": [],
+                          },
+                      )
+                      entry["sources"].append(label)
+
+          malicious = sorted(
+              key
+              for key, entry in findings.items()
+              if any(str(i).upper().startswith("MAL-") for i in entry["ids"])
+          )
+
+          out = []
+          out.append("## Locked dependency audit\n")
+          out.append(
+              f"Advisory services queried: "
+              f"{', '.join(available) if available else 'none'}. "
+              f"{audited} locked requirement entries audited.\n"
+          )
+          if unavailable:
+              out.append(
+                  f"> Advisory service(s) unavailable this run: "
+                  f"{', '.join(unavailable)}.\n"
+              )
+
+          if malicious:
+              out.append("\n### Malicious package advisories (build failed)\n")
+              for name, version, vid in malicious:
+                  ids = ", ".join(str(i) for i in findings[(name, version, vid)]["ids"])
+                  out.append(f"- `{name}=={version}` - {ids}\n")
+
+          if findings:
+              out.append(f"\n### All advisories ({len(findings)})\n\n")
+              out.append("| Package | Version | Advisory | Fixed in | Source |\n")
+              out.append("| --- | --- | --- | --- | --- |\n")
+              for (name, version, vid) in sorted(findings):
+                  entry = findings[(name, version, vid)]
+                  fix = ", ".join(entry["fix"]) or "none published"
+                  src = ", ".join(sorted(set(entry["sources"])))
+                  out.append(f"| `{name}` | `{version}` | {vid} | {fix} | {src} |\n")
+              out.append(
+                  "\nNon-malicious advisories are reported, not gated - see the "
+                  "comment on this step for the reasoning.\n"
+              )
+          else:
+              out.append("\nNo known advisories against the locked dependency set.\n")
+
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary:
+              with open(summary, "a", encoding="utf-8") as fh:
+                  fh.writelines(out)
+          sys.stdout.writelines(out)
+
+          # Fail closed only when we learned nothing at all. If one service
+          # answered, its data is good enough to gate on; if neither did, the
+          # check silently passing would be worse than a red build.
+          if not available:
+              print(
+                  "::error::No usable audit report was produced (advisory "
+                  "service unreachable, or --strict tripped on a requirement "
+                  "it could not collect). Failing closed rather than passing "
+                  "on no evidence."
+              )
+              raise SystemExit(1)
+
+          if malicious:
+              for name, version, vid in malicious:
+                  print(f"::error::Malicious package advisory {vid} for {name}=={version}")
+              raise SystemExit(1)
+          PY
+
+  dependency-review:
+    name: Dependency review
+    # `actions/dependency-review-action` compares the dependency graph of the
+    # base ref against the head ref, so it is only meaningful on pull requests.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # Needed to resolve the pull request's base and head refs. Deliberately
+      # `read` and not `write`: `write` is only required to post the summary as
+      # a PR comment, and the job summary is enough.
+      pull-requests: read
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          # This gate can afford to be a hard failure where the audit job
+          # cannot: it only evaluates dependencies the PR itself adds or bumps,
+          # so it is incapable of blocking a PR that does not touch
+          # dependencies. `high` rather than `low` keeps a bump from being
+          # blocked by a low-severity advisory in an unrelated transitive dep
+          # while still stopping the cases that matter.
+          fail-on-severity: high
+          fail-on-scopes: runtime, development
+          vulnerability-check: true
+          # No license policy is defined for this repo yet, so leave license
+          # enforcement off rather than fail on an undeclared policy.
+          license-check: false
+          show-patched-versions: true
+          # Posting to the PR would need `pull-requests: write`; the job summary
+          # carries the same information at lower privilege.
+          comment-summary-in-pr: never

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -66,9 +66,17 @@ jobs:
       # this job. The advisory data itself is fetched from the services at run
       # time, so pinning the tool does not stale the results. Bump manually.
       PIP_AUDIT_VERSION: "2.10.1"
+      # Written under RUNNER_TEMP, never the workspace. pip-audit creates its
+      # --output lazily and does not truncate it when it exits fatally, and the
+      # invocations below tolerate a non-zero exit. If these lived in the
+      # checkout, a fork PR could commit a clean looking pip-audit-*.json, make
+      # the tool fatal (a hashless or URL requirement in uv.lock does it under
+      # --require-hashes --strict), and the gate would read the attacker's file
+      # and report no advisories. RUNNER_TEMP is not attacker writable, so a
+      # report existing there means pip-audit actually wrote it.
       REQUIREMENTS_FILE: requirements-audit.txt
-      OSV_REPORT: pip-audit-osv.json
-      PYPI_REPORT: pip-audit-pypi.json
+      OSV_REPORT_NAME: pip-audit-osv.json
+      PYPI_REPORT_NAME: pip-audit-pypi.json
     steps:
       - name: Check out
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -104,11 +112,12 @@ jobs:
           uv export \
             --frozen \
             --all-extras \
+            --all-groups \
             --no-emit-project \
             --no-editable \
             --format requirements-txt \
-            --output-file "${REQUIREMENTS_FILE}"
-          echo "Exported $(grep -cE '^[A-Za-z0-9]' "${REQUIREMENTS_FILE}") pinned requirements."
+            --output-file "${RUNNER_TEMP}/${REQUIREMENTS_FILE}"
+          echo "Exported $(grep -cE '^[A-Za-z0-9]' "${RUNNER_TEMP}/${REQUIREMENTS_FILE}") pinned requirements."
 
       - name: pip-audit against OSV
         # OSV carries malicious-package advisories (MAL-* IDs) in addition to
@@ -119,8 +128,9 @@ jobs:
         # when it fails outright. The gate step below distinguishes the two by
         # checking whether the JSON report parsed.
         run: |
-          uvx --from "pip-audit==${PIP_AUDIT_VERSION}" pip-audit \
-            --requirement "${REQUIREMENTS_FILE}" \
+          rm -f "${RUNNER_TEMP}/${OSV_REPORT_NAME}"
+          uvx --no-config --from "pip-audit==${PIP_AUDIT_VERSION}" pip-audit \
+            --requirement "${RUNNER_TEMP}/${REQUIREMENTS_FILE}" \
             --require-hashes \
             --no-deps \
             --disable-pip \
@@ -128,7 +138,7 @@ jobs:
             --vulnerability-service osv \
             --aliases on \
             --format json \
-            --output "${OSV_REPORT}" \
+            --output "${RUNNER_TEMP}/${OSV_REPORT_NAME}" \
             --progress-spinner off || true
 
       - name: pip-audit against the PyPI advisory database
@@ -136,8 +146,9 @@ jobs:
         # overlapping but not identical coverage, and running both means a
         # single upstream outage does not blind the check.
         run: |
-          uvx --from "pip-audit==${PIP_AUDIT_VERSION}" pip-audit \
-            --requirement "${REQUIREMENTS_FILE}" \
+          rm -f "${RUNNER_TEMP}/${PYPI_REPORT_NAME}"
+          uvx --no-config --from "pip-audit==${PIP_AUDIT_VERSION}" pip-audit \
+            --requirement "${RUNNER_TEMP}/${REQUIREMENTS_FILE}" \
             --require-hashes \
             --no-deps \
             --disable-pip \
@@ -145,7 +156,7 @@ jobs:
             --vulnerability-service pypi \
             --aliases on \
             --format json \
-            --output "${PYPI_REPORT}" \
+            --output "${RUNNER_TEMP}/${PYPI_REPORT_NAME}" \
             --progress-spinner off || true
 
       - name: Report findings and gate on malicious packages
@@ -188,9 +199,10 @@ jobs:
           import pathlib
           import sys
 
+          TEMP = pathlib.Path(os.environ["RUNNER_TEMP"])
           SOURCES = (
-              ("OSV", os.environ["OSV_REPORT"]),
-              ("PyPI", os.environ["PYPI_REPORT"]),
+              ("OSV", TEMP / os.environ["OSV_REPORT_NAME"]),
+              ("PyPI", TEMP / os.environ["PYPI_REPORT_NAME"]),
           )
 
           findings: dict[tuple[str, str, str], dict[str, object]] = {}
@@ -200,7 +212,7 @@ jobs:
 
           for label, path in SOURCES:
               try:
-                  report = json.loads(pathlib.Path(path).read_text())
+                  report = json.loads(path.read_text())
                   dependencies = report["dependencies"]
               except (OSError, ValueError, KeyError, TypeError):
                   unavailable.append(label)
@@ -274,12 +286,17 @@ jobs:
           # Fail closed only when we learned nothing at all. If one service
           # answered, its data is good enough to gate on; if neither did, the
           # check silently passing would be worse than a red build.
-          if not available:
+          # OSV is the only one of the two services that publishes MAL-
+          # malicious package advisories, so it alone backs the hard gate below.
+          # Passing because PyPI answered while OSV did not would mean the
+          # malicious package check ran with zero coverage and still went green.
+          if "OSV" not in available:
               print(
-                  "::error::No usable audit report was produced (advisory "
-                  "service unreachable, or --strict tripped on a requirement "
-                  "it could not collect). Failing closed rather than passing "
-                  "on no evidence."
+                  "::error::No usable OSV report was produced (service "
+                  "unreachable, or --strict tripped on a requirement it could "
+                  "not collect). OSV is the only source of MAL- malicious "
+                  "package advisories, so the gate has no coverage without it. "
+                  "Failing closed rather than passing on no evidence."
               )
               raise SystemExit(1)
 

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -41,9 +41,9 @@ on:
     - cron: "23 6 * * 1" # Mondays, 06:23 UTC
 
 # Least privilege: nothing in this workflow writes anything. `contents: read`
-# is the floor; the one job that needs more widens it at the job level. In
-# particular we do not take `security-events: write`, because we deliberately
-# do not upload SARIF - the findings go to the job summary instead.
+# is the floor and no job widens it. In particular we do not take
+# `security-events: write`, because we deliberately do not upload SARIF; the
+# findings go to the job summary instead.
 permissions:
   contents: read
 
@@ -65,11 +65,17 @@ jobs:
     permissions:
       contents: read
     env:
+      # Kept in step with ci.yml by hand. Dependabot bumps action SHAs, not a
+      # `with: version:` input, so a grep for the version string has to find
+      # both files.
+      UV_VERSION: "0.12.10"
+      UV_CHECKSUM: "173d95a0c32d18c896c46ba6fafbf3cf9c14ab74b033f81b76c883ef492a976b"
       # Pinned so that a compromised pip-audit release cannot walk in through
       # this job. The advisory data itself is fetched from the services at run
       # time, so pinning the tool does not stale the results. Bump manually.
       PIP_AUDIT_VERSION: "2.10.1"
-      # Written under RUNNER_TEMP, never the workspace. pip-audit creates its
+      BASELINE_FILE: .github/audit-baseline.txt
+      # The three below are written under RUNNER_TEMP, never the workspace. pip-audit creates its
       # --output lazily and does not truncate it when it exits fatally, and the
       # invocations below tolerate a non-zero exit. If these lived in the
       # checkout, a fork PR could commit a clean looking pip-audit-*.json, make
@@ -77,7 +83,6 @@ jobs:
       # --require-hashes --strict), and the gate would read the attacker's file
       # and report no advisories. RUNNER_TEMP is not attacker writable, so a
       # report existing there means pip-audit actually wrote it.
-      BASELINE_FILE: .github/audit-baseline.txt
       REQUIREMENTS_FILE: requirements-audit.txt
       OSV_REPORT_NAME: pip-audit-osv.json
       PYPI_REPORT_NAME: pip-audit-pypi.json
@@ -90,11 +95,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.10"
+          version: ${{ env.UV_VERSION }}
           # sha256 of uv-x86_64-unknown-linux-gnu.tar.gz for the version above,
           # from the release's published .sha256 file. Verified by the action
           # before the binary is unpacked.
-          checksum: "173d95a0c32d18c896c46ba6fafbf3cf9c14ab74b033f81b76c883ef492a976b"
+          checksum: ${{ env.UV_CHECKSUM }}
           # No cross-run cache: a poisoned cache entry is a real path into a
           # security job, and this dependency tree is far too small to need one.
           enable-cache: false
@@ -193,9 +198,10 @@ jobs:
         #   false-positive rate is effectively zero. This is precisely the
         #   attack #99 is about, and it is worth blocking every PR over.
         #
-        #   Everything else -> report to the job summary. The weekly schedule
-        #   is what actually surfaces these: it puts a standing, dated list in
-        #   front of a maintainer without coupling it to unrelated work.
+        #   Everything else -> fails unless its id set intersects
+        #   .github/audit-baseline.txt. The baseline is the standing, dated
+        #   acknowledgement of what is already known and not fixable today, so
+        #   the backlog stays quiet while anything newly published is red.
         #
         # The hard gate is the baseline delta below: anything not already
         # recorded in .github/audit-baseline.txt fails the build. That is what
@@ -235,9 +241,9 @@ jobs:
 
               for dep in dependencies:
                   name, version = dep.get("name", "?"), dep.get("version", "?")
-                  for vuln in dep.get("vulns", []):
+                  for vuln in dep.get("vulns") or []:
                       key = (name, version, vuln.get("id", "?"))
-                      ids = [key[2], *vuln.get("aliases", [])]
+                      ids = [key[2], *(vuln.get("aliases") or [])]
                       entry = findings.setdefault(
                           key,
                           {
@@ -246,6 +252,10 @@ jobs:
                               "sources": [],
                           },
                       )
+                      # Union the ids: the two services can report different
+                      # alias sets for the same advisory, and keeping only the
+                      # first would miss a baseline entry naming the other's.
+                      entry["ids"] = sorted({*entry["ids"], *ids})
                       entry["sources"].append(label)
 
           # Anything whose id set does not intersect the baseline is new since
@@ -327,8 +337,9 @@ jobs:
                   src = ", ".join(sorted(set(entry["sources"])))
                   out.append(f"| `{name}` | `{version}` | {vid} | {fix} | {src} |\n")
               out.append(
-                  f"\n{len(findings) - len(new_findings)} of these are in the "
-                  "accepted baseline and did not fail the build.\n"
+                  f"\n{len(findings) - len(set(new_findings) | set(malicious))} "
+                  "of these are in the accepted baseline and did not fail the "
+                  "build.\n"
               )
           else:
               out.append("\nNo known advisories against the locked dependency set.\n")

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -7,12 +7,18 @@
 # ranges in requirements.txt) against both the PyPI advisory database and OSV,
 # and fails on anything not already recorded in .github/audit-baseline.txt.
 #
-# There was a `dependency-review` job here. It was removed rather than fixed:
-# the dependency graph is disabled for this repository, and enabling it would
-# not have helped much, because GitHub's graph does not parse `uv.lock` while
-# requirements.txt and pyproject.toml carry only lower bounds. There is no
-# concrete version for it to evaluate, and every transitive change lands in
-# the lock where it cannot see it.
+# There was a `dependency-review` job here. It was removed because the
+# dependency graph is disabled for this repository, so the action failed every
+# run. Enabling it is a settings change and is free on a public repo, so this
+# is a decision that can be revisited rather than a dead end.
+#
+# An earlier version of this comment claimed GitHub's graph cannot parse
+# `uv.lock`. That is wrong, and the correction is recorded here because it was
+# the stated reason for deleting the job: the graph does ingest `uv.lock` as a
+# pip manifest, and the compare endpoint the action calls does report added and
+# removed lock entries. The honest argument for leaving the job out is that it
+# would largely duplicate what the audit below already does against the same
+# locked set, not that it could not work.
 #
 # Deliberately NOT implemented here (tracked in #99 / #100): the network-egress
 # canary job, the sdist-diff artifact on bump PRs, and PyPI-vs-tag
@@ -135,7 +141,19 @@ jobs:
           sed -E 's/ ; [^\\]*(\\?)$/ \1/' \
             "${RUNNER_TEMP}/${REQUIREMENTS_FILE}.marked" \
             > "${RUNNER_TEMP}/${REQUIREMENTS_FILE}"
-          echo "Exported $(grep -cE '^[A-Za-z0-9]' "${RUNNER_TEMP}/${REQUIREMENTS_FILE}") pinned requirements."
+          exported=$(grep -cE '^[A-Za-z0-9]' "${RUNNER_TEMP}/${REQUIREMENTS_FILE}" || true)
+          echo "Exported ${exported} pinned requirements."
+          # An empty or truncated export is the one way this job goes green on
+          # zero coverage: pip-audit accepts an empty requirements file, exits
+          # 0, and writes a valid report with no dependencies, which the gate
+          # would read as "no known advisories". grep -c returning 1 on no
+          # matches does not trip errexit inside a command substitution, so
+          # this has to be checked explicitly.
+          if [ "${exported}" -lt 1 ]; then
+            echo "::error::The dependency export produced no requirements."
+            exit 1
+          fi
+          echo "EXPECTED_REQUIREMENTS=${exported}" >> "${GITHUB_ENV}"
 
       - name: pip-audit against OSV
         # OSV carries malicious-package advisories (MAL-* IDs) in addition to
@@ -357,6 +375,26 @@ jobs:
           # malicious package advisories, so it alone backs the hard gate below.
           # Passing because PyPI answered while OSV did not would mean the
           # malicious package check ran with zero coverage and still went green.
+          # Guard against auditing nothing and calling it clean. The count the
+          # export step measured is the only independent witness the gate has
+          # that it was handed the real dependency set.
+          expected_raw = os.environ.get("EXPECTED_REQUIREMENTS", "").strip()
+          if not expected_raw.isdigit():
+              print(
+                  "::error::The export step did not report how many "
+                  "requirements it produced, so the audit cannot be checked "
+                  "against it. Failing closed."
+              )
+              raise SystemExit(1)
+          expected = int(expected_raw)
+          if audited != expected:
+              print(
+                  f"::error::Audited {audited} requirement entries but the "
+                  f"export produced {expected}. Refusing to report on a "
+                  "dependency set that does not match what was locked."
+              )
+              raise SystemExit(1)
+
           if "OSV" not in available:
               print(
                   "::error::No usable OSV report was produced (service "

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -181,6 +181,20 @@ class TestGateCannotSilentlyMissANewWriteTool:
             for method in self.WRITING_CLIENT_METHODS:
                 if f"client.{method}(" in source:
                     mutating.add(name)
+
+            # The two checks above only see a mutation held in an UPPERCASE
+            # module constant or sent through a named client method. gql_call
+            # accepts an arbitrary document, so a mutation written inline, or
+            # held in a lowercase or local name, would slip past both and
+            # register ungated with this test still green.
+            inline_mutation = r"gql\(\s*[\"']{1,3}\s*mutation\b"
+            if re.search(inline_mutation, source, re.I):
+                mutating.add(name)
+            for ident in re.findall(
+                r"graphql_query\s*=\s*([A-Za-z_][A-Za-z0-9_]*)", source
+            ):
+                if self._is_mutation_document(getattr(module, ident, None)):
+                    mutating.add(name)
         return mutating, ro
 
     async def test_every_writing_tool_is_gated(self):


### PR DESCRIPTION
Closes #95, and the tractable halves of #99 and #100. The repo had no CI at all.

## ci.yml
Tests on Python 3.12 and 3.13 via `uv sync --locked`, so CI cannot resolve a different dependency set than the lockfile pins. `uv lock --check` runs as its own job so drift reports separately. That is the check I most wanted: a bump recently changed pyproject without regenerating the lock, leaving the lock pinning the old version with hashes while the manifest asked for a newer one, which silently disabled hash verified installs.

No mypy or black gating. Neither passes cleanly today and a red build on day one is worse than no build.

## supply-chain.yml
pip-audit against both OSV and the PyPI advisory database, on pull requests, pushes to main, and weekly so advisories against untouched dependencies still surface.

The gate is a baseline delta. `.github/audit-baseline.txt` records the 35 advisories currently outstanding, each with its package and fix version. Anything not in that list fails the build. The standing backlog stays quiet, a newly published advisory turns the build red. Malicious package advisories are a separate always fail that a baseline entry cannot silence, though the MAL prefix alone is not sufficient coverage on its own: GitHub reviewed malware is not consistently mirrored into that namespace, so the canonical ctx compromise is a plain GHSA. The delta gate is what catches that.

There is no Dependency Review job. It was removed rather than fixed. The dependency graph is disabled here, and enabling it would not help much: GitHub's graph does not parse `uv.lock`, and requirements.txt and pyproject.toml carry only lower bounds, so there is nothing concrete for it to evaluate while every transitive change lands in the lock.

## Verification
Both workflows green. The audit run reports 78 locked entries audited against both services, 35 findings, all baselined, zero new.

Every action pinned to a full SHA, each re-resolved against its tag. The uv checksum matches the published sha256 for that release byte for byte, and is passed explicitly because setup-uv's built in table stops at uv 0.12.4 while this pins 0.12.10, so without it the binary was fetched unverified. No `${{ }}` in any run block, least privilege permissions, no pull_request_target, no SARIF so the workflow never needs security-events write, and persist-credentials false on every checkout.

Environment markers are stripped before auditing. pip-audit silently skips requirements whose marker is false on the runner without recording them as skipped, so the win32 pins that Windows users install were going unaudited. That is the difference between 75 and 78 entries.

Two rounds of adversarial review were applied. The material finding: audit reports were written into the checked out workspace, and pip-audit does not truncate its output on a fatal error, so a fork PR could commit a clean looking report, force the fatal with a hashless requirement in uv.lock, and the gate would report no advisories. Reproduced, then fixed by writing reports under RUNNER_TEMP.

## Known limits, not addressed here
- Nothing in this PR blocks a merge. main has no required status checks and no rulesets. The check names have to report once before they can be marked required, so that settings change has to follow this merge.
- setuptools and wheel are outside uv.lock entirely and fetched unpinned on every build.
- requirements.txt is a hand maintained parallel manifest that no check validates, and the README points users at it.
- A hand edited uv.lock pointing at an attacker published release with a matching hash passes every check here. That is #100, still open.

## Worth acting on separately
mcp 1.13.1 carries 4 advisories. Constraining to `mcp[cli]>=1.28.1,<2` resolves to 1.29.1 and adds only pyjwt, clearing those 4. It does not clear the starlette or python multipart findings, which stay at 0.47.3 and 0.0.20 respectively. Clearing those needs a broad upgrade that also moves mypy, pytest and starlette across major versions.