### PR TITLE
Keep requirements.txt working as a compatibility shim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,22 @@ jobs:
           fi
           echo "requirements-lock.txt matches the lock."
 
+          # requirements.txt is a compatibility shim that must stay inert. If
+          # anything ever resolves it as a manifest and writes pins into it,
+          # the pip install path silently stops matching uv.lock again, which
+          # is the failure this whole arrangement exists to prevent.
+          # Captured rather than piped into `grep -q`: under pipefail, -q exits
+          # early, the upstream grep takes SIGPIPE, and the pipeline reports
+          # 141 instead of 0, so the check would never fire.
+          stray=$(grep -vE '^\s*(#|$)' requirements.txt \
+            | grep -vxF -- '-r requirements-lock.txt' || true)
+          if [ -n "${stray}" ]; then
+            echo "::error::requirements.txt must contain nothing but the include of requirements-lock.txt. Something wrote version specifiers into it:"
+            printf '%s\n' "${stray}"
+            exit 1
+          fi
+          echo "requirements.txt is still an inert shim."
+
   test:
     name: Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ My MonarchMoney referral: https://www.monarchmoney.com/referral/ufmn0r83yf?r_sou
    guarantee as the uv one. `--no-deps` on the second command stops pip
    re-resolving what the first command just pinned.
 
+   `pip install -r requirements.txt` still works and installs exactly the same
+   set. That file is now a one line include of `requirements-lock.txt`, kept so
+   existing setups and scripts do not break. The pins moved out of it because a
+   root `requirements.txt` gets resolved as an independent manifest, which had
+   started producing a pinned set that disagreed with `uv.lock`.
+
 3. **Configure Claude Desktop**:
    Add this to your Claude Desktop configuration file:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+# Compatibility shim. The real pinned set lives in requirements-lock.txt.
+#
+# This file exists so the long documented command still works:
+#   pip install -r requirements.txt --require-hashes
+#
+# It deliberately holds no version specifiers of its own. requirements.txt at
+# the repo root is treated by Dependabot as an independent pip manifest and
+# resolved separately from uv.lock, which produced a pull request pinning
+# mcp 1.13.1 in uv.lock and mcp 2.1.1 here in the same commit. With nothing
+# to resolve, there is nothing for that to get wrong, and CI fails if any
+# specifier appears below.
+#
+# Add or change dependencies in pyproject.toml, then regenerate the lock file.
+-r requirements-lock.txt


### PR DESCRIPTION
Follow up to #136. Renaming the pinned file broke anyone whose setup runs `pip install -r requirements.txt`, which the README documented as the primary install path for a long time. That was an avoidable break for existing users.

`requirements.txt` is back as a one line include of `requirements-lock.txt`, so the old command installs exactly the same pinned, hash verified set. Verified pip resolves through the include under `--require-hashes` to the identical resolution.

It holds no version specifiers of its own, which is the point: a root `requirements.txt` gets treated as an independent pip manifest and resolved separately from `uv.lock`, which is what produced #135 pinning mcp 1.13.1 in the lock and 2.1.1 in the requirements file within one commit. With nothing to resolve, there is nothing to get wrong.

CI now also fails if any specifier appears in the shim, so if something does start writing pins into it we find out immediately rather than through a silent divergence. Verified the guard fires on an injected pin under both zsh and bash with pipefail.