### PR TITLE
Add household member lookup and transaction owner updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,10 +358,15 @@ live tool registry and the functions' signatures, so it does not drift.
 | `update_category` | Update an existing category's settings | `category_id`, `name`?, `icon`?, `group_id`?, `category_type`?, `exclude_from_budget`?, `budget_variability`?, `rollover_enabled`?, `rollover_start_month`?, `rollover_starting_balance`?, `rollover_frequency`?, `rollover_target_amount`?, `rollover_type`?, `confirm_rollover_reset`?, `dry_run`? |
 | `update_merchant` | Update a merchant's name and/or recurring transaction stream settings | `merchant_id`, `name`?, `is_recurring`?, `frequency`?, `base_date`?, `amount`?, `is_active`? |
 | `update_savings_goal` | Update a savings goal's target or monthly contribution | `goal_id`, `target_amount`?, `target_date`?, `name`?, `priority`?, `goal_type`?, `is_sinking_fund`? |
-| `update_transaction` | Update an existing transaction in Monarch Money | `transaction_id`, `category_id`?, `merchant_name`?, `goal_id`?, `amount`?, `date`?, `hide_from_reports`?, `needs_review`?, `notes`? |
+| `update_transaction` | Update an existing transaction in Monarch Money | `transaction_id`, `category_id`?, `merchant_name`?, `goal_id`?, `amount`?, `date`?, `hide_from_reports`?, `needs_review`?, `notes`?, `owner_user_id`? |
 | `update_transaction_notes` | Update the notes/memo for a transaction | `transaction_id`, `notes`, `receipt_url`? |
 | `update_transaction_rule` | Update an existing transaction rule | `rule_id`, `merchant_criteria_operator`?, `merchant_criteria_value`?, `merchant_criteria_values`?, `merchant_criteria`?, `original_statement_operator`?, `original_statement_values`?, `original_statement_criteria`?, `use_original_statement`?, `amount_operator`?, `amount_value`?, `amount_lower`?, `amount_upper`?, `amount_is_expense`?, `set_category_id`?, `set_merchant_name`?, `add_tag_ids`?, `link_goal_id`?, `hide_from_reports`?, `review_status`?, `account_ids`?, `category_ids`?, `clear_category`?, `clear_merchant`?, `clear_tags`?, `clear_goal_link`?, `clear_review_status`?, `apply_to_existing`? |
 | `upload_account_balance_history` | Upload corrected balance snapshots for an account | `account_id`, `corrections`, `dry_run`? |
+
+`get_household_members` returns members in `myHousehold.users`. Pass a member's
+`id` to `update_transaction(owner_user_id=...)` to assign ownership, or pass
+`owner_user_id=""` to set Shared ownership. Omitting the parameter or passing
+`null` leaves the existing owner unchanged. Pending invitations are not included.
 
 ## 📝 Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Once authenticated, use these tools directly in Claude Desktop or Claude Code:
 
 ## 🛠️ Available Tools
 
-All 58 registered tools. Required parameters are listed first, optional ones
+All 59 registered tools. Required parameters are listed first, optional ones
 are marked with a trailing question mark. This table is generated from the
 live tool registry and the functions' signatures, so it does not drift.
 
@@ -325,6 +325,7 @@ live tool registry and the functions' signatures, so it does not drift.
 | `get_debt_paydown` | Get the debt paydown plan and the accounts feeding it | `method`? |
 | `get_goal_contributions` | Show a goal's budgeted contributions, broken down by funding account | `goal_id`, `month`? |
 | `get_goals` | List Monarch savings and debt-paydown goals | None |
+| `get_household_members` | Get household member IDs, names, display names, and roles | None |
 | `get_merchant` | Get a merchant's details including recurring transaction stream configuration | `merchant_id` |
 | `get_net_worth` | Get net worth history over time | `start_date`?, `end_date`?, `account_type`? |
 | `get_net_worth_by_account_type` | Get net worth breakdown by account type over time | `start_date`, `timeframe`? |
@@ -563,7 +564,7 @@ tool that is not there.
 }
 ```
 
-This leaves 30 of the 58 tools available, covering everything that reads.
+This leaves 31 of the 59 tools available, covering everything that reads.
 Read only is off by default, so existing setups are unaffected. Note that it
 also removes the login and logout tools, since those change durable state, so
 authenticate with `login_setup.py` before enabling it.

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -20,6 +20,7 @@ from monarch_mcp_server.tools.auth import (  # noqa: F401
     monarch_logout,
 )
 from monarch_mcp_server.tools.identity import (  # noqa: F401
+    get_household_members,
     monarch_whoami,
 )
 from monarch_mcp_server.tools.accounts import (  # noqa: F401

--- a/src/monarch_mcp_server/tools/identity.py
+++ b/src/monarch_mcp_server/tools/identity.py
@@ -177,3 +177,19 @@ async def monarch_whoami() -> str:
         })
     except Exception as e:
         return json_error("monarch_whoami", e)
+
+
+@mcp.tool()
+async def get_household_members() -> str:
+    """
+    Get household member IDs, names, display names, and roles.
+
+    Returns JSON with members in myHousehold.users. Use a member's id as
+    owner_user_id in update_transaction(). Pending invitations are not included.
+    """
+    try:
+        client = await get_monarch_client()
+        result = await client.get_household_members()
+        return json_success(result)
+    except Exception as e:
+        return json_error("get_household_members", e)

--- a/src/monarch_mcp_server/tools/transactions.py
+++ b/src/monarch_mcp_server/tools/transactions.py
@@ -682,6 +682,7 @@ async def update_transaction(
     hide_from_reports: Optional[bool] = None,
     needs_review: Optional[bool] = None,
     notes: Optional[str] = None,
+    owner_user_id: Optional[str] = None,
 ) -> str:
     """
     Update an existing transaction in Monarch Money.
@@ -696,6 +697,8 @@ async def update_transaction(
         hide_from_reports: Whether to hide this transaction from reports
         needs_review: Whether this transaction needs review
         notes: Notes for the transaction
+        owner_user_id: Member ID from get_household_members(), or "" for Shared.
+            Omitted or None leaves ownership unchanged.
     """
     try:
         client = await get_monarch_client()
@@ -718,6 +721,8 @@ async def update_transaction(
             update_data["needs_review"] = needs_review
         if notes is not None:
             update_data["notes"] = notes
+        if owner_user_id is not None:
+            update_data["owner_user_id"] = owner_user_id
 
         result = await client.update_transaction(**update_data)
         errors = payload_errors(result, "updateTransaction")

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -3,7 +3,7 @@
 import json
 from unittest.mock import AsyncMock, patch
 
-from monarch_mcp_server.tools.identity import monarch_whoami
+from monarch_mcp_server.tools.identity import get_household_members, monarch_whoami
 
 
 def _payload(**sub_overrides):
@@ -124,3 +124,45 @@ class TestMonarchWhoami:
 
         assert data["error"] is True
         assert data["tool"] == "monarch_whoami"
+
+
+class TestGetHouseholdMembers:
+    """Tests for get_household_members tool."""
+
+    @patch('monarch_mcp_server.tools.identity.get_monarch_client')
+    async def test_returns_members(self, mock_get_client):
+        users = [
+            {"id": "u1", "name": "Alex", "displayName": "Alex", "householdRole": "OWNER"},
+            {"id": "u2", "name": "Sam", "displayName": "Sam", "householdRole": "MEMBER"},
+        ]
+        client = AsyncMock()
+        client.get_household_members.return_value = {"myHousehold": {"users": users}}
+        mock_get_client.return_value = client
+
+        data = json.loads(await get_household_members())
+
+        assert data == {"myHousehold": {"users": users}}
+        client.get_household_members.assert_awaited_once_with()
+
+    @patch('monarch_mcp_server.tools.identity.get_monarch_client')
+    async def test_returns_empty_members(self, mock_get_client):
+        client = AsyncMock()
+        client.get_household_members.return_value = {"myHousehold": {"users": []}}
+        mock_get_client.return_value = client
+
+        data = json.loads(await get_household_members())
+
+        assert data == {"myHousehold": {"users": []}}
+        client.get_household_members.assert_awaited_once_with()
+
+    @patch('monarch_mcp_server.tools.identity.get_monarch_client')
+    async def test_error_handling(self, mock_get_client):
+        client = AsyncMock()
+        client.get_household_members.side_effect = Exception("Request failed")
+        mock_get_client.return_value = client
+
+        data = json.loads(await get_household_members())
+
+        assert data["error"] is True
+        assert data["tool"] == "get_household_members"
+        assert data["message"] == "Request failed"

--- a/tests/test_library_contract.py
+++ b/tests/test_library_contract.py
@@ -1,0 +1,40 @@
+"""Check the installed library, which conftest replaces with a mock in-process."""
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_installed_library_supports_transaction_ownership():
+    # A fresh interpreter bypasses conftest's sys.modules mocks. Importing and
+    # inspecting the class needs neither credentials nor a network request.
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                """
+                import inspect
+                from monarchmoney import MonarchMoney
+
+                lookup = getattr(MonarchMoney, "get_household_members", None)
+                assert inspect.iscoroutinefunction(lookup), (
+                    "Installed monarchmoneycommunity lacks get_household_members; "
+                    "update the dependency and both lockfiles to a release containing PR #80"
+                )
+                inspect.signature(lookup).bind(None)
+                update = inspect.signature(MonarchMoney.update_transaction)
+                assert "owner_user_id" in update.parameters, (
+                    "Installed monarchmoneycommunity lacks update_transaction(owner_user_id)"
+                )
+                assert update.parameters["owner_user_id"].default is None
+                for owner in ("member-id", "", None):
+                    update.bind(None, "transaction-id", owner_user_id=owner)
+            """
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -948,6 +948,38 @@ class TestUpdateTransaction:
             transaction_id="txn-1", amount=99.99, notes="Updated"
         )
 
+    @pytest.mark.parametrize("owner_user_id", ["user-1", ""])
+    async def test_passes_owner(self, mock_monarch_client, owner_user_id):
+        result = json.loads(
+            await update_transaction("txn-1", owner_user_id=owner_user_id)
+        )
+        assert result == {"updateTransaction": {"transaction": {"id": "txn-1"}}}
+        mock_monarch_client.update_transaction.assert_awaited_once_with(
+            transaction_id="txn-1", owner_user_id=owner_user_id
+        )
+
+    async def test_none_preserves_owner(self, mock_monarch_client):
+        await update_transaction("txn-1", category_id="cat-1", owner_user_id=None)
+        mock_monarch_client.update_transaction.assert_called_once_with(
+            transaction_id="txn-1", category_id="cat-1"
+        )
+
+    @pytest.mark.parametrize("owner_user_id", ["unknown-user", ""])
+    async def test_owner_rejection_is_not_success(
+        self, mock_monarch_client, owner_user_id
+    ):
+        mock_monarch_client.update_transaction.return_value = {
+            "updateTransaction": {
+                "transaction": None,
+                "errors": {"message": "Owner update rejected", "code": "INVALID"},
+            }
+        }
+        result = json.loads(
+            await update_transaction("txn-1", owner_user_id=owner_user_id)
+        )
+        assert result["success"] is False
+        assert "Owner update rejected" in json.dumps(result)
+
     async def test_passes_all_fields(self, mock_monarch_client):
         await update_transaction(
             "txn-1",
@@ -959,6 +991,7 @@ class TestUpdateTransaction:
             hide_from_reports=True,
             needs_review=False,
             notes="All fields",
+            owner_user_id="user-1",
         )
         mock_monarch_client.update_transaction.assert_called_once_with(
             transaction_id="txn-1",
@@ -970,6 +1003,7 @@ class TestUpdateTransaction:
             hide_from_reports=True,
             needs_review=False,
             notes="All fields",
+            owner_user_id="user-1",
         )
 
     async def test_handles_api_error(self, mock_monarch_client):


### PR DESCRIPTION
## Summary

Adds household member lookup and transaction ownership updates. A client can list the members of a household, assign a transaction to a member or set it to Shared without leaving the MCP server.

The two commits add:

1. `get_household_members()`, returning member IDs, names, display names and roles in `myHousehold.users`. Pending invitations are excluded.
2. An optional `owner_user_id` parameter on `update_transaction()`. A member ID assigns ownership, `""` sets Shared ownership, and omitted or `None` leaves the current owner unchanged.

## Library dependency

Requires [bradleyseanf/monarchmoneycommunity#80](https://github.com/bradleyseanf/monarchmoneycommunity/pull/80), which merged into `dev` as `c2f91f14f3d962d36275cb934dd3594b8aa1dcad`. That change adds `MonarchMoney.get_household_members()` and the `owner_user_id` argument to `MonarchMoney.update_transaction()`.

This PR is a draft pending a PyPI release containing those changes. The latest published version is still 1.5.2, and both lockfiles still pin it. Before this is ready to merge, I will raise the minimum version in `pyproject.toml`, update `uv.lock` and regenerate `requirements-lock.txt` using the published release.

The new installed-library compatibility test currently fails against 1.5.2. It runs in a separate interpreter because the existing test fixtures mock the library and would otherwise hide the missing APIs.

## Design notes

- The parameter is appended to preserve existing positional calls. The `is not None` guard forwards the empty string needed for Shared ownership.
- Ownership writes reuse the existing transaction error handling and read-only registration guard. Household member lookup is read-only.
- The new tool is re-exported from `server.py`. README parameters, alphabetical ordering and tool counts are updated.

## Testing

- With the exact merged library source above: **390 tests passed on Python 3.12 and 3.13**. The source was supplied through `PYTHONPATH`; the committed dependency locks were unchanged.
- With the locked PyPI 1.5.2 installation: **389 passed, 1 failed**, the installed-library compatibility check described above.
- Verified the real MCP-to-library path with GraphQL transport mocked: member lookup, owner assignment, Shared ownership, explicit `None` and omission.
- Added coverage for rejected ownership writes so they cannot be reported as successful.
- Verified 59 registered tools and 31 available in read-only mode. Lockfile consistency and `git diff --check` passed.

No live Monarch API calls or ownership writes were made during MCP validation.
