### PR TITLE
get_accounts: expose sync status and last-updated time

### DIFF
--- a/src/monarch_mcp_server/tools/accounts.py
+++ b/src/monarch_mcp_server/tools/accounts.py
@@ -28,9 +28,50 @@ class BalanceCorrections(RootModel[Dict[date, Decimal]]):
     """
 
 
+def _sync_status(account: dict) -> dict:
+    """Summarise an account's institution-connection state.
+
+    When a bank link breaks, the account keeps its last balance and stops
+    importing; the API does not raise an error for it. The GetAccounts query
+    already returns the credential metadata that reveals this, so surface it
+    in the listing rather than requiring a second call. For a per-connection
+    view with staleness thresholds, see ``get_account_sync_health``.
+    """
+    credential = account.get("credential") or {}
+    needs_reauth = bool(credential.get("updateRequired"))
+    disconnected_at = credential.get("disconnectedFromDataProviderAt")
+    sync_disabled = bool(account.get("syncDisabled"))
+    if account.get("isManual"):
+        state = "manual"
+    elif needs_reauth:
+        state = "needs_reauth"
+    elif disconnected_at:
+        state = "disconnected"
+    elif sync_disabled:
+        state = "sync_disabled"
+    else:
+        state = "ok"
+    return {
+        "state": state,
+        "needs_reauth": needs_reauth,
+        "disconnected_at": disconnected_at,
+        "sync_disabled": sync_disabled,
+        "data_provider": credential.get("dataProvider") or account.get("dataProvider"),
+    }
+
+
 @mcp.tool()
 async def get_accounts() -> str:
-    """Get all financial accounts from Monarch Money."""
+    """Get all financial accounts from Monarch Money.
+
+    Each account includes ``last_updated_at`` (Monarch's last successful sync
+    for the account) and a ``sync`` block whose ``state`` is one of ``ok``,
+    ``needs_reauth``, ``disconnected``, ``sync_disabled`` or ``manual``. A
+    broken link does not error: balances freeze and transactions stop
+    arriving, so check ``sync.state`` before trusting a stale-looking account.
+    ``get_account_sync_health`` gives the same information per institution
+    connection, with staleness thresholds.
+    """
     try:
         client = await get_monarch_client()
         accounts = await client.get_accounts()
@@ -50,6 +91,9 @@ async def get_accounts() -> str:
                 if "isActive" in account
                 else not account.get("deactivatedAt"),
                 "is_hidden": account.get("isHidden", False),
+                "is_manual": account.get("isManual", False),
+                "last_updated_at": account.get("displayLastUpdatedAt"),
+                "sync": _sync_status(account),
             }
             account_list.append(account_info)
 

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -59,6 +59,63 @@ class TestGetAccounts:
         result = json.loads(await get_accounts())
         assert result[0]["owned_by_user"] is None
 
+    async def test_sync_status_ok_by_default(self):
+        result = json.loads(await get_accounts())
+        assert result[0]["sync"]["state"] == "ok"
+        assert result[0]["sync"]["needs_reauth"] is False
+        assert result[0]["sync"]["disconnected_at"] is None
+        assert result[0]["is_manual"] is False
+        assert result[0]["last_updated_at"] is None
+
+    async def test_sync_status_surfaces_broken_connection(self, mock_monarch_client):
+        """A frozen bank link is silent in Monarch; get_accounts must say so."""
+        mock_monarch_client.get_accounts.return_value = {
+            "accounts": [
+                {
+                    "id": "acc-reauth",
+                    "displayName": "Needs Login",
+                    "displayLastUpdatedAt": "2026-02-08T04:00:00+00:00",
+                    "credential": {"updateRequired": True, "dataProvider": "PLAID"},
+                },
+                {
+                    "id": "acc-disc",
+                    "displayName": "Dropped",
+                    "credential": {
+                        "updateRequired": False,
+                        "disconnectedFromDataProviderAt": "2026-03-01T00:00:00+00:00",
+                        "dataProvider": "FINICITY",
+                    },
+                },
+                {
+                    "id": "acc-paused",
+                    "displayName": "Paused",
+                    "syncDisabled": True,
+                    "credential": {"updateRequired": False},
+                },
+                {
+                    "id": "acc-manual",
+                    "displayName": "House",
+                    "isManual": True,
+                    "credential": None,
+                },
+            ]
+        }
+        result = {a["id"]: a for a in json.loads(await get_accounts())}
+
+        assert result["acc-reauth"]["sync"]["state"] == "needs_reauth"
+        assert result["acc-reauth"]["sync"]["needs_reauth"] is True
+        assert result["acc-reauth"]["sync"]["data_provider"] == "PLAID"
+        assert result["acc-reauth"]["last_updated_at"] == "2026-02-08T04:00:00+00:00"
+
+        assert result["acc-disc"]["sync"]["state"] == "disconnected"
+        assert result["acc-disc"]["sync"]["disconnected_at"] == "2026-03-01T00:00:00+00:00"
+
+        assert result["acc-paused"]["sync"]["state"] == "sync_disabled"
+        assert result["acc-paused"]["sync"]["sync_disabled"] is True
+
+        assert result["acc-manual"]["sync"]["state"] == "manual"
+        assert result["acc-manual"]["is_manual"] is True
+
     async def test_handles_empty_accounts(self, mock_monarch_client):
         mock_monarch_client.get_accounts.return_value = {"accounts": []}
         result = json.loads(await get_accounts())


### PR DESCRIPTION
When an institution link breaks, the account keeps its last balance and stops importing transactions; the API raises no error for it. The GetAccounts query already returns the credential metadata that reveals this (updateRequired, disconnectedFromDataProviderAt, syncDisabled, displayLastUpdatedAt), but get_accounts dropped it, so the basic listing could not distinguish a healthy account from one frozen for a year without a second call to get_account_sync_health.

Add last_updated_at, is_manual and a sync block with a single state (ok / needs_reauth / disconnected / sync_disabled / manual) plus the raw fields. get_account_sync_health remains the per-connection view with staleness thresholds; this makes the listing itself trustworthy.