### PR TITLE
feat: add Docker hosting with Streamable HTTP transport

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Send only the files needed to build the application, excluding local credentials.
+*
+!Dockerfile
+!uv.lock
+!pyproject.toml
+!README.md
+!LICENSE
+!login_setup.py
+!src/
+!src/**
+**/__pycache__
+**/*.py[cod]
+**/*.egg-info
+**/.env*
+**/*.pickle
+**/*.session
+**/.monarch-mcp-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Keep the uv version aligned with .github/workflows/ci.yml.
+FROM ghcr.io/astral-sh/uv:0.12.10-python3.12-trixie-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_NO_CACHE=1 \
+    UV_PYTHON_DOWNLOADS=0 \
+    MONARCH_MCP_TRANSPORT=streamable-http \
+    MONARCH_MCP_HOST=0.0.0.0 \
+    PATH="/app/.venv/bin:$PATH"
+
+WORKDIR /app
+
+# Install locked runtime dependencies separately so source changes reuse this layer.
+COPY pyproject.toml uv.lock ./
+RUN uv sync --locked --no-dev --no-install-project
+
+COPY README.md LICENSE ./
+COPY src/ ./src/
+RUN uv sync --locked --no-dev --no-editable
+
+COPY login_setup.py ./
+
+# Session credentials live in this user's home and can be persisted with a volume.
+RUN useradd --create-home --uid 10001 app \
+    && mkdir /home/app/.monarch-mcp-server \
+    && chown app:app /home/app/.monarch-mcp-server
+USER app
+
+EXPOSE 8000
+CMD ["monarch-mcp-server"]

--- a/README.md
+++ b/README.md
@@ -149,6 +149,88 @@ My MonarchMoney referral: https://www.monarchmoney.com/referral/ufmn0r83yf?r_sou
 
 4. **Restart Claude Code**
 
+### HTTP transport and Docker
+
+The server supports MCP Streamable HTTP at `/mcp`. Local launches still default
+to STDIO; select HTTP explicitly:
+
+```bash
+uv run --locked monarch-mcp-server --transport http --host 127.0.0.1 --port 8000
+```
+
+Connect an MCP client using Streamable HTTP to `http://127.0.0.1:8000/mcp`.
+This is an MCP endpoint, not a REST API or a browser page.
+
+The Docker image uses Astral's uv/Python 3.12 slim base, installs from `uv.lock`,
+and defaults to HTTP on `0.0.0.0:8000` inside the container. Build the image and
+authenticate using a persistent session volume:
+
+```bash
+docker build -t monarch-mcp-server .
+
+docker run --rm -it \
+  -v monarch-session:/home/app/.monarch-mcp-server \
+  monarch-mcp-server python login_setup.py
+
+docker run -d --name monarch-mcp --restart unless-stopped \
+  -p 127.0.0.1:8000:8000 \
+  -v monarch-session:/home/app/.monarch-mcp-server \
+  monarch-mcp-server
+```
+
+The login script supports a cookie file for browser-cookie authentication. To
+use it, also mount your cookie file at `/tmp/monarch-cookie.txt:ro` and set
+`MONARCH_MCP_COOKIE_FILE=/tmp/monarch-cookie.txt` for the login container. The
+file must be readable by the container's UID 10001. Once saved, the session
+volume is sufficient for normal server launches.
+
+To connect from another machine, put the container behind an authenticated
+HTTPS reverse proxy or a private network with access controls, publish the port
+on the appropriate interface, and allow the hostname used by the client:
+
+```bash
+docker run -d --name monarch-mcp --restart unless-stopped \
+  -p 127.0.0.1:8000:8000 \
+  -e MONARCH_MCP_ALLOWED_HOSTS=mcp.example.com \
+  -v monarch-session:/home/app/.monarch-mcp-server \
+  monarch-mcp-server
+```
+
+Here a reverse proxy on the Docker host forwards `https://mcp.example.com/mcp`
+to `http://127.0.0.1:8000/mcp`, preserving the public Host header. It must support
+streaming responses without buffering. For direct access on a private network,
+allow the client's Host value including the port, such as `server.lan:8000`.
+
+**This is a single-account server:** all connected clients share the same saved
+Monarch session and permissions, including enabled write tools. HTTP does not
+add client authentication or per-user account isolation. Host/origin checks
+protect against DNS rebinding; they do not authenticate callers. Use one server
+and session volume per Monarch account. Run one process/replica per endpoint:
+HTTP sessions are held in memory, and clients reconnect after a restart.
+
+| Setting | CLI flag | Environment variable | Default outside Docker |
+| --- | --- | --- | --- |
+| Transport | `--transport` | `MONARCH_MCP_TRANSPORT` | `stdio` (`http` aliases `streamable-http`) |
+| Listen address | `--host` | `MONARCH_MCP_HOST` | `127.0.0.1` |
+| Listen port | `--port` | `MONARCH_MCP_PORT` | `8000` |
+| Additional allowed Host headers | `--allowed-host` (repeatable) | `MONARCH_MCP_ALLOWED_HOSTS` (comma-separated) | None; loopback hosts are always allowed |
+| Additional allowed browser Origins | `--allowed-origin` (repeatable) | `MONARCH_MCP_ALLOWED_ORIGINS` (comma-separated) | None; HTTP loopback origins are always allowed |
+
+CLI flags override their environment settings. Host entries include the port
+when clients send one; `server.lan:*` allows any port. Origin entries include
+the scheme, for example `https://client.example.com`. Clients without an Origin
+header are supported. Browser clients may additionally require CORS handling
+at the reverse proxy.
+
+To run the Docker image over STDIO instead:
+
+```bash
+docker run --rm -i \
+  -e MONARCH_MCP_TRANSPORT=stdio \
+  -v monarch-session:/home/app/.monarch-mcp-server \
+  monarch-mcp-server
+```
+
 ### 2. One-Time Authentication Setup
 
 **Important**: For security and MFA support, authentication is done outside of Claude.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ My MonarchMoney referral: https://www.monarchmoney.com/referral/ufmn0r83yf?r_sou
 
 ## 🚀 Quick Start
 
-### 1. Installation
+If you plan to use this MCP server locally / on the same computer as Claude Desktop or similar, start with the [`Local Installation` section](#1-local-installation).
+
+For other deployment scenarios - like containerized deployment or cloud hosting - start with the [`Containerized Deployment` section](#containerized-deployment).
+
+### 1. Local Installation
 
 1. **Clone this repository**:
    ```bash
@@ -149,88 +153,6 @@ My MonarchMoney referral: https://www.monarchmoney.com/referral/ufmn0r83yf?r_sou
 
 4. **Restart Claude Code**
 
-### HTTP transport and Docker
-
-The server supports MCP Streamable HTTP at `/mcp`. Local launches still default
-to STDIO; select HTTP explicitly:
-
-```bash
-uv run --locked monarch-mcp-server --transport http --host 127.0.0.1 --port 8000
-```
-
-Connect an MCP client using Streamable HTTP to `http://127.0.0.1:8000/mcp`.
-This is an MCP endpoint, not a REST API or a browser page.
-
-The Docker image uses Astral's uv/Python 3.12 slim base, installs from `uv.lock`,
-and defaults to HTTP on `0.0.0.0:8000` inside the container. Build the image and
-authenticate using a persistent session volume:
-
-```bash
-docker build -t monarch-mcp-server .
-
-docker run --rm -it \
-  -v monarch-session:/home/app/.monarch-mcp-server \
-  monarch-mcp-server python login_setup.py
-
-docker run -d --name monarch-mcp --restart unless-stopped \
-  -p 127.0.0.1:8000:8000 \
-  -v monarch-session:/home/app/.monarch-mcp-server \
-  monarch-mcp-server
-```
-
-The login script supports a cookie file for browser-cookie authentication. To
-use it, also mount your cookie file at `/tmp/monarch-cookie.txt:ro` and set
-`MONARCH_MCP_COOKIE_FILE=/tmp/monarch-cookie.txt` for the login container. The
-file must be readable by the container's UID 10001. Once saved, the session
-volume is sufficient for normal server launches.
-
-To connect from another machine, put the container behind an authenticated
-HTTPS reverse proxy or a private network with access controls, publish the port
-on the appropriate interface, and allow the hostname used by the client:
-
-```bash
-docker run -d --name monarch-mcp --restart unless-stopped \
-  -p 127.0.0.1:8000:8000 \
-  -e MONARCH_MCP_ALLOWED_HOSTS=mcp.example.com \
-  -v monarch-session:/home/app/.monarch-mcp-server \
-  monarch-mcp-server
-```
-
-Here a reverse proxy on the Docker host forwards `https://mcp.example.com/mcp`
-to `http://127.0.0.1:8000/mcp`, preserving the public Host header. It must support
-streaming responses without buffering. For direct access on a private network,
-allow the client's Host value including the port, such as `server.lan:8000`.
-
-**This is a single-account server:** all connected clients share the same saved
-Monarch session and permissions, including enabled write tools. HTTP does not
-add client authentication or per-user account isolation. Host/origin checks
-protect against DNS rebinding; they do not authenticate callers. Use one server
-and session volume per Monarch account. Run one process/replica per endpoint:
-HTTP sessions are held in memory, and clients reconnect after a restart.
-
-| Setting | CLI flag | Environment variable | Default outside Docker |
-| --- | --- | --- | --- |
-| Transport | `--transport` | `MONARCH_MCP_TRANSPORT` | `stdio` (`http` aliases `streamable-http`) |
-| Listen address | `--host` | `MONARCH_MCP_HOST` | `127.0.0.1` |
-| Listen port | `--port` | `MONARCH_MCP_PORT` | `8000` |
-| Additional allowed Host headers | `--allowed-host` (repeatable) | `MONARCH_MCP_ALLOWED_HOSTS` (comma-separated) | None; loopback hosts are always allowed |
-| Additional allowed browser Origins | `--allowed-origin` (repeatable) | `MONARCH_MCP_ALLOWED_ORIGINS` (comma-separated) | None; HTTP loopback origins are always allowed |
-
-CLI flags override their environment settings. Host entries include the port
-when clients send one; `server.lan:*` allows any port. Origin entries include
-the scheme, for example `https://client.example.com`. Clients without an Origin
-header are supported. Browser clients may additionally require CORS handling
-at the reverse proxy.
-
-To run the Docker image over STDIO instead:
-
-```bash
-docker run --rm -i \
-  -e MONARCH_MCP_TRANSPORT=stdio \
-  -v monarch-session:/home/app/.monarch-mcp-server \
-  monarch-mcp-server
-```
-
 ### 2. One-Time Authentication Setup
 
 **Important**: For security and MFA support, authentication is done outside of Claude.
@@ -299,10 +221,113 @@ Kept for users with an existing token captured before the May 2026 API change. M
 ### 3. Start Using
 
 Once authenticated, use these tools directly in Claude Desktop or Claude Code:
+
 - `get_accounts` - View all your financial accounts
 - `get_transactions` - Recent transactions with filtering
 - `get_budgets` - Budget information and spending
 - `get_cashflow` - Income/expense analysis
+
+## Containerized Deployment
+
+The Docker image uses Astral's uv/Python 3.12 slim base, installs from `uv.lock`,
+and defaults to HTTP on `0.0.0.0:8000` inside the container.
+
+### Build the image
+
+```bash
+docker build -t monarch-mcp-server .
+```
+
+### Authenticate
+
+Authenticate once using a persistent session volume:
+
+```bash
+docker run --rm -it \
+  -v monarch-session:/home/app/.monarch-mcp-server \
+  monarch-mcp-server python login_setup.py
+```
+
+The login script supports a cookie file for browser-cookie authentication.
+To use it, also mount your cookie file at `/tmp/monarch-cookie.txt:ro` and set `MONARCH_MCP_COOKIE_FILE=/tmp/monarch-cookie.txt` for the login container.
+
+The file must be readable by the container's UID: `10001`.
+Once saved, the session volume is sufficient for normal server launches.
+
+### Start the HTTP server
+
+Reuse the session volume when starting the server:
+
+```bash
+$ docker run -d --name monarch-mcp --restart unless-stopped \
+  -p 127.0.0.1:8000:8000 \
+  -v monarch-session:/home/app/.monarch-mcp-server \
+  monarch-mcp-server
+```
+
+Connect your MCP client to `http://127.0.0.1:8000/mcp` using Streamable HTTP.
+See [HTTP transport configuration](#http-transport-configuration) for all settings.
+
+### Connect from another machine
+
+> [!WARNING]
+> This MCP server is not multi-user or multi-account. All connected clients share the same session and permissions.
+> Ensure that you understand the security implications before exposing the server to a network.
+
+To connect from another machine, **put the container behind an authenticated HTTPS reverse proxy or a private network with access controls**, publish the port on the appropriate interface, and allow the hostname used by the client:
+
+```bash
+docker run -d --name monarch-mcp --restart unless-stopped \
+  -p 127.0.0.1:8000:8000 \
+  -e MONARCH_MCP_ALLOWED_HOSTS=mcp.example.com \
+  -v monarch-session:/home/app/.monarch-mcp-server \
+  monarch-mcp-server
+```
+
+Here a reverse proxy on the Docker host forwards `https://mcp.example.com/mcp` to `http://127.0.0.1:8000/mcp`, preserving the public Host header.
+
+The proxy must support streaming responses without buffering.
+For direct access on a private network, allow the client's Host value including the port, such as `server.lan:8000`.
+
+Let me stress this point: **This is a single-account server!**
+All connected clients share the *same* saved Monarch session and permissions, including enabled write tools.
+Basic Host/origin checks protect against DNS rebinding; they do not authenticate callers.
+Use one server and session volume per Monarch account if you need to.
+
+### Use STDIO instead
+
+To run the Docker image over STDIO instead:
+
+```bash
+docker run --rm -i \
+  -e MONARCH_MCP_TRANSPORT=stdio \
+  -v monarch-session:/home/app/.monarch-mcp-server \
+  monarch-mcp-server
+```
+
+## HTTP Transport Configuration
+
+The server supports MCP Streamable HTTP at `/mcp` but only when explicitly selected:
+
+```bash
+uv run --locked monarch-mcp-server --transport http --host 127.0.0.1 --port 8000
+```
+
+Connect an MCP client using Streamable HTTP to `http://127.0.0.1:8000/mcp`.
+
+| Setting                            | CLI flag                        | Environment variable                            | Default outside Docker                         |
+| ---------------------------------- | ------------------------------- | ----------------------------------------------- | ---------------------------------------------- |
+| Transport                          | `--transport`                   | `MONARCH_MCP_TRANSPORT`                         | `stdio` (`http` aliases `streamable-http`)     |
+| Listen address                     | `--host`                        | `MONARCH_MCP_HOST`                              | `127.0.0.1`                                    |
+| Listen port                        | `--port`                        | `MONARCH_MCP_PORT`                              | `8000`                                         |
+| Additional allowed Host headers    | `--allowed-host` (repeatable)   | `MONARCH_MCP_ALLOWED_HOSTS` (comma-separated)   | None; loopback hosts are always allowed        |
+| Additional allowed browser Origins | `--allowed-origin` (repeatable) | `MONARCH_MCP_ALLOWED_ORIGINS` (comma-separated) | None; HTTP loopback origins are always allowed |
+
+CLI flags override their environment settings.
+Host entries include the port when clients send one; `server.lan:*` allows any port.
+Origin entries include the scheme, for example `https://client.example.com`.
+Clients without an Origin header are supported.
+Browser clients may additionally require CORS handling at the reverse proxy.
 
 ## ✨ Features
 
@@ -383,66 +408,66 @@ All 58 registered tools. Required parameters are listed first, optional ones
 are marked with a trailing question mark. This table is generated from the
 live tool registry and the functions' signatures, so it does not drift.
 
-| Tool | Description | Parameters |
-|------|-------------|------------|
-| `add_transaction_tag` | Add a tag to a transaction, preserving any tags already on it | `transaction_id`, `tag_id` |
-| `bulk_categorize_transactions` | Apply the same category to multiple transactions at once | `transaction_ids`, `category_id`, `mark_reviewed`?, `dry_run`? |
-| `categorize_transaction` | Assign a category to a transaction | `transaction_id`, `category_id` |
-| `check_auth_status` | Report the stored session and its auth mode | None |
-| `create_transaction` | Create a new transaction in Monarch Money | `date`, `account_id`, `amount`, `merchant_name`, `category_id`, `notes`?, `update_balance`? |
-| `create_transaction_category` | Create a new transaction category | `group_id`, `transaction_category_name`, `icon`?, `rollover_enabled`?, `rollover_type`? |
-| `create_transaction_rule` | Create a new transaction auto-categorization rule | `merchant_criteria_operator`?, `merchant_criteria_value`?, `merchant_criteria_values`?, `merchant_criteria`?, `original_statement_operator`?, `original_statement_values`?, `original_statement_criteria`?, `use_original_statement`?, `amount_operator`?, `amount_value`?, `amount_lower`?, `amount_upper`?, `amount_is_expense`?, `set_category_id`?, `set_merchant_name`?, `add_tag_ids`?, `link_goal_id`?, `hide_from_reports`?, `review_status`?, `account_ids`?, `category_ids`?, `apply_to_existing`? |
-| `create_transaction_tag` | Create a new transaction tag | `name`, `color` |
-| `debug_session_loading` | Diagnose session loading problems | None |
-| `delete_transaction` | Delete a transaction from Monarch Money | `transaction_id` |
-| `delete_transaction_rule` | Delete a transaction rule | `rule_id` |
-| `get_account_balance_history` | Get historical balance data for a specific account | `account_id` |
-| `get_account_holdings` | Get investment holdings for a specific account | `account_id` |
-| `get_account_sync_health` | Report the health of each linked institution connection | `stale_after_days`? |
-| `get_accounts` | Get all financial accounts from Monarch Money | None |
-| `get_budgets` | Get budget information from Monarch Money | `start_date`?, `end_date`? |
-| `get_cashflow` | Get cashflow analysis from Monarch Money | `start_date`?, `end_date`? |
-| `get_cashflow_by_month` | Get spending trends over time, broken down by category and month | `start_date`, `end_date` |
-| `get_category_details` | Get a single category's details including budget amounts for a month | `category_id`, `month`? |
-| `get_debt_paydown` | Get the debt paydown plan and the accounts feeding it | `method`? |
-| `get_goal_contributions` | Show a goal's budgeted contributions, broken down by funding account | `goal_id`, `month`? |
-| `get_goals` | List Monarch savings and debt-paydown goals | None |
-| `get_merchant` | Get a merchant's details including recurring transaction stream configuration | `merchant_id` |
-| `get_net_worth` | Get net worth history over time | `start_date`?, `end_date`?, `account_type`? |
-| `get_net_worth_by_account_type` | Get net worth breakdown by account type over time | `start_date`, `timeframe`? |
-| `get_recurring_transactions` | Get upcoming recurring transactions | `start_date`?, `end_date`? |
-| `get_spending_summary` | Get a spending summary broken down by category, category group, and merchant | `start_date`?, `end_date`? |
-| `get_transaction_categories` | Get all available transaction categories from Monarch Money | None |
-| `get_transaction_category_groups` | Get all transaction category groups (parent groupings for categories) | None |
-| `get_transaction_details` | Get full details for a specific transaction | `transaction_id` |
-| `get_transaction_rules` | Get all transaction auto-categorization rules from Monarch Money | None |
-| `get_transaction_splits` | Get the splits for a transaction | `transaction_id` |
-| `get_transaction_tags` | Get all available transaction tags from Monarch Money | None |
-| `get_transactions` | Get transactions from Monarch Money | `limit`?, `offset`?, `start_date`?, `end_date`?, `account_id`?, `search`?, `category_ids`?, `category_group_ids`?, `account_ids`?, `tag_ids`?, `has_notes`?, `is_split`?, `is_recurring`?, `wide_search`?, `search_scan_limit`? |
-| `get_transactions_needing_review` | Get transactions that need review based on various criteria | `needs_review`?, `days`?, `uncategorized_only`?, `without_notes_only`?, `limit`?, `offset`?, `account_id`? |
-| `get_transactions_summary` | Get a high-level summary of transactions | None |
-| `mark_transaction_reviewed` | Mark a transaction as reviewed (clears the needs_review flag) | `transaction_id` |
-| `monarch_login` | Sign in via a secure form in the client UI | None |
-| `monarch_login_with_token` | Sign in with a browser copied session token | None |
-| `monarch_logout` | Clear the stored session and drop the cached client | None |
-| `monarch_whoami` | Report who is signed in and what the account's plan entitles it to | None |
-| `refresh_accounts` | Request account data refresh from financial institutions | `account_ids`? |
-| `reorder_transaction_rule` | Move a transaction rule to a new position in the evaluation order | `rule_id`, `new_order` |
-| `review_recurring_stream` | Set the review status of a recurring transaction stream | `stream_id`, `review_status` |
-| `search_transactions` | Search and filter transactions with comprehensive filtering options | `search`?, `limit`?, `offset`?, `start_date`?, `end_date`?, `category_ids`?, `account_ids`?, `tag_ids`?, `has_attachments`?, `has_notes`?, `hidden_from_reports`?, `is_split`?, `is_recurring`? |
-| `set_budget_amount` | Set or update a budget amount for a category or category group | `amount`, `category_id`?, `category_group_id`?, `start_date`?, `apply_to_future`? |
-| `set_goal_contribution` | Set the budgeted monthly contribution to a goal from one funding account | `goal_id`, `account_id`, `amount` |
-| `set_transaction_tags` | Set tags on a transaction | `transaction_id`, `tag_ids` |
-| `setup_authentication` | Get setup instructions | None |
-| `split_transaction` | Split a transaction into multiple parts with different categories/merchants | `transaction_id`, `splits` |
-| `update_account` | Update an account's name, balance, type or visibility settings | `account_id`, `name`?, `balance`?, `account_type`?, `account_sub_type`?, `include_in_net_worth`?, `hide_from_summary_list`?, `hide_transactions_from_reports`?, `dry_run`? |
-| `update_category` | Update an existing category's settings | `category_id`, `name`?, `icon`?, `group_id`?, `category_type`?, `exclude_from_budget`?, `budget_variability`?, `rollover_enabled`?, `rollover_start_month`?, `rollover_starting_balance`?, `rollover_frequency`?, `rollover_target_amount`?, `rollover_type`?, `confirm_rollover_reset`?, `dry_run`? |
-| `update_merchant` | Update a merchant's name and/or recurring transaction stream settings | `merchant_id`, `name`?, `is_recurring`?, `frequency`?, `base_date`?, `amount`?, `is_active`? |
-| `update_savings_goal` | Update a savings goal's target or monthly contribution | `goal_id`, `target_amount`?, `target_date`?, `name`?, `priority`?, `goal_type`?, `is_sinking_fund`? |
-| `update_transaction` | Update an existing transaction in Monarch Money | `transaction_id`, `category_id`?, `merchant_name`?, `goal_id`?, `amount`?, `date`?, `hide_from_reports`?, `needs_review`?, `notes`? |
-| `update_transaction_notes` | Update the notes/memo for a transaction | `transaction_id`, `notes`, `receipt_url`? |
-| `update_transaction_rule` | Update an existing transaction rule | `rule_id`, `merchant_criteria_operator`?, `merchant_criteria_value`?, `merchant_criteria_values`?, `merchant_criteria`?, `original_statement_operator`?, `original_statement_values`?, `original_statement_criteria`?, `use_original_statement`?, `amount_operator`?, `amount_value`?, `amount_lower`?, `amount_upper`?, `amount_is_expense`?, `set_category_id`?, `set_merchant_name`?, `add_tag_ids`?, `link_goal_id`?, `hide_from_reports`?, `review_status`?, `account_ids`?, `category_ids`?, `clear_category`?, `clear_merchant`?, `clear_tags`?, `clear_goal_link`?, `clear_review_status`?, `apply_to_existing`? |
-| `upload_account_balance_history` | Upload corrected balance snapshots for an account | `account_id`, `corrections`, `dry_run`? |
+| Tool                              | Description                                                                   | Parameters                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| --------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `add_transaction_tag`             | Add a tag to a transaction, preserving any tags already on it                 | `transaction_id`, `tag_id`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `bulk_categorize_transactions`    | Apply the same category to multiple transactions at once                      | `transaction_ids`, `category_id`, `mark_reviewed`?, `dry_run`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `categorize_transaction`          | Assign a category to a transaction                                            | `transaction_id`, `category_id`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `check_auth_status`               | Report the stored session and its auth mode                                   | None                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `create_transaction`              | Create a new transaction in Monarch Money                                     | `date`, `account_id`, `amount`, `merchant_name`, `category_id`, `notes`?, `update_balance`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `create_transaction_category`     | Create a new transaction category                                             | `group_id`, `transaction_category_name`, `icon`?, `rollover_enabled`?, `rollover_type`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `create_transaction_rule`         | Create a new transaction auto-categorization rule                             | `merchant_criteria_operator`?, `merchant_criteria_value`?, `merchant_criteria_values`?, `merchant_criteria`?, `original_statement_operator`?, `original_statement_values`?, `original_statement_criteria`?, `use_original_statement`?, `amount_operator`?, `amount_value`?, `amount_lower`?, `amount_upper`?, `amount_is_expense`?, `set_category_id`?, `set_merchant_name`?, `add_tag_ids`?, `link_goal_id`?, `hide_from_reports`?, `review_status`?, `account_ids`?, `category_ids`?, `apply_to_existing`?                                                                                                             |
+| `create_transaction_tag`          | Create a new transaction tag                                                  | `name`, `color`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `debug_session_loading`           | Diagnose session loading problems                                             | None                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `delete_transaction`              | Delete a transaction from Monarch Money                                       | `transaction_id`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `delete_transaction_rule`         | Delete a transaction rule                                                     | `rule_id`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `get_account_balance_history`     | Get historical balance data for a specific account                            | `account_id`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `get_account_holdings`            | Get investment holdings for a specific account                                | `account_id`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `get_account_sync_health`         | Report the health of each linked institution connection                       | `stale_after_days`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `get_accounts`                    | Get all financial accounts from Monarch Money                                 | None                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `get_budgets`                     | Get budget information from Monarch Money                                     | `start_date`?, `end_date`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `get_cashflow`                    | Get cashflow analysis from Monarch Money                                      | `start_date`?, `end_date`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `get_cashflow_by_month`           | Get spending trends over time, broken down by category and month              | `start_date`, `end_date`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `get_category_details`            | Get a single category's details including budget amounts for a month          | `category_id`, `month`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `get_debt_paydown`                | Get the debt paydown plan and the accounts feeding it                         | `method`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `get_goal_contributions`          | Show a goal's budgeted contributions, broken down by funding account          | `goal_id`, `month`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `get_goals`                       | List Monarch savings and debt-paydown goals                                   | None                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `get_merchant`                    | Get a merchant's details including recurring transaction stream configuration | `merchant_id`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `get_net_worth`                   | Get net worth history over time                                               | `start_date`?, `end_date`?, `account_type`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `get_net_worth_by_account_type`   | Get net worth breakdown by account type over time                             | `start_date`, `timeframe`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `get_recurring_transactions`      | Get upcoming recurring transactions                                           | `start_date`?, `end_date`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `get_spending_summary`            | Get a spending summary broken down by category, category group, and merchant  | `start_date`?, `end_date`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `get_transaction_categories`      | Get all available transaction categories from Monarch Money                   | None                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `get_transaction_category_groups` | Get all transaction category groups (parent groupings for categories)         | None                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `get_transaction_details`         | Get full details for a specific transaction                                   | `transaction_id`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `get_transaction_rules`           | Get all transaction auto-categorization rules from Monarch Money              | None                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `get_transaction_splits`          | Get the splits for a transaction                                              | `transaction_id`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `get_transaction_tags`            | Get all available transaction tags from Monarch Money                         | None                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `get_transactions`                | Get transactions from Monarch Money                                           | `limit`?, `offset`?, `start_date`?, `end_date`?, `account_id`?, `search`?, `category_ids`?, `category_group_ids`?, `account_ids`?, `tag_ids`?, `has_notes`?, `is_split`?, `is_recurring`?, `wide_search`?, `search_scan_limit`?                                                                                                                                                                                                                                                                                                                                                                                          |
+| `get_transactions_needing_review` | Get transactions that need review based on various criteria                   | `needs_review`?, `days`?, `uncategorized_only`?, `without_notes_only`?, `limit`?, `offset`?, `account_id`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `get_transactions_summary`        | Get a high-level summary of transactions                                      | None                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `mark_transaction_reviewed`       | Mark a transaction as reviewed (clears the needs_review flag)                 | `transaction_id`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `monarch_login`                   | Sign in via a secure form in the client UI                                    | None                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `monarch_login_with_token`        | Sign in with a browser copied session token                                   | None                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `monarch_logout`                  | Clear the stored session and drop the cached client                           | None                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `monarch_whoami`                  | Report who is signed in and what the account's plan entitles it to            | None                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `refresh_accounts`                | Request account data refresh from financial institutions                      | `account_ids`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `reorder_transaction_rule`        | Move a transaction rule to a new position in the evaluation order             | `rule_id`, `new_order`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `review_recurring_stream`         | Set the review status of a recurring transaction stream                       | `stream_id`, `review_status`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `search_transactions`             | Search and filter transactions with comprehensive filtering options           | `search`?, `limit`?, `offset`?, `start_date`?, `end_date`?, `category_ids`?, `account_ids`?, `tag_ids`?, `has_attachments`?, `has_notes`?, `hidden_from_reports`?, `is_split`?, `is_recurring`?                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `set_budget_amount`               | Set or update a budget amount for a category or category group                | `amount`, `category_id`?, `category_group_id`?, `start_date`?, `apply_to_future`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `set_goal_contribution`           | Set the budgeted monthly contribution to a goal from one funding account      | `goal_id`, `account_id`, `amount`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `set_transaction_tags`            | Set tags on a transaction                                                     | `transaction_id`, `tag_ids`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `setup_authentication`            | Get setup instructions                                                        | None                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `split_transaction`               | Split a transaction into multiple parts with different categories/merchants   | `transaction_id`, `splits`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `update_account`                  | Update an account's name, balance, type or visibility settings                | `account_id`, `name`?, `balance`?, `account_type`?, `account_sub_type`?, `include_in_net_worth`?, `hide_from_summary_list`?, `hide_transactions_from_reports`?, `dry_run`?                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `update_category`                 | Update an existing category's settings                                        | `category_id`, `name`?, `icon`?, `group_id`?, `category_type`?, `exclude_from_budget`?, `budget_variability`?, `rollover_enabled`?, `rollover_start_month`?, `rollover_starting_balance`?, `rollover_frequency`?, `rollover_target_amount`?, `rollover_type`?, `confirm_rollover_reset`?, `dry_run`?                                                                                                                                                                                                                                                                                                                     |
+| `update_merchant`                 | Update a merchant's name and/or recurring transaction stream settings         | `merchant_id`, `name`?, `is_recurring`?, `frequency`?, `base_date`?, `amount`?, `is_active`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `update_savings_goal`             | Update a savings goal's target or monthly contribution                        | `goal_id`, `target_amount`?, `target_date`?, `name`?, `priority`?, `goal_type`?, `is_sinking_fund`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `update_transaction`              | Update an existing transaction in Monarch Money                               | `transaction_id`, `category_id`?, `merchant_name`?, `goal_id`?, `amount`?, `date`?, `hide_from_reports`?, `needs_review`?, `notes`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `update_transaction_notes`        | Update the notes/memo for a transaction                                       | `transaction_id`, `notes`, `receipt_url`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `update_transaction_rule`         | Update an existing transaction rule                                           | `rule_id`, `merchant_criteria_operator`?, `merchant_criteria_value`?, `merchant_criteria_values`?, `merchant_criteria`?, `original_statement_operator`?, `original_statement_values`?, `original_statement_criteria`?, `use_original_statement`?, `amount_operator`?, `amount_value`?, `amount_lower`?, `amount_upper`?, `amount_is_expense`?, `set_category_id`?, `set_merchant_name`?, `add_tag_ids`?, `link_goal_id`?, `hide_from_reports`?, `review_status`?, `account_ids`?, `category_ids`?, `clear_category`?, `clear_merchant`?, `clear_tags`?, `clear_goal_link`?, `clear_review_status`?, `apply_to_existing`? |
+| `upload_account_balance_history`  | Upload corrected balance snapshots for an account                             | `account_id`, `corrections`, `dry_run`?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
 ## 📝 Usage Examples
 

--- a/src/monarch_mcp_server/app.py
+++ b/src/monarch_mcp_server/app.py
@@ -1,6 +1,8 @@
 """FastMCP application instance and entry point."""
 
+import argparse
 import logging
+import os
 
 try:  # mcp >= 2.0 renamed FastMCP to MCPServer
     from mcp.server.mcpserver import MCPServer as FastMCP
@@ -33,11 +35,105 @@ import monarch_mcp_server.tools  # noqa: E402, F401
 app = mcp
 
 
-def main() -> None:
-    """Main entry point for the server."""
-    logger.info("Starting Monarch Money MCP Server...")
+def _port(value: str) -> int:
     try:
-        mcp.run()
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError("port must be an integer") from None
+    if not 1 <= port <= 65535:
+        raise argparse.ArgumentTypeError("port must be between 1 and 65535")
+    return port
+
+
+def _env_list(name: str) -> list[str]:
+    return [
+        value.strip() for value in os.environ.get(name, "").split(",") if value.strip()
+    ]
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Main entry point for the server."""
+    parser = argparse.ArgumentParser(description="Monarch Money MCP Server")
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "streamable-http", "http"),
+        default=os.environ.get("MONARCH_MCP_TRANSPORT", "stdio"),
+        help="MCP transport (env: MONARCH_MCP_TRANSPORT; default: stdio)",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("MONARCH_MCP_HOST", "127.0.0.1"),
+        help="HTTP bind address (env: MONARCH_MCP_HOST; default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=_port,
+        default=os.environ.get("MONARCH_MCP_PORT", "8000"),
+        help="HTTP port (env: MONARCH_MCP_PORT; default: 8000)",
+    )
+    parser.add_argument(
+        "--allowed-host",
+        action="append",
+        default=None,
+        help="Additional HTTP Host value, e.g. mcp.example.com (repeatable; "
+        "env: MONARCH_MCP_ALLOWED_HOSTS, comma-separated)",
+    )
+    parser.add_argument(
+        "--allowed-origin",
+        action="append",
+        default=None,
+        help="Additional browser Origin, e.g. https://client.example.com (repeatable; "
+        "env: MONARCH_MCP_ALLOWED_ORIGINS, comma-separated)",
+    )
+    args = parser.parse_args(argv)
+    # argparse does not check choices for defaults supplied by the environment.
+    if args.transport not in ("stdio", "streamable-http", "http"):
+        parser.error("MONARCH_MCP_TRANSPORT must be stdio, streamable-http, or http")
+    if not args.host.strip():
+        parser.error("HTTP host must not be empty")
+
+    if args.transport != "stdio":
+        from mcp.server.transport_security import TransportSecuritySettings
+
+        mcp.settings.host = args.host
+        mcp.settings.port = args.port
+        # Listening on all interfaces must not disable Host/Origin validation.
+        # Remote clients explicitly allow their public hostname (including port).
+        mcp.settings.transport_security = TransportSecuritySettings(
+            allowed_hosts=[
+                "localhost",
+                "localhost:*",
+                "127.0.0.1",
+                "127.0.0.1:*",
+                "[::1]",
+                "[::1]:*",
+                *(
+                    args.allowed_host
+                    if args.allowed_host is not None
+                    else _env_list("MONARCH_MCP_ALLOWED_HOSTS")
+                ),
+            ],
+            allowed_origins=[
+                "http://localhost",
+                "http://localhost:*",
+                "http://127.0.0.1",
+                "http://127.0.0.1:*",
+                "http://[::1]",
+                "http://[::1]:*",
+                *(
+                    args.allowed_origin
+                    if args.allowed_origin is not None
+                    else _env_list("MONARCH_MCP_ALLOWED_ORIGINS")
+                ),
+            ],
+        )
+
+    logger.info("Starting Monarch Money MCP Server (%s)...", args.transport)
+    try:
+        if args.transport == "stdio":
+            mcp.run()
+        else:
+            mcp.run(transport="streamable-http")
     except Exception as e:
         logger.error(f"Failed to run server: {str(e)}")
         raise

--- a/tests/test_readme_tool_reference.py
+++ b/tests/test_readme_tool_reference.py
@@ -16,7 +16,19 @@ from monarch_mcp_server import server as srv
 from monarch_mcp_server.app import mcp
 
 README = Path(__file__).resolve().parent.parent / "README.md"
-ROW = re.compile(r"^\| `(?P<name>\w+)` \| .* \| (?P<params>.*) \|$", re.M)
+ROW = re.compile(
+    r"^\|[ \t]*`(?P<name>\w+)`[ \t]*\|[^|\r\n]*\|(?P<params>[^|\r\n]*)\|[ \t]*$",
+    re.M,
+)
+
+
+@pytest.mark.parametrize("padding", ["", " ", "    "])
+def test_tool_rows_allow_column_alignment(padding):
+    row = f"|{padding}`get_accounts`{padding}|{padding}List accounts{padding}|{padding}None{padding}|"
+    match = ROW.fullmatch(row)
+    assert match is not None
+    assert match.group("name") == "get_accounts"
+    assert match.group("params").strip() == "None"
 
 
 def _documented():

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,208 @@
+"""Transport selection and real MCP requests through the HTTP ASGI application."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+from starlette.testclient import TestClient
+
+from monarch_mcp_server import app
+
+
+@pytest.fixture(autouse=True)
+def isolate_transport(monkeypatch):
+    for suffix in ("TRANSPORT", "HOST", "PORT", "ALLOWED_HOSTS", "ALLOWED_ORIGINS"):
+        monkeypatch.delenv(f"MONARCH_MCP_{suffix}", raising=False)
+    monkeypatch.setattr(app.mcp, "settings", app.mcp.settings.model_copy(deep=True))
+    monkeypatch.setattr(app.mcp, "_session_manager", None)
+    run = Mock()
+    monkeypatch.setattr(app.mcp, "run", run)
+    return run
+
+
+def test_default_remains_stdio(isolate_transport):
+    app.main([])
+    isolate_transport.assert_called_once_with()
+
+
+def test_environment_configures_http(monkeypatch, isolate_transport):
+    monkeypatch.setenv("MONARCH_MCP_TRANSPORT", "streamable-http")
+    monkeypatch.setenv("MONARCH_MCP_HOST", "0.0.0.0")
+    monkeypatch.setenv("MONARCH_MCP_PORT", "9000")
+    monkeypatch.setenv(
+        "MONARCH_MCP_ALLOWED_HOSTS", "mcp.example.com, server.lan:9000, "
+    )
+    monkeypatch.setenv("MONARCH_MCP_ALLOWED_ORIGINS", "https://client.example.com")
+    app.main([])
+    isolate_transport.assert_called_once_with(transport="streamable-http")
+    assert (app.mcp.settings.host, app.mcp.settings.port) == ("0.0.0.0", 9000)
+    security = app.mcp.settings.transport_security
+    assert security.enable_dns_rebinding_protection
+    assert "server.lan:9000" in security.allowed_hosts
+    assert "https://client.example.com" in security.allowed_origins
+
+
+def test_cli_overrides_environment(monkeypatch, isolate_transport):
+    monkeypatch.setenv("MONARCH_MCP_TRANSPORT", "stdio")
+    monkeypatch.setenv("MONARCH_MCP_HOST", "127.0.0.1")
+    monkeypatch.setenv("MONARCH_MCP_PORT", "invalid")
+    monkeypatch.setenv("MONARCH_MCP_ALLOWED_HOSTS", "old.example.com")
+    monkeypatch.setenv("MONARCH_MCP_ALLOWED_ORIGINS", "https://old.example.com")
+    app.main(
+        [
+            "--transport",
+            "http",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "9001",
+            "--allowed-host",
+            "mcp.example.com",
+            "--allowed-host",
+            "server.lan:9001",
+            "--allowed-origin",
+            "https://client.example.com",
+        ]
+    )
+    isolate_transport.assert_called_once_with(transport="streamable-http")
+    assert (app.mcp.settings.host, app.mcp.settings.port) == ("0.0.0.0", 9001)
+    security = app.mcp.settings.transport_security
+    assert "mcp.example.com" in security.allowed_hosts
+    assert "server.lan:9001" in security.allowed_hosts
+    assert "old.example.com" not in security.allowed_hosts
+    assert "https://client.example.com" in security.allowed_origins
+    assert "https://old.example.com" not in security.allowed_origins
+
+
+def test_stdio_overrides_container_default(monkeypatch, isolate_transport):
+    monkeypatch.setenv("MONARCH_MCP_TRANSPORT", "streamable-http")
+    app.main(["--transport", "stdio"])
+    isolate_transport.assert_called_once_with()
+
+
+@pytest.mark.parametrize("port", ["0", "65536", "-1", "invalid"])
+def test_invalid_environment_port_fails(monkeypatch, isolate_transport, port):
+    monkeypatch.setenv("MONARCH_MCP_PORT", port)
+    with pytest.raises(SystemExit) as exc:
+        app.main([])
+    assert exc.value.code == 2
+    isolate_transport.assert_not_called()
+
+
+def test_invalid_environment_transport_fails(monkeypatch, isolate_transport):
+    monkeypatch.setenv("MONARCH_MCP_TRANSPORT", "invalid")
+    with pytest.raises(SystemExit) as exc:
+        app.main([])
+    assert exc.value.code == 2
+    isolate_transport.assert_not_called()
+
+
+HEADERS = {"Accept": "application/json, text/event-stream"}
+INITIALIZE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-06-18",
+        "capabilities": {},
+        "clientInfo": {"name": "transport-test", "version": "1.0"},
+    },
+}
+
+
+def rpc_result(response):
+    assert response.status_code == 200, response.text
+    # Keep the production SSE response mode, rather than changing server settings.
+    data = next(
+        line[6:] for line in response.text.splitlines() if line.startswith("data: ")
+    )
+    return json.loads(data)["result"]
+
+
+def test_http_initialize_list_and_call_tool(mock_monarch_client):
+    app.main(["--transport", "http", "--host", "0.0.0.0"])
+    with TestClient(
+        app.mcp.streamable_http_app(), base_url="http://localhost:8000"
+    ) as client:
+        response = client.post("/mcp", headers=HEADERS, json=INITIALIZE)
+        assert rpc_result(response)["serverInfo"]["name"] == "Monarch Money MCP Server"
+        headers = {**HEADERS, "Mcp-Session-Id": response.headers["mcp-session-id"]}
+        initialized = client.post(
+            "/mcp",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+            },
+        )
+        assert initialized.status_code == 202
+        listed = client.post(
+            "/mcp",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/list",
+                "params": {},
+            },
+        )
+        assert "get_accounts" in {tool["name"] for tool in rpc_result(listed)["tools"]}
+        called = client.post(
+            "/mcp",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "get_accounts", "arguments": {}},
+            },
+        )
+        result = rpc_result(called)
+        assert not result.get("isError")
+        assert "Checking Account" in result["content"][0]["text"]
+        mock_monarch_client.get_accounts.assert_awaited_once()
+        assert client.delete("/mcp", headers=headers).status_code == 200
+
+
+@pytest.mark.parametrize(
+    "headers,status",
+    [
+        ({"Host": "evil.example"}, 421),
+        ({"Origin": "https://evil.example"}, 400),
+        ({"Origin": "null"}, 400),
+        ({"Origin": "http://localhost"}, 200),
+        ({"Host": "localhost"}, 200),
+    ],
+)
+def test_http_validates_host_and_origin(headers, status):
+    app.main(["--transport", "http", "--host", "0.0.0.0"])
+    with TestClient(
+        app.mcp.streamable_http_app(), base_url="http://localhost:8000"
+    ) as client:
+        response = client.post("/mcp", headers={**HEADERS, **headers}, json=INITIALIZE)
+        assert response.status_code == status
+
+
+def test_http_allows_configured_remote_host_and_origin():
+    app.main(
+        [
+            "--transport",
+            "http",
+            "--allowed-host",
+            "mcp.example.com",
+            "--allowed-origin",
+            "https://client.example.com",
+        ]
+    )
+    with TestClient(
+        app.mcp.streamable_http_app(), base_url="https://mcp.example.com"
+    ) as client:
+        response = client.post(
+            "/mcp",
+            json=INITIALIZE,
+            headers={
+                **HEADERS,
+                "Origin": "https://client.example.com",
+            },
+        )
+        assert "serverInfo" in rpc_result(response)


### PR DESCRIPTION
This is a minimally invasive change to add streamable http support and basic Docker container image building.

See #141 for the github actions to build and push the container automatically.


The Docker image listens on `0.0.0.0:8000`; local launches keep STDIO as the default.
Transport, host, port, and allowed Host/Origin headers can be configured through CLI flags or environment variables.

The Astral uv/Python 3.12 image installs runtime dependencies from `uv.lock` and runs as a non-root user.

The README separates local installation, container deployment, and HTTP configuration, including authentication through a persistent session volume and reverse-proxy deployment.

All connected clients share one Monarch account; remote access requires an authenticated proxy or a private network with access controls and I did my best to call this out _twice_ so it's hard to ignore the implications.

### Merge order

1. Merge this PR to add the Docker image, HTTP transport, tests, and deployment documentation.
2. Merge https://github.com/robcerda/monarch-mcp-server/pull/141 to add release-triggered GHCR publishing and manual workflow dispatch on top of this Dockerfile.

### Validation

- All 400 tests pass, including HTTP initialization, tool discovery, a mocked tool call, configuration precedence, and Host/Origin validation.
- Built the Dockerfile with Podman and connected through a published HTTP port using the MCP SDK client: initialization, all 58 tools, and the expected response before Monarch authentication passed.
- Verified the Docker STDIO override with an MCP client.
- `git diff --check` passed.
