### PR TITLE
Rename the generated pin file so Dependabot stops resolving it separately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,23 +69,23 @@ jobs:
       - name: uv lock --check
         run: uv lock --check
 
-      # requirements.txt is generated from uv.lock and is the documented pip
-      # install path. If it drifts, that path silently loses its pins and
+      # requirements-lock.txt is generated from uv.lock and is the documented
+      # pip install path. If it drifts, that path silently loses its pins and
       # hashes while everything else stays locked, which is the one install
       # route with no supply chain guarantee. Regenerate it in the same commit
       # that changes a dependency.
-      - name: requirements.txt matches uv.lock
+      - name: requirements-lock.txt matches uv.lock
         run: |
           uv export --frozen --no-emit-project --no-editable --no-dev \
-            --format requirements-txt -o "${RUNNER_TEMP}/expected.txt"
+            --format requirements-txt --output-file "${RUNNER_TEMP}/expected.txt"
           # Compare only the requirement and hash lines: the committed file
           # carries an explanatory header that the export does not.
           strip() { grep -vE '^\s*#' "$1" | grep -vE '^\s*$'; }
-          if ! diff -u <(strip "${RUNNER_TEMP}/expected.txt") <(strip requirements.txt); then
-            echo "::error::requirements.txt is out of sync with uv.lock. Regenerate it: uv export --frozen --no-emit-project --no-editable --no-dev --format requirements-txt -o requirements.txt"
+          if ! diff -u <(strip "${RUNNER_TEMP}/expected.txt") <(strip requirements-lock.txt); then
+            echo "::error::requirements-lock.txt is out of sync with uv.lock. Regenerate it: uv export --frozen --no-emit-project --no-editable --no-dev --format requirements-txt --output-file requirements-lock.txt"
             exit 1
           fi
-          echo "requirements.txt matches the lock."
+          echo "requirements-lock.txt matches the lock."
 
   test:
     name: Tests (Python ${{ matrix.python-version }})

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -3,8 +3,8 @@
 # This server holds a long-lived credential for the user's real financial
 # accounts, so a compromised or vulnerable dependency is the highest-impact
 # failure mode in the repo. One check lives here: `audit` screens the *locked*
-# dependency set (everything `uv.lock` actually resolves to, not the loose
-# ranges in requirements.txt) against both the PyPI advisory database and OSV,
+# dependency set (everything `uv.lock` actually resolves to) against both the
+# PyPI advisory database and OSV,
 # and fails on anything not already recorded in .github/audit-baseline.txt.
 #
 # There was a `dependency-review` job here. It was removed because the

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ My MonarchMoney referral: https://www.monarchmoney.com/referral/ufmn0r83yf?r_sou
 
    **Using `pip`**:
    ```bash
-   pip install -r requirements.txt --require-hashes
+   pip install -r requirements-lock.txt --require-hashes
    pip install -e . --no-deps
    ```
 
-   `requirements.txt` is generated from `uv.lock` and pins every transitive
+   `requirements-lock.txt` is generated from `uv.lock` and pins every transitive
    dependency with hashes, so `--require-hashes` gives the pip path the same
    guarantee as the uv one. `--no-deps` on the second command stops pip
    re-resolving what the first command just pinned.
@@ -520,7 +520,7 @@ monarch-mcp-server/
 │   └── tools/             # MCP tools grouped by domain (accounts, transactions, budgets, …)
 ├── login_setup.py         # Terminal authentication script
 ├── pyproject.toml         # Project configuration
-├── requirements.txt       # Generated from uv.lock, hash pinned
+├── requirements-lock.txt  # Generated from uv.lock, hash pinned
 └── README.md             # This documentation
 ```
 

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -2,7 +2,14 @@
 #
 # Regenerate with:
 #   uv export --frozen --no-emit-project --no-editable --no-dev \
-#     --format requirements-txt -o requirements.txt
+#     --format requirements-txt --output-file requirements-lock.txt
+#
+# Named requirements-lock.txt rather than requirements.txt on purpose.
+# Dependabot treats a root requirements.txt as an independent pip manifest and
+# resolves it separately from uv.lock. It did exactly that here: one PR
+# carried uv.lock pinning mcp 1.13.1 while requirements.txt said mcp 2.1.1,
+# a major version the lock never took. This file is derived from uv.lock and
+# must never be resolved on its own.
 #
 # CI fails if this drifts from uv.lock, so regenerate it in the same commit
 # that changes a dependency.
@@ -15,7 +22,7 @@
 # no supply chain guarantee at all.
 #
 # Install with hash checking enforced:
-#   pip install -r requirements.txt --require-hashes
+#   pip install -r requirements-lock.txt --require-hashes
 #   pip install -e . --no-deps
 #    uv export --frozen --no-emit-project --no-editable --no-dev --format requirements-txt
 aiohappyeyeballs==2.6.1 \


### PR DESCRIPTION
Follow up to #134, prompted by Dependabot's first run.

Dependabot treats a root `requirements.txt` as an independent pip manifest and resolves it separately from `uv.lock`. #135 is the proof: one pull request carried `uv.lock` pinning mcp 1.13.1 while its `requirements.txt` said mcp 2.1.1, and starlette 0.47.3 against 1.6.0. 37 packages disagreed between two files in the same commit, and the requirements side had jumped a major version the lock never took.

Merging that would have meant `pip install -r requirements.txt` and `uv sync --locked` installing different code, which is the divergence #134 existed to remove.

So the drift check was correct to fail and stays strict. What changes is the filename: `requirements-lock.txt` is derived from the lock and is not a manifest anything should resolve on its own. Same contents, same hashes, same 59 runtime pins.

The file header now records why the name matters, so it does not get renamed back.

Verified the drift check still catches an edited pin under the new name, and the suite is at 379.